### PR TITLE
Move ISBN checksum calculator to a separate class

### DIFF
--- a/src/Faker/Calculator/Ean.php
+++ b/src/Faker/Calculator/Ean.php
@@ -20,19 +20,14 @@ class Ean
      */
     public static function checksum($digits)
     {
-        $length = strlen($digits);
+        $sequence = (strlen($digits) + 1) === 8 ? [3, 1] : [1, 3];
+        $sums = 0;
 
-        $even = 0;
-        for ($i = $length - 1; $i >= 0; $i -= 2) {
-            $even += $digits[$i];
+        foreach (str_split($digits) as $n => $digit) {
+            $sums += ((int) $digit) * $sequence[$n % 2];
         }
 
-        $odd = 0;
-        for ($i = $length - 2; $i >= 0; $i -= 2) {
-            $odd += $digits[$i];
-        }
-
-        return (10 - ((3 * $even + $odd) % 10)) % 10;
+        return (10 - $sums % 10) % 10;
     }
 
     /**
@@ -48,6 +43,6 @@ class Ean
             return false;
         }
 
-        return self::checksum(substr($ean, 0, -1)) === intval(substr($ean, -1));
+        return self::checksum(substr($ean, 0, -1)) === (int) substr($ean, -1);
     }
 }

--- a/src/Faker/Calculator/Inn.php
+++ b/src/Faker/Calculator/Inn.php
@@ -14,12 +14,14 @@ class Inn
      */
     public static function checksum($inn)
     {
-        $multipliers = [1 => 2, 2 => 4, 3 => 10, 4 => 3, 5 => 5, 6 => 9, 7 => 4, 8 => 6, 9 => 8];
+        $multipliers = [2, 4, 10, 3, 5, 9, 4, 6, 8];
         $sum = 0;
-        for ($i = 1; $i <= 9; $i++) {
-            $sum += intval(substr($inn, $i - 1, 1)) * $multipliers[$i];
+
+        for ($i = 0; $i < 9; $i++) {
+            $sum += (int) $inn[$i] * $multipliers[$i];
         }
-        return strval(($sum % 11) % 10);
+
+        return (string) (($sum % 11) % 10);
     }
 
     /**
@@ -30,6 +32,6 @@ class Inn
      */
     public static function isValid($inn)
     {
-        return self::checksum(substr($inn, 0, -1)) === substr($inn, -1, 1);
+        return strlen($inn) === 10 && self::checksum($inn) === $inn[9];
     }
 }

--- a/src/Faker/Calculator/Isbn.php
+++ b/src/Faker/Calculator/Isbn.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Faker\Calculator;
+
+/**
+ * Utility class for validating ISBN-10
+ */
+class Isbn
+{
+    /** @var string ISBN-10 validation pattern */
+    public const PATTERN = '/^\d{9}[0-9X]$/';
+
+    /**
+     * ISBN-10 check digit
+     * @link http://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digits
+     *
+     * @param  string           $input ISBN without check-digit
+     * @throws \LengthException When wrong input length passed
+     *
+     * @return string
+     */
+    public static function checksum(string $input): string
+    {
+        // We're calculating check digit for ISBN-10
+        // so, the length of the input should be 9
+        $length = 9;
+
+        if (strlen($input) !== $length) {
+            throw new \LengthException(sprintf('Input length should be equal to %d', $length));
+        }
+
+        $digits = str_split($input);
+        array_walk(
+            $digits,
+            function (&$digit, $position) {
+                $digit = (10 - $position) * $digit;
+            }
+        );
+        $result = (11 - array_sum($digits) % 11) % 11;
+
+        // 10 is replaced by X
+        return ($result < 10) ? (string) $result : 'X';
+    }
+
+    /**
+     * Checks whether the provided number is a valid ISBN-10 number
+     *
+     * @param string $isbn ISBN to check
+     *
+     * @return bool
+     */
+    public static function isValid(string $isbn): bool
+    {
+        if (!preg_match(self::PATTERN, $isbn)) {
+            return false;
+        }
+
+        return self::checksum(substr($isbn, 0, -1)) === substr($isbn, -1);
+    }
+}

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -216,11 +216,7 @@ class Generator
         if ($seed === null) {
             mt_srand();
         } else {
-            if (PHP_VERSION_ID < 70100) {
-                mt_srand((int) $seed);
-            } else {
-                mt_srand((int) $seed, MT_RAND_PHP);
-            }
+            mt_srand((int) $seed, MT_RAND_PHP);
         }
     }
 

