### PR TITLE
Change phpunit test annotation to function prefix

### DIFF
--- a/test/Faker/Provider/de_CH/AddressTest.php
+++ b/test/Faker/Provider/de_CH/AddressTest.php
@@ -23,10 +23,7 @@ final class AddressTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     * @test
-     */
-    public function canton ()
+    public function testCanton ()
     {
         $canton = $this->faker->canton();
         $this->assertIsArray($canton);
@@ -40,30 +37,21 @@ final class AddressTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function cantonName ()
+    public function testCantonName ()
     {
         $cantonName = $this->faker->cantonName();
         $this->assertIsString($cantonName);
         $this->assertGreaterThan(2, strlen($cantonName));
     }
 
-    /**
-     * @test
-     */
-    public function cantonShort ()
+    public function testCantonShort ()
     {
         $cantonShort = $this->faker->cantonShort();
         $this->assertIsString($cantonShort);
         $this->assertEquals(2, strlen($cantonShort));
     }
 
-    /**
-     * @test
-     */
-    public function address ()
+    public function testAddress ()
     {
         $address = $this->faker->address();
         $this->assertIsString($address);

--- a/test/Faker/Provider/de_CH/InternetTest.php
+++ b/test/Faker/Provider/de_CH/InternetTest.php
@@ -25,10 +25,7 @@ final class InternetTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     * @test
-     */
-    public function emailIsValid()
+    public function testEmailIsValid()
     {
         $email = $this->faker->email();
         $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));

--- a/test/Faker/Provider/fr_CH/AddressTest.php
+++ b/test/Faker/Provider/fr_CH/AddressTest.php
@@ -23,10 +23,7 @@ final class AddressTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     * @test
-     */
-    public function canton ()
+    public function testCanton ()
     {
         $canton = $this->faker->canton();
         $this->assertIsArray($canton);
@@ -40,30 +37,21 @@ final class AddressTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function cantonName ()
+    public function testCantonName ()
     {
         $cantonName = $this->faker->cantonName();
         $this->assertIsString($cantonName);
         $this->assertGreaterThan(2, strlen($cantonName));
     }
 
-    /**
-     * @test
-     */
-    public function cantonShort ()
+    public function testCantonShort ()
     {
         $cantonShort = $this->faker->cantonShort();
         $this->assertIsString($cantonShort);
         $this->assertEquals(2, strlen($cantonShort));
     }
 
-    /**
-     * @test
-     */
-    public function address ()
+    public function testAddress ()
     {
         $address = $this->faker->address();
         $this->assertIsString($address);

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -25,10 +25,7 @@ final class InternetTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     * @test
-     */
-    public function emailIsValid()
+    public function testEmailIsValid()
     {
         $email = $this->faker->email();
         $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));

--- a/test/Faker/Provider/it_CH/AddressTest.php
+++ b/test/Faker/Provider/it_CH/AddressTest.php
@@ -23,10 +23,7 @@ final class AddressTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     * @test
-     */
-    public function canton ()
+    public function testCanton ()
     {
         $canton = $this->faker->canton();
         $this->assertIsArray($canton);
@@ -40,30 +37,21 @@ final class AddressTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function cantonName ()
+    public function testCantonName ()
     {
         $cantonName = $this->faker->cantonName();
         $this->assertIsString($cantonName);
         $this->assertGreaterThan(2, strlen($cantonName));
     }
 
-    /**
-     * @test
-     */
-    public function cantonShort ()
+    public function testCantonShort ()
     {
         $cantonShort = $this->faker->cantonShort();
         $this->assertIsString($cantonShort);
         $this->assertEquals(2, strlen($cantonShort));
     }
 
-    /**
-     * @test
-     */
-    public function address ()
+    public function testAddress ()
     {
         $address = $this->faker->address();
         $this->assertIsString($address);

--- a/test/Faker/Provider/it_CH/InternetTest.php
+++ b/test/Faker/Provider/it_CH/InternetTest.php
@@ -25,10 +25,7 @@ final class InternetTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     * @test
-     */
-    public function emailIsValid()
+    public function testEmailIsValid()
     {
         $email = $this->faker->email();
         $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));


### PR DESCRIPTION
The phpunit test names/annotations for a group of Swiss test classes were inconsistent with the other tests.