### PR TITLE
Limit workflow builds to main branch and PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,6 +3,8 @@
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 name: "Continuous Integration"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - "main"
+      - "[0-9].*"
 
 name: "Continuous Integration"
 


### PR DESCRIPTION
This PR:

 - [x] Limits workflow builds to pushes to the `main` branch.
 - [x] Not excluding PR builds.