### PR TITLE
Fix: Remove conflict with ergebnis/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         }
     },
     "conflict": {
-        "fzaninotto/faker": "*",
-        "ergebnis/faker": "*"
+        "fzaninotto/faker": "*"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This PR

* [x] removes the conflict with `ergebnis/faker`

💁‍♂️ I have archived the repository and abandoned the package, see

- https://github.com/ergebnis/faker
- https://packagist.org/packages/ergebnis/faker