### PR TITLE
add blood types

### DIFF
--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -6,7 +6,7 @@ class Factory
 {
     public const DEFAULT_LOCALE = 'en_US';
 
-    protected static $defaultProviders = ['Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid'];
+    protected static $defaultProviders = ['Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Medical', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid'];
 
     /**
      * Create a new generator

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -14,6 +14,9 @@ namespace Faker;
  * @method string title(string $gender = null)
  * @property string $titleMale
  * @property string $titleFemale
+ * @property string $bloodType
+ * @property string $bloodRh
+ * @property string $bloodGroup
  *
  * @property string $citySuffix
  * @property string $streetSuffix

--- a/src/Faker/Provider/Medical.php
+++ b/src/Faker/Provider/Medical.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Faker\Provider;
+
+class Medical extends Base
+{
+    protected static $bloodTypes = ['A', 'AB', 'B', 'O'];
+
+    protected static $bloodRhFactors = ['+', '-'];
+
+    /**
+     * @example 'AB'
+     */
+    public static function bloodType(): string
+    {
+        return static::randomElement(static::$bloodTypes);
+    }
+
+    /**
+     * @example '+'
+     */
+    public static function bloodRh(): string
+    {
+        return static::randomElement(static::$bloodRhFactors);
+    }
+
+    /**
+     * @example 'AB+'
+     */
+    public function bloodGroup(): string
+    {
+        return $this->generator->parse('{{bloodType}}{{bloodRh}}');
+    }
+}

--- a/test/Faker/Provider/MedicalTest.php
+++ b/test/Faker/Provider/MedicalTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Faker\Test\Provider;
+
+use Faker\Provider\Medical;
+use Faker\Generator;
+use Faker\Test\TestCase;
+
+final class MedicalTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
+    {
+        $this->faker = new Generator();
+        $this->faker->addProvider(new Medical($this->faker));
+    }
+    public function testBloodType(): void
+    {
+        self::assertContains($this->faker->bloodType, ['A', 'AB', 'B', 'O']);
+    }
+
+    public function testBloodRh(): void
+    {
+        self::assertContains($this->faker->bloodRh, ['+', '-']);
+    }
+
+    public function testBloodGroup(): void
+    {
+        self::assertContains($this->faker->bloodGroup, ['A+', 'A-', 'AB+', 'AB-', 'B+', 'B-', 'O+', 'O-']);
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds a new feature for generating blood type/Rh/group 
- [x] Covered by tests

Some countries use `0` instead of `O` (Poland and some post-SU countries) but I was not able to find a complete list of those so it's not localized.