### PR TITLE
add Singapore NRIC/FIN provider

### DIFF
--- a/src/Faker/Provider/en_SG/Person.php
+++ b/src/Faker/Provider/en_SG/Person.php
@@ -64,7 +64,7 @@ class Person extends \Faker\Provider\Person
 
         $checksum = in_array($prefix, ['G', 'T'], true) ? 4 : 0;
         for ($i = 0; $i < $length; $i++) {
-            $checksum += $result[$i] * $weights[$i];
+            $checksum += (int) $result[$i] * $weights[$i];
         }
 
         return $prefix . $result . $checksumArr[$checksum % 11];

--- a/src/Faker/Provider/en_SG/Person.php
+++ b/src/Faker/Provider/en_SG/Person.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Faker\Provider\en_SG;
+
+use Faker\Provider\DateTime;
+
+class Person extends \Faker\Provider\Person
+{
+    /**
+     * National Registration Identity Card number
+     *
+     * @param \DateTime|null $birthDate birth date
+     *
+     * @return string in format S1234567D or T1234567J
+     */
+    public static function nric(?\DateTime $birthDate = null): string
+    {
+        return self::singaporeId($birthDate, false);
+    }
+
+    /**
+     * Foreign Identification Number
+     *
+     * @param \DateTime|null $issueDate issue date
+     *
+     * @return string in format F1234567N or G1234567X
+     */
+    public static function fin(?\DateTime $issueDate = null): string
+    {
+        return self::singaporeId($issueDate, true);
+    }
+
+    /**
+     * Singapore NRIC (citizens) or FIN (foreigners) number
+     *
+     * @param \DateTime|null $issueDate birth/issue date
+     * @param bool           $foreigner whether a person is foreigner or citizen
+     *
+     * @return string in format S1234567D, T1234567J, F1234567N or G1234567X
+     */
+    public static function singaporeId(?\DateTime $issueDate = null, bool $foreigner = false): string
+    {
+        if ($issueDate === null) {
+            $issueDate = DateTime::dateTimeThisCentury();
+        }
+
+        $weights = [2, 7, 6, 5, 4, 3, 2];
+        $result = '';
+
+        if ($foreigner) {
+            $prefix = ($issueDate < new \DateTime('2000-01-01')) ? 'F' : 'G';
+            $checksumArr = ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K'];
+        } else {
+            $prefix = ($issueDate < new \DateTime('2000-01-01')) ? 'S' : 'T';
+            // NRICs before 1968 did not contain YOB
+            $result .= ($issueDate < new \DateTime('1968-01-01')) ? static::randomElement(['00', '01']) : $issueDate->format('y');
+            $checksumArr = ['J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
+        }
+
+        $length = count($weights);
+        for ($i = strlen($result); $i < $length; ++$i) {
+            $result .= static::randomDigit();
+        }
+
+        $checksum = in_array($prefix, ['G', 'T'], true) ? 4 : 0;
+        for ($i = 0; $i < $length; $i++) {
+            $checksum += $result[$i] * $weights[$i];
+        }
+
+        return $prefix . $result . $checksumArr[$checksum % 11];
+    }
+}

--- a/test/Faker/Provider/en_SG/PersonTest.php
+++ b/test/Faker/Provider/en_SG/PersonTest.php
@@ -73,7 +73,7 @@ final class PersonTest extends TestCase
         $checksum = in_array($prefix, ['T', 'G'], true) ? 4 : 0;
 
         foreach ($weights as $key => $weight) {
-            $checksum += $id[$key+1] * $weight;
+            $checksum += (int) $id[$key+1] * $weight;
         }
 
         $checksumArr = in_array($prefix, ['F', 'G'])

--- a/test/Faker/Provider/en_SG/PersonTest.php
+++ b/test/Faker/Provider/en_SG/PersonTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Faker\Test\Provider\en_SG;
+
+use Faker\Factory;
+use Faker\Generator;
+use Faker\Provider\en_SG\Person;
+use Faker\Test\TestCase;
+
+final class PersonTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
+    {
+        $faker = Factory::create('en_SG');
+        $faker->addProvider(new Person($faker));
+        $this->faker = $faker;
+    }
+
+    public function testNric(): void
+    {
+        $this->assertValidSingaporeId($this->faker->nric());
+    }
+
+    public function testNricAfter2000(): void
+    {
+        $nric = $this->faker->nric(new \DateTime('2005-03-01'));
+        $this->assertMatchesRegularExpression('/^T05[0-9]{5}[A-Z]$/', $nric);
+        $this->assertValidSingaporeId($nric);
+    }
+
+    public function testNricBefore2000(): void
+    {
+        $nric = $this->faker->nric(new \DateTime('1993-03-01'));
+        $this->assertMatchesRegularExpression('/^S93[0-9]{5}[A-Z]$/', $nric);
+        $this->assertValidSingaporeId($nric);
+    }
+
+    public function testNricBefore1968(): void
+    {
+        $nric = $this->faker->nric(new \DateTime('1967-12-31'));
+        $this->assertMatchesRegularExpression('/^S0[0-1][0-9]{5}[A-Z]$/', $nric);
+        $this->assertValidSingaporeId($nric);
+    }
+
+    public function testFin(): void
+    {
+        $this->assertValidSingaporeId($this->faker->fin());
+    }
+
+    public function testFinAfter2000(): void
+    {
+        $fin = $this->faker->fin(new \DateTime('2005-03-01'));
+        $this->assertMatchesRegularExpression('/^G[0-9]{7}[A-Z]$/', $fin);
+        $this->assertValidSingaporeId($fin);
+    }
+
+    public function testFinBefore2000(): void
+    {
+        $fin = $this->faker->fin(new \DateTime('1993-03-01'));
+        $this->assertMatchesRegularExpression('/^F[0-9]{7}[A-Z]$/', $fin);
+        $this->assertValidSingaporeId($fin);
+    }
+
+    public function assertValidSingaporeId(string $id): void
+    {
+        $prefix = $id[0];
+        $weights = [2, 7, 6, 5, 4, 3, 2];
+        $checksum = in_array($prefix, ['T', 'G'], true) ? 4 : 0;
+
+        foreach ($weights as $key => $weight) {
+            $checksum += $id[$key+1] * $weight;
+        }
+
+        $checksumArr = in_array($prefix, ['F', 'G'])
+            ? ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K']
+            : ['J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
+
+        $this->assertSame($checksumArr[$checksum % 11], $id[8], sprintf('Invalid checksum for NRIC/FIN: %s', $id));
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds a new feature allowing to generate Singapore NRIC/FIN numbers: https://en.wikipedia.org/wiki/National_Registration_Identity_Card#Structure_of_the_NRIC_number.2FFIN
- [x] Is covered by tests (100%)

