### PR TITLE
Look at major version too when deciding to update branch alias

### DIFF
--- a/.github/workflows/branch-alias.yml
+++ b/.github/workflows/branch-alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi


### PR DESCRIPTION
This PR:

- [ ] Adds a new feature ...
- [ ] Covered by tests
- [ ] Fixes #nnnn

-----

If the current branch alias is 1.6 and we release 2.0, then the current logic would not update the branch alias. (Since 6 is bigger than 0). 

This PR will fix that by look at the major version too. 