--- a/src/Faker/Provider/Barcode.php
+++ b/src/Faker/Provider/Barcode.php
@@ -2,6 +2,9 @@
 
 namespace Faker\Provider;
 
+use Faker\Calculator\Ean;
+use Faker\Calculator\Isbn;
+
 /**
  * @see http://en.wikipedia.org/wiki/EAN-13
  * @see http://en.wikipedia.org/wiki/ISBN
@@ -12,11 +15,13 @@ class Barcode extends Base
     {
         $code = static::numerify(str_repeat('#', $length - 1));
 
-        return $code . static::eanChecksum($code);
+        return $code . Ean::checksum($code);
     }
 
     /**
      * Utility function for computing EAN checksums
+     *
+     * @deprecated Use \Faker\Calculator\Ean::checksum() instead
      *
      * @param string $input
      *
@@ -24,17 +29,14 @@ class Barcode extends Base
      */
     protected static function eanChecksum($input)
     {
-        $sequence = (strlen($input) + 1) === 8 ? [3, 1] : [1, 3];
-        $sums = 0;
-        foreach (str_split($input) as $n => $digit) {
-            $sums += ((int) $digit) * $sequence[$n % 2];
-        }
-        return (10 - $sums % 10) % 10;
+        return Ean::checksum($input);
     }
 
     /**
      * ISBN-10 check digit
      * @link http://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digits
+     *
+     * @deprecated Use \Faker\Calculator\Isbn::checksum() instead
      *
      * @param  string           $input ISBN without check-digit
      * @throws \LengthException When wrong input length passed
@@ -43,25 +45,7 @@ class Barcode extends Base
      */
     protected static function isbnChecksum($input)
     {
-        // We're calculating check digit for ISBN-10
-        // so, the length of the input should be 9
-        $length = 9;
-
-        if (strlen($input) !== $length) {
-            throw new \LengthException(sprintf('Input length should be equal to %d', $length));
-        }
-
-        $digits = str_split($input);
-        array_walk(
-            $digits,
-            function (&$digit, $position) {
-                $digit = (10 - $position) * $digit;
-            }
-        );
-        $result = (11 - array_sum($digits) % 11) % 11;
-
-        // 10 is replaced by X
-        return ($result < 10) ? (string) $result : 'X';
+        return Isbn::checksum($input);
     }
 
     /**
@@ -95,7 +79,7 @@ class Barcode extends Base
     {
         $code = static::numerify(str_repeat('#', 9));
 
-        return $code . static::isbnChecksum($code);
+        return $code . Isbn::checksum($code);
     }
 
     /**
@@ -109,6 +93,6 @@ class Barcode extends Base
     {
         $code = '97' . static::numberBetween(8, 9) . static::numerify(str_repeat('#', 9));
 
-        return $code . static::eanChecksum($code);
+        return $code . Ean::checksum($code);
     }
 }

--- a/test/Faker/Calculator/EanTest.php
+++ b/test/Faker/Calculator/EanTest.php
@@ -23,6 +23,7 @@ final class EanTest extends TestCase
             ['2354698521469', true],
             ['3001092650834', false],
             ['3921092190838', false],
+            ['39210921908381', false],
         ];
     }
 

--- a/test/Faker/Calculator/EanTest.php
+++ b/test/Faker/Calculator/EanTest.php
@@ -7,75 +7,75 @@ use Faker\Test\TestCase;
 
 final class EanTest extends TestCase
 {
-    public function Ean8checksumProvider()
+    public function Ean8checksumProvider(): array
     {
-        return array(
-            array('1234567', '0'),
-            array('2345678', '5'),
-            array('3456789', '0'),
-        );
+        return [
+            ['1234567', 0],
+            ['2345678', 5],
+            ['3456789', 0],
+        ];
     }
 
-    public function ean8ValidationProvider()
+    public function ean8ValidationProvider(): array
     {
-        return array(
-            array('1234567891231', true),
-            array('2354698521469', true),
-            array('3001092650834', false),
-            array('3921092190838', false),
-        );
+        return [
+            ['1234567891231', true],
+            ['2354698521469', true],
+            ['3001092650834', false],
+            ['3921092190838', false],
+        ];
     }
 
     /**
      * @dataProvider Ean8checksumProvider
      */
