### PR TITLE
Deprecate at_AT providers

### DIFF
--- a/src/Faker/Provider/at_AT/Payment.php
+++ b/src/Faker/Provider/at_AT/Payment.php
@@ -2,6 +2,11 @@
 
 namespace Faker\Provider\at_AT;
 
+/**
+ * @deprecated at_AT is not an existing locale, use {@link \Faker\Provider\de_AT\Payment}.
+ *
+ * @see \Faker\Provider\de_AT\Payment
+ */
 class Payment extends \Faker\Provider\de_AT\Payment
 {
 }


### PR DESCRIPTION
Since `at_AT` is a non-existing locale. A backwards compatible change has been made to move away from this provider.

In my opinion the next step is to deprecate `at_AT`. This could be a patch release, since it's a backwards compatible bugfix.

Next step is to update the docs accordingly and preferably mention `de_AT` instead of `at_AT`.