### PR TITLE
Added stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+daysUntilStale: 30
+daysUntilClose: 7
+exemptLabels:
+    - pinned
+    - security
+# Label to use when marking an issue as stale
+staleLabel: lifecycle/stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed after 1 week if no further activity occurs. Thank you
+    for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This PR adds the stale bot to the repo. It will close things after:

* 30 days inactive
* 7 days after inactive it will close

I kept the inactive period short since overall people will handle stuff fast anyways. If needed a label can be set to prevent auto closing though.