-    public function testChecksumEan8($partial, $checksum)
+    public function testChecksumEan8(string $partial, int $checksum): void
     {
-        $this->assertEquals($checksum, Ean::checksum($partial));
+        self::assertSame($checksum, Ean::checksum($partial));
     }
 
     /**
      * @dataProvider ean8ValidationProvider
      */
-    public function testEan8Validation($ean8, $valid)
+    public function testEan8Validation(string $ean8, bool $valid): void
     {
-        $this->assertTrue(Ean::isValid($ean8) === $valid);
+        self::assertSame($valid, Ean::isValid($ean8));
     }
 
-    public function Ean13checksumProvider()
+    public function Ean13checksumProvider(): array
     {
-        return array(
-            array('123456789123', '1'),
-            array('978020137962', '4'),
-            array('235469852146', '9'),
-            array('300109265083', '5'),
-            array('392109219083', '7'),
-        );
+        return [
+            ['123456789123', 1],
+            ['978020137962', 4],
+            ['235469852146', 9],
+            ['300109265083', 5],
+            ['392109219083', 7],
+        ];
     }
 
-    public function ean13ValidationProvider()
+    public function ean13ValidationProvider(): array
     {
-        return array(
-            array('1234567891231', true),
-            array('2354698521469', true),
-            array('3001092650834', false),
-            array('3921092190838', false),
-        );
+        return [
+            ['1234567891231', true],
+            ['2354698521469', true],
+            ['3001092650834', false],
+            ['3921092190838', false],
+        ];
     }
 
     /**
      * @dataProvider Ean13checksumProvider
      */
-    public function testChecksumEan13($partial, $checksum)
+    public function testChecksumEan13(string $partial, int $checksum): void
     {
-        $this->assertEquals($checksum, Ean::checksum($partial));
+        self::assertSame($checksum, Ean::checksum($partial));
     }
 
     /**
      * @dataProvider ean13ValidationProvider
      */
-    public function testEan13Validation($ean13, $valid)
+    public function testEan13Validation(string $ean13, bool $valid): void
     {
-        $this->assertTrue(Ean::isValid($ean13) === $valid);
+        self::assertSame($valid, Ean::isValid($ean13));
     }
 }

