### PR TITLE
Move AT payment provider logic to de_AT

### DIFF
--- a/src/Faker/Provider/at_AT/Payment.php
+++ b/src/Faker/Provider/at_AT/Payment.php
@@ -2,38 +2,7 @@
 
 namespace Faker\Provider\at_AT;
 
-class Payment extends \Faker\Provider\Payment
+class Payment extends \Faker\Provider\de_AT\Payment
 {
-    /**
-     * Value Added Tax (VAT)
-     *
-     * @example 'ATU12345678', ('spaced') 'AT U12345678'
-     *
-     * @see http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
-     * @see http://www.iecomputersystems.com/ordering/eu_vat_numbers.htm
-     * @see http://en.wikipedia.org/wiki/VAT_identification_number
-     *
-     * @param bool $spacedNationalPrefix
-     *
-     * @return string VAT Number
-     */
-    public static function vat($spacedNationalPrefix = true)
-    {
-        $prefix = $spacedNationalPrefix ? "AT U" : "ATU";
 
-        return sprintf("%s%d", $prefix, self::randomNumber(8, true));
-    }
-
-    /**
-     * International Bank Account Number (IBAN)
-     * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
-     * @param  string  $prefix      for generating bank account number of a specific bank
-     * @param  string  $countryCode ISO 3166-1 alpha-2 country code
-     * @param  int $length      total length without country code and 2 check digits
-     * @return string
-     */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'AT', $length = null)
-    {
-        return static::iban($countryCode, $prefix, $length);
-    }
 }

--- a/src/Faker/Provider/de_AT/Payment.php
+++ b/src/Faker/Provider/de_AT/Payment.php
@@ -5,6 +5,26 @@ namespace Faker\Provider\de_AT;
 class Payment extends \Faker\Provider\Payment
 {
     /**
+     * Value Added Tax (VAT)
+     *
+     * @example 'ATU12345678', ('spaced') 'AT U12345678'
+     *
+     * @see http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
+     * @see http://www.iecomputersystems.com/ordering/eu_vat_numbers.htm
+     * @see http://en.wikipedia.org/wiki/VAT_identification_number
+     *
+     * @param bool $spacedNationalPrefix
+     *
+     * @return string VAT Number
+     */
+    public static function vat($spacedNationalPrefix = true)
+    {
+        $prefix = $spacedNationalPrefix ? "AT U" : "ATU";
+
+        return sprintf("%s%d", $prefix, self::randomNumber(8, true));
+    }
+
+    /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
      * @param  string  $prefix      for generating bank account number of a specific bank

--- a/test/Faker/Provider/de_AT/PaymentTest.php
+++ b/test/Faker/Provider/de_AT/PaymentTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Faker\Test\Provider\de_AT;
+
+use Faker\Generator;
+use Faker\Provider\de_AT\Payment;
+use Faker\Test\TestCase;
+
+final class PaymentTest extends TestCase
+{
+
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Payment($faker));
+        $this->faker = $faker;
+    }
+
+    public function testVatIsValid()
+    {
+        $vat = $this->faker->vat();
+        $unspacedVat = $this->faker->vat(false);
+        $this->assertMatchesRegularExpression('/^(AT U\d{8})$/', $vat);
+        $this->assertMatchesRegularExpression('/^(ATU\d{8})$/', $unspacedVat);
+    }
+
+    public function testBankAccountNumber()
+    {
+        $accNo = $this->faker->bankAccountNumber;
+        $this->assertEquals(substr($accNo, 0, 2), 'AT');
+        $this->assertEquals(20, strlen($accNo));
+    }
+}


### PR DESCRIPTION
This PR:

- [ ] Adds a new feature ...
- [x] Covered by tests
- [x] Fixes  #71

It moves the payment provider logic from the misnamed locale at_AT to de_AT.