### PR TITLE
Skip the BC check on update of new providers in array listing

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -1,4 +1,4 @@
 parameters:
     ignoreErrors:
-        - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-z_A-Z]+\\[a-zA-Z]+::\$[a-zA-Z]+ changed default value from#'
+        - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-z_A-Z]+\\[a-zA-Z]+::\$[a-zA-Z]+ changed default value#'
         - '#\[BC\] CHANGED: Property Faker\\Factory::\$defaultProviders changed default value#'

--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -1,6 +1,4 @@
 parameters:
     ignoreErrors:
         - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-z_A-Z]+\\[a-zA-Z]+::\$[a-zA-Z]+ changed default value from#'
-        - '#\[BC\] CHANGED: Type documentation for property Faker\\Provider\\pl_PL\\Person::\$title changed from string to string\[\]#'
-        - '#\[BC\] CHANGED: Default parameter value for for parameter \$length of Faker\\Provider\\me_ME\\Payment::bankAccountNumber\(\) changed from ''18'' to 18#'
         - '#\[BC\] CHANGED: Property Faker\\Factory::\$defaultProviders changed default value#'

--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -3,3 +3,4 @@ parameters:
         - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-z_A-Z]+\\[a-zA-Z]+::\$[a-zA-Z]+ changed default value from#'
         - '#\[BC\] CHANGED: Type documentation for property Faker\\Provider\\pl_PL\\Person::\$title changed from string to string\[\]#'
         - '#\[BC\] CHANGED: Default parameter value for for parameter \$length of Faker\\Provider\\me_ME\\Payment::bankAccountNumber\(\) changed from ''18'' to 18#'
+        - '#\[BC\] CHANGED: Property Faker\\Factory::\$defaultProviders changed default value#'


### PR DESCRIPTION
This PR:

- Skips the BC flag for adding new providers to the provider list
- Fixes #64 