--- a/test/Faker/Calculator/EanTest.php
+++ b/test/Faker/Calculator/EanTest.php
@@ -7,7 +7,7 @@ use Faker\Test\TestCase;
 
 final class EanTest extends TestCase
 {
-    public function Ean8checksumProvider(): array
+    public function Ean8checksumProvider()
     {
         return [
             ['1234567', 0],
@@ -16,7 +16,7 @@ final class EanTest extends TestCase
         ];
     }
 
-    public function ean8ValidationProvider(): array
+    public function ean8ValidationProvider()
     {
         return [
             ['1234567891231', true],
@@ -30,7 +30,7 @@ final class EanTest extends TestCase
     /**
      * @dataProvider Ean8checksumProvider
      */
-    public function testChecksumEan8(string $partial, int $checksum): void
+    public function testChecksumEan8($partial, $checksum)
     {
         self::assertSame($checksum, Ean::checksum($partial));
     }
@@ -38,12 +38,12 @@ final class EanTest extends TestCase
     /**
      * @dataProvider ean8ValidationProvider
      */
-    public function testEan8Validation(string $ean8, bool $valid): void
+    public function testEan8Validation($ean8, $valid)
     {
         self::assertSame($valid, Ean::isValid($ean8));
     }
 
-    public function Ean13checksumProvider(): array
+    public function Ean13checksumProvider()
     {
         return [
             ['123456789123', 1],
@@ -54,7 +54,7 @@ final class EanTest extends TestCase
         ];
     }
 
-    public function ean13ValidationProvider(): array
+    public function ean13ValidationProvider()
     {
         return [
             ['1234567891231', true],
@@ -67,7 +67,7 @@ final class EanTest extends TestCase
     /**
      * @dataProvider Ean13checksumProvider
      */
-    public function testChecksumEan13(string $partial, int $checksum): void
+    public function testChecksumEan13($partial, $checksum)
     {
         self::assertSame($checksum, Ean::checksum($partial));
     }
@@ -75,7 +75,7 @@ final class EanTest extends TestCase
     /**
      * @dataProvider ean13ValidationProvider
      */
-    public function testEan13Validation(string $ean13, bool $valid): void
+    public function testEan13Validation($ean13, $valid)
     {
         self::assertSame($valid, Ean::isValid($ean13));
     }

--- a/test/Faker/Calculator/InnTest.php
+++ b/test/Faker/Calculator/InnTest.php
@@ -7,44 +7,43 @@ use Faker\Test\TestCase;
 
 final class InnTest extends TestCase
 {
-    public function checksumProvider()
+    public function checksumProvider(): array
     {
-        return array(
-            array('143525744', '4'),
-            array('500109285', '3'),
-            array('500109285', '3'),
-            array('500109285', '3'),
-            array('027615723', '1')
-        );
+        return [
+            ['143525744', '4'],
+            ['500109285', '3'],
+            ['500109285', '3'],
+            ['500109285', '3'],
+            ['027615723', '1']
+        ];
     }
 
     /**
      * @dataProvider checksumProvider
      */
-    public function testChecksum($inn, $checksum)
+    public function testChecksum(string $inn, string $checksum): void
     {
-        $this->assertEquals($checksum, Inn::checksum($inn), $inn);
+        self::assertSame($checksum, Inn::checksum($inn), $inn);
     }
 
-    public function validatorProvider()
+    public function validatorProvider(): array
     {
-        return array(
-            array('5902179757', true),
-            array('5408294405', true),
-            array('2724164617', true),
-            array('0726000515', true),
-            array('6312123552', true),
-
-            array('1111111111', false),
-            array('0123456789', false),
-        );
+        return [
+            ['5902179757', true],
+            ['5408294405', true],
+            ['2724164617', true],
+            ['0726000515', true],
+            ['6312123552', true],
+            ['1111111111', false],
+            ['0123456789', false],
+        ];
     }
 
     /**
      * @dataProvider validatorProvider
      */
-    public function testIsValid($inn, $isValid)
+    public function testIsValid(string $inn, bool $isValid): void
     {
-        $this->assertEquals($isValid, Inn::isValid($inn), $inn);
+        self::assertSame($isValid, Inn::isValid($inn), $inn);
     }
 }

--- a/test/Faker/Calculator/InnTest.php
+++ b/test/Faker/Calculator/InnTest.php
@@ -7,7 +7,7 @@ use Faker\Test\TestCase;
 
 final class InnTest extends TestCase
 {
-    public function checksumProvider(): array
+    public function checksumProvider()
     {
         return [
             ['143525744', '4'],
@@ -21,12 +21,12 @@ final class InnTest extends TestCase
     /**
      * @dataProvider checksumProvider
      */
-    public function testChecksum(string $inn, string $checksum): void
+    public function testChecksum($inn, $checksum)
     {
         self::assertSame($checksum, Inn::checksum($inn), $inn);
     }
 
-    public function validatorProvider(): array
+    public function validatorProvider()
     {
         return [
             ['5902179757', true],
@@ -42,7 +42,7 @@ final class InnTest extends TestCase
     /**
      * @dataProvider validatorProvider
      */
-    public function testIsValid(string $inn, bool $isValid): void
+    public function testIsValid($inn, $isValid)
     {
         self::assertSame($isValid, Inn::isValid($inn), $inn);
     }

--- a/test/Faker/Calculator/IsbnTest.php
+++ b/test/Faker/Calculator/IsbnTest.php
@@ -4,6 +4,7 @@ namespace Faker\Test\Calculator;
 
 use Faker\Calculator\Isbn;
 use Faker\Test\TestCase;
+use LengthException;
 
 final class IsbnTest extends TestCase
 {
@@ -21,6 +22,8 @@ final class IsbnTest extends TestCase
         yield ['093583933X', true];
         yield ['0935839330', false];
         yield ['1434856045', false];
+        yield ['143485604', false];
+        yield ['093583933A', false];
     }
 
     /**
@@ -29,6 +32,12 @@ final class IsbnTest extends TestCase
     public function testChecksumIsbn(string $partial, string $checksum): void
     {
         self::assertSame($checksum, Isbn::checksum($partial));
+    }
+
+    public function testInvalidChecksumIsbn(): void
+    {
+        $this->expectException(LengthException::class);
+        Isbn::checksum('9971502100');
     }
 
     /**

--- a/test/Faker/Calculator/IsbnTest.php
+++ b/test/Faker/Calculator/IsbnTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Faker\Test\Calculator;
+
+use Faker\Calculator\Isbn;
+use Faker\Test\TestCase;
+
+final class IsbnTest extends TestCase
+{
+    public function isbnChecksumProvider(): iterable
+    {
+        yield ['997150210', '0'];
+        yield ['999215810', '7'];
+        yield ['960425059', '0'];
+    }
+
+    public function isbnValidationProvider(): iterable
+    {
+        yield ['9971502100', true];
+        yield ['0754013235', true];
+        yield ['093583933X', true];
+        yield ['0935839330', false];
+        yield ['1434856045', false];
+    }
+
+    /**
+     * @dataProvider isbnChecksumProvider
+     */
+    public function testChecksumIsbn(string $partial, string $checksum): void
+    {
+        self::assertSame($checksum, Isbn::checksum($partial));
+    }
+
+    /**
+     * @dataProvider isbnValidationProvider
+     */
+    public function testIsbnValidation(string $isbn, bool $valid): void
+    {
+        self::assertSame($valid, Isbn::isValid($isbn));
+    }
+}

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Test\Provider;
 
+use Faker\Calculator\Ean;
+use Faker\Calculator\Isbn;
 use Faker\Generator;
 use Faker\Provider\Barcode;
 use Faker\Test\TestCase;
@@ -18,29 +20,31 @@ final class BarcodeTest extends TestCase
         $this->faker = $faker;
     }
 
-    public function testEan8()
+    public function testEan8(): void
     {
         $code = $this->faker->ean8();
-        $this->assertMatchesRegularExpression('/^\d{8}$/i', $code);
-        $codeWithoutChecksum = substr($code, 0, -1);
-        $checksum = substr($code, -1);
-        $this->assertEquals(TestableBarcode::eanChecksum($codeWithoutChecksum), $checksum);
+        self::assertMatchesRegularExpression('/^\d{8}$/i', $code);
+        $this->assertTrue(Ean::isValid($code));
     }
 
-    public function testEan13()
+    public function testEan13(): void
     {
         $code = $this->faker->ean13();
-        $this->assertMatchesRegularExpression('/^\d{13}$/i', $code);
-        $codeWithoutChecksum = substr($code, 0, -1);
-        $checksum = substr($code, -1);
-        $this->assertEquals(TestableBarcode::eanChecksum($codeWithoutChecksum), $checksum);
+        self::assertMatchesRegularExpression('/^\d{13}$/i', $code);
+        self::assertTrue(Ean::isValid($code));
     }
-}
 
-final class TestableBarcode extends Barcode
-{
-    public static function eanChecksum($input)
+    public function testIsbn10(): void
     {
-        return parent::eanChecksum($input);
+        $code = $this->faker->isbn10();
+        self::assertMatchesRegularExpression('/^\d{9}[0-9X]$/i', $code);
+        self::assertTrue(Isbn::isValid($code));
+    }
+
+    public function testIsbn13(): void
+    {
+        $code = $this->faker->isbn13();
+        self::assertMatchesRegularExpression('/^\d{13}$/i', $code);
+        self::assertTrue(Ean::isValid($code));
     }
 }

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -20,14 +20,14 @@ final class BarcodeTest extends TestCase
         $this->faker = $faker;
     }
 
-    public function testEan8(): void
+    public function testEan8()
     {
         $code = $this->faker->ean8();
         self::assertMatchesRegularExpression('/^\d{8}$/i', $code);
         $this->assertTrue(Ean::isValid($code));
     }
 
-    public function testEan13(): void
+    public function testEan13()
     {
         $code = $this->faker->ean13();
         self::assertMatchesRegularExpression('/^\d{13}$/i', $code);


### PR DESCRIPTION
This PR adds more coverage to ISBN and EAN codes and moves ISBN checksum calculation to a separate class. EAN checksum has been removed from `Barcode` provider because it already existed in `Ean` calculator.
I have also improved `Inn` calculator to avoid unnecessary index offset.