### PR TITLE
Improve test consistency

### DIFF
--- a/src/Faker/Provider/at_AT/Payment.php
+++ b/src/Faker/Provider/at_AT/Payment.php
@@ -2,38 +2,7 @@
 
 namespace Faker\Provider\at_AT;
 
-class Payment extends \Faker\Provider\Payment
+class Payment extends \Faker\Provider\de_AT\Payment
 {
-    /**
-     * Value Added Tax (VAT)
-     *
-     * @example 'ATU12345678', ('spaced') 'AT U12345678'
-     *
-     * @see http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
-     * @see http://www.iecomputersystems.com/ordering/eu_vat_numbers.htm
-     * @see http://en.wikipedia.org/wiki/VAT_identification_number
-     *
-     * @param bool $spacedNationalPrefix
-     *
-     * @return string VAT Number
-     */
-    public static function vat($spacedNationalPrefix = true)
-    {
-        $prefix = $spacedNationalPrefix ? "AT U" : "ATU";
 
-        return sprintf("%s%d", $prefix, self::randomNumber(8, true));
-    }
-
-    /**
-     * International Bank Account Number (IBAN)
-     * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
-     * @param  string  $prefix      for generating bank account number of a specific bank
-     * @param  string  $countryCode ISO 3166-1 alpha-2 country code
-     * @param  int $length      total length without country code and 2 check digits
-     * @return string
-     */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'AT', $length = null)
-    {
-        return static::iban($countryCode, $prefix, $length);
-    }
 }

--- a/src/Faker/Provider/de_AT/Payment.php
+++ b/src/Faker/Provider/de_AT/Payment.php
@@ -5,6 +5,26 @@ namespace Faker\Provider\de_AT;
 class Payment extends \Faker\Provider\Payment
 {
     /**
+     * Value Added Tax (VAT)
+     *
+     * @example 'ATU12345678', ('spaced') 'AT U12345678'
+     *
+     * @see http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
+     * @see http://www.iecomputersystems.com/ordering/eu_vat_numbers.htm
+     * @see http://en.wikipedia.org/wiki/VAT_identification_number
+     *
+     * @param bool $spacedNationalPrefix
+     *
+     * @return string VAT Number
+     */
+    public static function vat($spacedNationalPrefix = true)
+    {
+        $prefix = $spacedNationalPrefix ? "AT U" : "ATU";
+
+        return sprintf("%s%d", $prefix, self::randomNumber(8, true));
+    }
+
+    /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
      * @param  string  $prefix      for generating bank account number of a specific bank

--- a/src/Faker/Provider/el_GR/PhoneNumber.php
+++ b/src/Faker/Provider/el_GR/PhoneNumber.php
@@ -2,84 +2,323 @@
 
 namespace Faker\Provider\el_GR;
 
+/**
+ * @link https://en.wikipedia.org/wiki/Telephone_numbers_in_Greece
+ * @link https://github.com/giggsey/libphonenumber-for-php/blob/master/src/data/PhoneNumberMetadata_GR.php
+ */
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
-    /**
-     * @link https://en.wikipedia.org/wiki/Telephone_numbers_in_Greece
-     */
+    protected static $internationalCallPrefixes = ['', '+30'];
+
     protected static $formats = [
-        // International formats
-        '+30 2# ########',
-        '+30 2## #######',
-        '+30 2### ######',
-        '+302#########',
+        '{{fixedLineNumber}}',
+        '{{mobileNumber}}',
+        '{{personalNumber}}',
+        '{{tollFreeNumber}}',
+        '{{sharedCostNumber}}',
+        '{{premiumRateNumber}}',
+    ];
 
-        '+3069########',
-        '+30 69 ########',
-        '+30 69########',
-        '+30 69# #######',
-        '+30 69# ### ####',
-        '+30 69# #### ###',
-        '+30 69## ######',
-        '+30 69## ## ## ##',
-        '+30 69## ### ###',
+    protected static $areaCodes = [
+        // Zone 22: Central Greece and the Aegean Islands
+        2221, 2222, 2223, 2224, 2226, 2227, 2228, 2229,
+        2231, 2232, 2233, 2234, 2235, 2236, 2237, 2238,
+        2241, 2242, 2243, 2244, 2245, 2246, 2247,
+        2251, 2252, 2253, 2254,
+        2261, 2262, 2263, 2264, 2265, 2266, 2267, 2268,
+        2271, 2272, 2273, 2274, 2275,
+        2281, 2282, 2283, 2284, 2285, 2286, 2287, 2288, 2289,
+        2291, 2292, 2293, 2294, 2295, 2296, 2297, 2298, 2299,
 
-        // Standard format
-        '2#########',
-        '2## #######',
-        '2### ######',
+        // Zone 23: Central Macedonia and Florina
+        231,
+        2321, 2322, 2323, 2324, 2325, 2327,
+        2331, 2332, 2333,
+        2341, 2343,
+        2351, 2352, 2353,
+        2371, 2372, 2373, 2374, 2375, 2376, 2377,
+        2381, 2382, 2384, 2385, 2386,
+        2391, 2392, 2393, 2394, 2395, 2396, 2397, 2399,
 
-        '69########',
-        '69# #######',
-        '69# ### ####',
-        '69# #### ###',
-        '69## ######',
-        '69## ## ## ##',
-        '69## ### ###',
+        // Zone 24: Thessaly and West Macedonia (excluding Florina)
+        241,
+        2421, 2422, 2423, 2424, 2425, 2426, 2427, 2428,
+        2431, 2432, 2433, 2434,
+        2441, 2443, 2444, 2445,
+        2461, 2462, 2463, 2464, 2465, 2467, 2468,
+        2491, 2492, 2493, 2494, 2495,
+
+        // Zone 25: East Macedonia and Thrace
+        251,
+        2521, 2522, 2523, 2524,
+        2531, 2532, 2533, 2534, 2535,
+        2541, 2542, 2544,
+        2591, 2592, 2593, 2594,
+        2551, 2552, 2553, 2554, 2555, 2556,
+
+        // Zone 26: West Greece, Ionian Island and Epirus
+        261,
+        2621, 2622, 2623, 2624, 2625, 2626,
+        2631, 2632, 2634, 2635,
+        2661, 2662, 2663, 2664, 2665, 2666,
+        2691, 2692, 2693, 2694, 2695, 2696,
+        2641, 2642, 2643, 2644, 2645, 2646, 2647,
+        2651, 2653, 2654, 2655, 2656, 2657, 2658, 2659,
+        2671, 2674,
+        2681, 2682, 2683, 2684, 2685,
+
+        // Zone 27: Peloponnese and Kythera
+        271,
+        2721, 2722, 2723, 2724, 2725,
+        2731, 2732, 2733, 2734, 2735, 2736,
+        2741, 2742, 2743, 2744, 2745, 2746, 2747,
+        2751, 2752, 2753, 2754, 2755, 2757,
+        2761, 2763, 2765,
+        2791, 2792, 2795, 2797,
+
+        // Zone 28: Crete
+        281,
+        2821, 2822, 2823, 2824, 2825,
+        2831, 2832, 2833, 2834,
+        2841, 2842, 2843, 2844,
+        2891, 2892, 2893, 2894, 2895, 2897,
+    ];
+
+    protected static $fixedLineFormats = [
+        '{{internationalCodePrefix}}21########',
+        '{{internationalCodePrefix}} 21# ### ####',
+        '{{internationalCodePrefix}}{{areaCode}}######',
+        '{{internationalCodePrefix}} {{areaCode}} ######',
+    ];
+
+    protected static $mobileCodes = [
+        685, 687, 688, 689,
+        690, 691, 693, 694, 695, 696, 697, 698, 699,
     ];
 
     protected static $mobileFormats = [
-        // International formats
-        '+3069########',
-        '+30 69########',
-        '+30 69# #######',
-        '+30 69# ### ####',
-        '+30 69# #### ###',
-        '+30 69## ######',
-        '+30 69## ## ## ##',
-        '+30 69## ### ###',
-
-        // Standard formats
-        '69########',
-        '69# #######',
-        '69# ### ####',
-        '69# #### ###',
-        '69## ######',
-        '69## ## ## ##',
-        '69## ### ###',
+        '{{internationalCodePrefix}}{{mobileCode}}#######',
+        '{{internationalCodePrefix}} {{mobileCode}} ### ####',
     ];
 
-    public static function mobilePhoneNumber()
-    {
-        return static::numerify(static::randomElement(static::$mobileFormats));
-    }
+    protected static $personalFormats = [
+        '{{internationalCodePrefix}}70########',
+        '{{internationalCodePrefix}} 70 #### ####',
+    ];
 
     protected static $tollFreeFormats = [
-        // International formats
-        '+30 800#######',
-        '+30 800 #######',
-        '+30 800 ## #####',
-        '+30 800 ### ####',
-
-        // Standard formats
-        '800#######',
-        '800 #######',
-        '800 ## #####',
-        '800 ### ####',
+        '{{internationalCodePrefix}}800#######',
+        '{{internationalCodePrefix}} 800 ### ####',
     ];
 
+    protected static $sharedCostCodes = [801, 806, 812, 825, 850, 875];
+
+    protected static $sharedCostFormats = [
+        '{{internationalCodePrefix}}{{sharedCostCode}}#######',
+        '{{internationalCodePrefix}} {{sharedCostCode}} ### ####',
+    ];
+
+    protected static $premiumRateCodes = [901, 909];
+
+    protected static $premiumRateFormats = [
+        '{{internationalCodePrefix}}{{premiumRateCode}}#######',
+        '{{internationalCodePrefix}} {{premiumRateCode}} ### ####',
+    ];
+
+    /**
+     * Generate a country calling code prefix.
+     *
+     * @example Prefix an empty string: ''
+     * @example Prefix the country calling code: '+30'
+     *
+     * @internal Used to generate phone numbers with or without prefixes.
+     *
+     * @return string
+     */
+    public static function internationalCodePrefix()
+    {
+        return static::randomElement(static::$internationalCallPrefixes);
+    }
+
+    /**
+     * Generate an area code for a fixed line number.
+     *
+     * Doesn't include codes for Greater Athens Metropolitan Area (21#) because
+     * this zone uses 3 digits, and phone numbers have a different formatting.
+     *
+     * Area codes in all the other zones use 4 digits.
+     * The capital of each zone uses 3 digits and the 4th digit can be any number.
+     * The other areas in each zone use 4 digits, but not every number is valid for the 4th digit.
+     *
+     * @example Thessaloniki has code '231', so '2310' and '2313' are valid.
+     * @example Serres has code '232', but '2326', '2328' and '2329' are not valid.
+     *
+     * @return string
+     */
+    public static function areaCode()
+    {
+        return static::numerify(
+            str_pad(static::randomElement(static::$areaCodes), 4, '#')
+        );
+    }
+
+    /**
+     * Generate a fixed line number.
+     *
+     * Numbers can be generated with or without the international code prefix.
+     * Numbers can be generated with or without spaces between their parts.
+     * Numbers in Athens use a 3-digit area code, and can be formatted as 21# ### ####.
+     * Numbers in other areas use a 4-digit area code, and can be formatted as 2### ### ###.
+     *
+     * @example A number in Athens: '2101234567'
+     * @example A number in Thessaloniki: '2310123456'
+     * @example A number with spaces in Athens: '210 123 4567'
+     * @example A number with spaces in Thessaloniki: '2310 123 456'
+     * @example A number with international code prefix: '+302101234567'
+     * @example A number with international code prefix and spaces: '+30 2310 123 456'
+     *
+     * @return string
+     */
+    public function fixedLineNumber()
+    {
+        return static::numerify($this->generator->parse(
+            static::randomElement(static::$fixedLineFormats)
+        ));
+    }
+
+    /**
+     * Generate a code for a mobile number.
+     *
+     * @internal Used to generate mobile numbers.
+     *
+     * @return string
+     */
+    public static function mobileCode()
+    {
+        return static::randomElement(static::$mobileCodes);
+    }
+
+    /**
+     * Generate a mobile number.
+     *
+     * @example A mobile number: '6901234567'
+     * @example A mobile number with spaces: '690 123 4567'
+     * @example A mobile number with international code prefix: '+306901234567'
+     * @example A mobile number with international code prefix and spaces: '+30 690 123 4567'
+     *
+     * @return string
+     */
+    public function mobileNumber()
+    {
+        return static::numerify($this->generator->parse(
+            static::randomElement(static::$mobileFormats)
+        ));
+    }
+
+    /**
+     * @deprecated Use PhoneNumber::mobileNumber() instead.
+     */
+    public static function mobilePhoneNumber()
+    {
+        return static::numerify(
+            strtr(static::randomElement(static::$mobileFormats), [
+                '{{internationalCodePrefix}}' => static::internationalCodePrefix(),
+                '{{mobileCode}}' => static::mobileCode(),
+            ])
+        );
+    }
+
+    /**
+     * Generate a personal number.
+     *
+     * @example A personal number: '7012345678'
+     * @example A personal number with spaces: '70 1234 5678'
+     * @example A personal number with international code prefix: '+307012345678'
+     * @example A personal number with international code prefix and spaces: '+30 70 1234 5678'
+     *
+     * @return string
+     */
+    public function personalNumber()
+    {
+        return static::numerify($this->generator->parse(
+            static::randomElement(static::$personalFormats)
+        ));
+    }
+
+    /**
+     * Generate a toll-free number.
+     *
+     * @example A toll-free number: '8001234567'
+     * @example A toll-free number with spaces: '800 123 4567'
+     * @example A toll-free number with international code prefix: '+308001234567'
+     * @example A toll-free number with international code prefix and spaces: '+30 800 123 4567'
+     *
+     * @return string
+     */
     public static function tollFreeNumber()
     {
-        return static::numerify(static::randomElement(static::$tollFreeFormats));
+        return static::numerify(
+            strtr(static::randomElement(static::$tollFreeFormats), [
+                '{{internationalCodePrefix}}' => static::internationalCodePrefix(),
+            ])
+        );
+    }
+
+    /**
+     * Generate a code for a shared-cost number.
+     *
+     * @internal Used to generate shared-cost numbers.
+     *
+     * @return string
+     */
+    public static function sharedCostCode()
+    {
+        return static::randomElement(static::$sharedCostCodes);
+    }
+
+    /**
+     * Generate a shared-cost number.
+     *
+     * @example A shared-cost number: '8011234567'
+     * @example A shared-cost number with spaces: '801 123 4567'
+     * @example A shared-cost number with international code prefix: '+308011234567'
+     * @example A shared-cost number with international code prefix and spaces: '+30 801 123 4567'
+     *
+     * @return string
+     */
+    public function sharedCostNumber()
+    {
+        return static::numerify($this->generator->parse(
+            static::randomElement(static::$sharedCostFormats)
+        ));
+    }
+
+    /**
+     * Generate a code for a premium-rate number.
+     *
+     * @internal Used to generate premium-rate numbers.
+     *
+     * @return string
+     */
+    public static function premiumRateCode()
+    {
+        return static::randomElement(static::$premiumRateCodes);
+    }
+
+    /**
+     * Generate a premium-rate number.
+     *
+     * @example A premium-rate number: '9011234567'
+     * @example A premium-rate number with spaces: '901 123 4567'
+     * @example A premium-rate number with international code prefix: '+309011234567'
+     * @example A premium-rate number with international code prefix and spaces: '+30 901 123 4567'
+     *
+     * @return string
+     */
+    public function premiumRateNumber()
+    {
+        return static::numerify($this->generator->parse(
+            static::randomElement(static::$premiumRateFormats)
+        ));
     }
 }

--- a/test/Faker/Provider/ar_JO/InternetTest.php
+++ b/test/Faker/Provider/ar_JO/InternetTest.php
@@ -10,7 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/ar_SA/InternetTest.php
+++ b/test/Faker/Provider/ar_SA/InternetTest.php
@@ -10,7 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/at_AT/PaymentTest.php
+++ b/test/Faker/Provider/at_AT/PaymentTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PaymentTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/bg_BG/PaymentTest.php
+++ b/test/Faker/Provider/bg_BG/PaymentTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PaymentTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/bn_BD/PersonTest.php
+++ b/test/Faker/Provider/bn_BD/PersonTest.php
@@ -8,6 +8,11 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = new Generator();
@@ -27,4 +32,3 @@ final class PersonTest extends TestCase
         $this->assertNotEmpty($firstNameFemale);
     }
 }
-?>

--- a/test/Faker/Provider/cs_CZ/PersonTest.php
+++ b/test/Faker/Provider/cs_CZ/PersonTest.php
@@ -9,14 +9,23 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-    public function testBirthNumber()
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));
         $faker->addProvider(new Miscellaneous($faker));
+        $this->faker = $faker;
+    }
 
+    public function testBirthNumber()
+    {
         for ($i = 0; $i < 1000; $i++) {
-            $birthNumber = $faker->birthNumber();
+            $birthNumber = $this->faker->birthNumber();
             $birthNumber = str_replace('/', '', $birthNumber);
 
             // check date

--- a/test/Faker/Provider/da_DK/InternetTest.php
+++ b/test/Faker/Provider/da_DK/InternetTest.php
@@ -10,7 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/de_AT/AddressTest.php
+++ b/test/Faker/Provider/de_AT/AddressTest.php
@@ -17,9 +17,7 @@ final class AddressTest extends TestCase
     protected function setUp(): void
     {
         $faker = new Generator();
-
         $faker->addProvider(new Address($faker));
-
         $this->faker = $faker;
     }
 

--- a/test/Faker/Provider/de_AT/InternetTest.php
+++ b/test/Faker/Provider/de_AT/InternetTest.php
@@ -10,7 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/de_AT/PaymentTest.php
+++ b/test/Faker/Provider/de_AT/PaymentTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Faker\Test\Provider\de_AT;
+
+use Faker\Generator;
+use Faker\Provider\de_AT\Payment;
+use Faker\Test\TestCase;
+
+final class PaymentTest extends TestCase
+{
+
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Payment($faker));
+        $this->faker = $faker;
+    }
+
+    public function testVatIsValid()
+    {
+        $vat = $this->faker->vat();
+        $unspacedVat = $this->faker->vat(false);
+        $this->assertMatchesRegularExpression('/^(AT U\d{8})$/', $vat);
+        $this->assertMatchesRegularExpression('/^(ATU\d{8})$/', $unspacedVat);
+    }
+
+    public function testBankAccountNumber()
+    {
+        $accNo = $this->faker->bankAccountNumber;
+        $this->assertEquals(substr($accNo, 0, 2), 'AT');
+        $this->assertEquals(20, strlen($accNo));
+    }
+}

--- a/test/Faker/Provider/de_AT/PaymentTest.php
+++ b/test/Faker/Provider/de_AT/PaymentTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PaymentTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/de_AT/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_AT/PhoneNumberTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/de_CH/AddressTest.php
+++ b/test/Faker/Provider/de_CH/AddressTest.php
@@ -9,9 +9,8 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/de_CH/InternetTest.php
+++ b/test/Faker/Provider/de_CH/InternetTest.php
@@ -10,9 +10,8 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/de_CH/PersonTest.php
+++ b/test/Faker/Provider/de_CH/PersonTest.php
@@ -9,6 +9,9 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/de_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_CH/PhoneNumberTest.php
@@ -8,9 +8,8 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/de_DE/InternetTest.php
+++ b/test/Faker/Provider/de_DE/InternetTest.php
@@ -10,7 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/el_GR/PhoneNumberTest.php
+++ b/test/Faker/Provider/el_GR/PhoneNumberTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Faker\Test\Provider\el_GR;
+
+use Faker\Generator;
+use Faker\Provider\el_GR\PhoneNumber;
+use Faker\Test\TestCase;
+
+final class PhoneNumberTest extends TestCase
+{
+    private $faker;
+
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new PhoneNumber($faker));
+        $this->faker = $faker;
+    }
+
+    public function testFixedLineNumber()
+    {
+        $this->assertMatchesRegularExpression(
+            '/^(\+30)?2(?:1\d\d|2(?:2[1-46-9]|[36][1-8]|4[1-7]|5[1-4]|7[1-5]|[89][1-9])|3(?:1\d|2[1-57]|[35][1-3]|4[13]|7[1-7]|8[124-6]|9[1-79])|4(?:1\d|2[1-8]|3[1-4]|4[13-5]|6[1-578]|9[1-5])|5(?:1\d|[29][1-4]|3[1-5]|4[124]|5[1-6])|6(?:1\d|[269][1-6]|3[1245]|4[1-7]|5[13-9]|7[14]|8[1-5])|7(?:1\d|2[1-5]|3[1-6]|4[1-7]|5[1-57]|6[135]|9[125-7])|8(?:1\d|2[1-5]|[34][1-4]|9[1-57]))\d{6}$/',
+            str_replace(' ', '', $this->faker->fixedLineNumber())
+        );
+    }
+
+    public function testMobileNumber()
+    {
+        $this->assertMatchesRegularExpression(
+            '/^(\+30)?68[57-9]\d{7}|(?:69|94)\d{8}$/',
+            str_replace(' ', '', $this->faker->mobileNumber())
+        );
+    }
+
+    public function testPersonalNumber()
+    {
+        $this->assertMatchesRegularExpression(
+            '/^(\+30)?70\d{8}$/',
+            str_replace(' ', '', $this->faker->personalNumber())
+        );
+    }
+
+    public function testTollFreeNumber()
+    {
+        $this->assertMatchesRegularExpression(
+            '/^(\+30)?800\d{7}$/',
+            str_replace(' ', '', $this->faker->tollFreeNumber())
+        );
+    }
+
+    public function testSharedCostNumber()
+    {
+        $this->assertMatchesRegularExpression(
+            '/^(\+30)?8(?:0[16]|12|[27]5|50)\d{7}$/',
+            str_replace(' ', '', $this->faker->sharedCostNumber())
+        );
+    }
+
+    public function testPremiumRateNumber()
+    {
+        $this->assertMatchesRegularExpression(
+            '/^(\+30)?90[19]\d{7}$/',
+            str_replace(' ', '', $this->faker->premiumRateNumber())
+        );
+    }
+}

--- a/test/Faker/Provider/el_GR/PhoneNumberTest.php
+++ b/test/Faker/Provider/el_GR/PhoneNumberTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/en_AU/AddressTest.php
+++ b/test/Faker/Provider/en_AU/AddressTest.php
@@ -1,48 +1,46 @@
 <?php
 
-namespace Faker\Provider\en_AU;
+namespace Faker\Test\Provider\en_AU;
 
 use Faker\Generator;
+use Faker\Provider\en_AU\Address;
 use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
-  /**
-   * @var Faker\Generator
-   */
-  private $faker;
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Address($faker));
+        $this->faker = $faker;
+    }
 
-  protected function setUp(): void
-  {
-    $faker = new Generator();
-    $faker->addProvider(new Address($faker));
-    $this->faker = $faker;
-  }
+    public function testCityPrefix()
+    {
+        $cityPrefix = $this->faker->cityPrefix();
+        $this->assertNotEmpty($cityPrefix);
+        $this->assertIsString($cityPrefix);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $cityPrefix);
+    }
 
-  public function testCityPrefix()
-  {
-    $cityPrefix = $this->faker->cityPrefix();
-    $this->assertNotEmpty($cityPrefix);
-    $this->assertIsString($cityPrefix);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $cityPrefix);
-  }
+    public function testStreetSuffix()
+    {
+        $streetSuffix = $this->faker->streetSuffix();
+        $this->assertNotEmpty($streetSuffix);
+        $this->assertIsString($streetSuffix);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $streetSuffix);
+    }
 
-  public function testStreetSuffix()
-  {
-    $streetSuffix = $this->faker->streetSuffix();
-    $this->assertNotEmpty($streetSuffix);
-    $this->assertIsString($streetSuffix);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $streetSuffix);
-  }
-
-  public function testState()
-  {
-    $state = $this->faker->state();
-    $this->assertNotEmpty($state);
-    $this->assertIsString($state);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $state);
-  }
+    public function testState()
+    {
+        $state = $this->faker->state();
+        $this->assertNotEmpty($state);
+        $this->assertIsString($state);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $state);
+    }
 }
-
-?>

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Faker\Provider\en_CA;
+namespace Faker\Test\Provider\en_CA;
 
 use Faker\Generator;
 use Faker\Provider\en_CA\Address;
@@ -8,62 +8,59 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
-  /**
-   * @var Faker\Generator
-   */
-  private $faker;
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Address($faker));
+        $this->faker = $faker;
+    }
 
-  protected function setUp(): void
-  {
-    $faker = new Generator();
-    $faker->addProvider(new Address($faker));
-    $this->faker = $faker;
-  }
+    /**
+     * Test the validity of province
+     */
+    public function testProvince()
+    {
+        $province = $this->faker->province();
+        $this->assertNotEmpty($province);
+        $this->assertIsString($province);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $province);
+    }
 
-  /**
-   * Test the validity of province
-   */
-  public function testProvince()
-  {
-    $province = $this->faker->province();
-    $this->assertNotEmpty($province);
-    $this->assertIsString($province);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $province);
-  }
+    /**
+     * Test the validity of province abbreviation
+     */
+    public function testProvinceAbbr()
+    {
+        $provinceAbbr = $this->faker->provinceAbbr();
+        $this->assertNotEmpty($provinceAbbr);
+        $this->assertIsString($provinceAbbr);
+        $this->assertMatchesRegularExpression('/^[A-Z]{2}$/', $provinceAbbr);
+    }
 
-  /**
-   * Test the validity of province abbreviation
-   */
-  public function testProvinceAbbr()
-  {
-    $provinceAbbr = $this->faker->provinceAbbr();
-    $this->assertNotEmpty($provinceAbbr);
-    $this->assertIsString($provinceAbbr);
-    $this->assertMatchesRegularExpression('/^[A-Z]{2}$/', $provinceAbbr);
-  }
+    /**
+     * Test the validity of postcode letter
+     */
+    public function testPostcodeLetter()
+    {
+        $postcodeLetter = $this->faker->randomPostcodeLetter();
+        $this->assertNotEmpty($postcodeLetter);
+        $this->assertIsString($postcodeLetter);
+        $this->assertMatchesRegularExpression('/^[A-Z]{1}$/', $postcodeLetter);
+    }
 
-  /**
-   * Test the validity of postcode letter
-   */
-  public function testPostcodeLetter()
-  {
-    $postcodeLetter = $this->faker->randomPostcodeLetter();
-    $this->assertNotEmpty($postcodeLetter);
-    $this->assertIsString($postcodeLetter);
-    $this->assertMatchesRegularExpression('/^[A-Z]{1}$/', $postcodeLetter);
-  }
-
-  /**
-   * Test the validity of Canadian postcode
-   */
-  public function testPostcode()
-  {
-    $postcode = $this->faker->postcode();
-    $this->assertNotEmpty($postcode);
-    $this->assertIsString($postcode);
-    $this->assertMatchesRegularExpression('/^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/', $postcode);
-  }
+    /**
+     * Test the validity of Canadian postcode
+     */
+    public function testPostcode()
+    {
+        $postcode = $this->faker->postcode();
+        $this->assertNotEmpty($postcode);
+        $this->assertIsString($postcode);
+        $this->assertMatchesRegularExpression('/^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/', $postcode);
+    }
 }
-
-?>

--- a/test/Faker/Provider/en_GB/AddressTest.php
+++ b/test/Faker/Provider/en_GB/AddressTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Faker\Provider\en_GB;
+namespace Faker\Test\Provider\en_GB;
 
 use Faker\Generator;
+use Faker\Provider\en_GB\Address;
 use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
      * @var Generator
      */
@@ -20,17 +20,11 @@ final class AddressTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     *
-     */
     public function testPostcode()
     {
-
         $postcode = $this->faker->postcode();
         $this->assertNotEmpty($postcode);
         $this->assertIsString($postcode);
         $this->assertMatchesRegularExpression('@^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]) ?[0-9][ABD-HJLNP-UW-Z]{2})$@i', $postcode);
-
     }
-
 }

--- a/test/Faker/Provider/en_IN/AddressTest.php
+++ b/test/Faker/Provider/en_IN/AddressTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Faker\Provider\en_IN;
+namespace Faker\Test\Provider\en_IN;
 
 use Faker\Generator;
 use Faker\Provider\en_IN\Address;
@@ -8,50 +8,47 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
-  /**
-   * @var Faker\Generator
-   */
-  private $faker;
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Address($faker));
+        $this->faker = $faker;
+    }
 
-  protected function setUp(): void
-  {
-    $faker = new Generator();
-    $faker->addProvider(new Address($faker));
-    $this->faker = $faker;
-  }
+    public function testCity()
+    {
+        $city = $this->faker->city();
+        $this->assertNotEmpty($city);
+        $this->assertIsString($city);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $city);
+    }
 
-  public function testCity()
-  {
-    $city = $this->faker->city();
-    $this->assertNotEmpty($city);
-    $this->assertIsString($city);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $city);
-  }
+    public function testCountry()
+    {
+        $country = $this->faker->country();
+        $this->assertNotEmpty($country);
+        $this->assertIsString($country);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $country);
+    }
 
-  public function testCountry()
-  {
-    $country = $this->faker->country();
-    $this->assertNotEmpty($country);
-    $this->assertIsString($country);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $country);
-  }
+    public function testLocalityName()
+    {
+        $localityName = $this->faker->localityName();
+        $this->assertNotEmpty($localityName);
+        $this->assertIsString($localityName);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $localityName);
+    }
 
-  public function testLocalityName()
-  {
-    $localityName = $this->faker->localityName();
-    $this->assertNotEmpty($localityName);
-    $this->assertIsString($localityName);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $localityName);
-  }
-
-  public function testAreaSuffix()
-  {
-    $areaSuffix = $this->faker->areaSuffix();
-    $this->assertNotEmpty($areaSuffix);
-    $this->assertIsString($areaSuffix);
-    $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $areaSuffix);
-  }
+    public function testAreaSuffix()
+    {
+        $areaSuffix = $this->faker->areaSuffix();
+        $this->assertNotEmpty($areaSuffix);
+        $this->assertIsString($areaSuffix);
+        $this->assertMatchesRegularExpression('/[A-Z][a-z]+/', $areaSuffix);
+    }
 }
-
-?>

--- a/test/Faker/Provider/en_NG/AddressTest.php
+++ b/test/Faker/Provider/en_NG/AddressTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Faker\Provider\en_NG;
+namespace Faker\Test\Provider\en_NG;
 
 use Faker\Generator;
 use Faker\Provider\en_NG\Address;
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
      * @var Generator
      */
@@ -21,9 +20,6 @@ final class AddressTest extends TestCase
         $this->faker = $faker;
     }
 
-    /**
-     *
-     */
     public function testPostcodeIsNotEmptyAndIsValid()
     {
         $postcode = $this->faker->postcode();
@@ -53,5 +49,4 @@ final class AddressTest extends TestCase
         $this->assertNotEmpty($region);
         $this->assertIsString($region);
     }
-
 }

--- a/test/Faker/Provider/en_NG/InternetTest.php
+++ b/test/Faker/Provider/en_NG/InternetTest.php
@@ -9,7 +9,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/en_NG/PersonTest.php
+++ b/test/Faker/Provider/en_NG/PersonTest.php
@@ -8,7 +8,7 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-     /**
+    /**
      * @var Generator
      */
     private $faker;

--- a/test/Faker/Provider/en_NG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NG/PhoneNumberTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/en_NZ/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NZ/PhoneNumberTest.php
@@ -8,9 +8,8 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 
@@ -33,4 +32,3 @@ final class PhoneNumberTest extends TestCase
       $this->assertMatchesRegularExpression('/(^\([0]\d{1}\))(\d{7}$)|(^\([0][2]\d{1}\))(\d{6,8}$)|([0][8][0][0])([\s])(\d{5,8}$)/', $number);
     }
 }
-?>

--- a/test/Faker/Provider/en_PH/AddressTest.php
+++ b/test/Faker/Provider/en_PH/AddressTest.php
@@ -8,43 +8,42 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 
     protected function setUp(): void
     {
-      $faker = new Generator();
-      $faker->addProvider(new Address($faker));
-      $this->faker = $faker;
+        $faker = new Generator();
+        $faker->addProvider(new Address($faker));
+        $this->faker = $faker;
     }
 
     public function testProvince()
     {
-      $province = $this->faker->province();
-      $this->assertNotEmpty($province);
-      $this->assertIsString($province);
+        $province = $this->faker->province();
+        $this->assertNotEmpty($province);
+        $this->assertIsString($province);
     }
 
     public function testCity()
     {
-      $city = $this->faker->city();
-      $this->assertNotEmpty($city);
-      $this->assertIsString($city);
+        $city = $this->faker->city();
+        $this->assertNotEmpty($city);
+        $this->assertIsString($city);
     }
 
     public function testMunicipality()
     {
-      $municipality = $this->faker->municipality();
-      $this->assertNotEmpty($municipality);
-      $this->assertIsString($municipality);
+        $municipality = $this->faker->municipality();
+        $this->assertNotEmpty($municipality);
+        $this->assertIsString($municipality);
     }
 
     public function testBarangay()
     {
-      $barangay = $this->faker->barangay();
-      $this->assertIsString($barangay);
+        $barangay = $this->faker->barangay();
+        $this->assertIsString($barangay);
     }
 }

--- a/test/Faker/Provider/en_SG/AddressTest.php
+++ b/test/Faker/Provider/en_SG/AddressTest.php
@@ -3,11 +3,17 @@
 namespace Faker\Test\Provider\en_SG;
 
 use Faker\Factory;
+use Faker\Generator;
 use Faker\Provider\en_SG\Address;
 use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = Factory::create('en_SG');

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -3,11 +3,15 @@
 namespace Faker\Test\Provider\en_SG;
 
 use Faker\Factory;
+use Faker\Generator;
 use Faker\Provider\en_SG\PhoneNumber;
 use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/en_UG/AddressTest.php
+++ b/test/Faker/Provider/en_UG/AddressTest.php
@@ -8,37 +8,36 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
-/**
- * @var Faker\Generator
- */
-  private $faker;
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Address($faker));
+        $this->faker = $faker;
+    }
 
-  protected function setUp(): void
-  {
-      $faker = new Generator();
-      $faker->addProvider(new Address($faker));
-      $this->faker = $faker;
-  }
+    public function testCityName()
+    {
+        $city = $this->faker->cityName();
+        $this->assertNotEmpty($city);
+        $this->assertIsString($city);
+    }
 
-  public function testCityName()
-  {
-    $city = $this->faker->cityName();
-    $this->assertNotEmpty($city);
-    $this->assertIsString($city);
-  }
+    public function testDistrict()
+    {
+        $district = $this->faker->district();
+        $this->assertNotEmpty($district);
+        $this->assertIsString($district);
+    }
 
-  public function testDistrict()
-  {
-    $district = $this->faker->district();
-    $this->assertNotEmpty($district);
-    $this->assertIsString($district);
-  }
-
-  public function testRegion()
-  {
-    $region = $this->faker->region();
-    $this->assertNotEmpty($region);
-    $this->assertIsString($region);
-  }
+    public function testRegion()
+    {
+        $region = $this->faker->region();
+        $this->assertNotEmpty($region);
+        $this->assertIsString($region);
+    }
 }

--- a/test/Faker/Provider/en_US/CompanyTest.php
+++ b/test/Faker/Provider/en_US/CompanyTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/en_US/PersonTest.php
+++ b/test/Faker/Provider/en_US/PersonTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/en_ZA/CompanyTest.php
+++ b/test/Faker/Provider/en_ZA/CompanyTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/en_ZA/InternetTest.php
+++ b/test/Faker/Provider/en_ZA/InternetTest.php
@@ -10,7 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/en_ZA/PersonTest.php
+++ b/test/Faker/Provider/en_ZA/PersonTest.php
@@ -9,6 +9,9 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/es_ES/PersonTest.php
+++ b/test/Faker/Provider/es_ES/PersonTest.php
@@ -8,6 +8,11 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = new Generator();

--- a/test/Faker/Provider/es_ES/PhoneNumberTest.php
+++ b/test/Faker/Provider/es_ES/PhoneNumberTest.php
@@ -8,6 +8,11 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = new Generator();

--- a/test/Faker/Provider/es_VE/CompanyTest.php
+++ b/test/Faker/Provider/es_VE/CompanyTest.php
@@ -33,6 +33,4 @@ final class CompanyTest extends TestCase
         $rif = $this->faker->taxpayerIdentificationNumber('-');
         $this->assertMatchesRegularExpression($pattern, $rif);
     }
-
-
 }

--- a/test/Faker/Provider/es_VE/PersonTest.php
+++ b/test/Faker/Provider/es_VE/PersonTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/fa_IR/PersonTest.php
+++ b/test/Faker/Provider/fa_IR/PersonTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/fi_FI/InternetTest.php
+++ b/test/Faker/Provider/fi_FI/InternetTest.php
@@ -10,7 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -9,8 +9,10 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-    /** @var Generator */
-    protected $faker;
+    /**
+     * @var Generator
+     */
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/fr_CH/AddressTest.php
+++ b/test/Faker/Provider/fr_CH/AddressTest.php
@@ -9,9 +9,8 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -10,9 +10,8 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/fr_CH/PersonTest.php
+++ b/test/Faker/Provider/fr_CH/PersonTest.php
@@ -9,6 +9,9 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/fr_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_CH/PhoneNumberTest.php
@@ -8,9 +8,8 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -8,23 +8,22 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
-/**
- * @var Faker\Generator
- */
-  private $faker;
+    protected function setUp(): void
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Address($faker));
+        $this->faker = $faker;
+    }
 
-  protected function setUp(): void
-  {
-      $faker = new Generator();
-      $faker->addProvider(new Address($faker));
-      $this->faker = $faker;
-  }
-
-  public function testSecondaryAddress()
-  {
-    $secondaryAdress = $this->faker->secondaryAddress();
-    $this->assertNotEmpty($secondaryAdress);
-    $this->assertIsString($secondaryAdress);
-  }
+    public function testSecondaryAddress()
+    {
+        $secondaryAdress = $this->faker->secondaryAddress();
+        $this->assertNotEmpty($secondaryAdress);
+        $this->assertIsString($secondaryAdress);
+    }
 }

--- a/test/Faker/Provider/fr_FR/CompanyTest.php
+++ b/test/Faker/Provider/fr_FR/CompanyTest.php
@@ -9,6 +9,9 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/fr_FR/PaymentTest.php
+++ b/test/Faker/Provider/fr_FR/PaymentTest.php
@@ -9,6 +9,9 @@ use Faker\Test\TestCase;
 
 final class PaymentTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void
@@ -29,7 +32,7 @@ final class PaymentTest extends TestCase
 
         $key = (int) substr($siren, 2, 2);
         if ($key === 0) {
-            $this->assertEqual($key, (12 + 3 * ($siren % 97)) % 97);            
+            $this->assertEqual($key, (12 + 3 * ($siren % 97)) % 97);
         }
     }
 
@@ -43,7 +46,7 @@ final class PaymentTest extends TestCase
 
         $key = (int) substr($siren, 2, 2);
         if ($key === 0) {
-            $this->assertEqual($key, (12 + 3 * ($siren % 97)) % 97);            
+            $this->assertEqual($key, (12 + 3 * ($siren % 97)) % 97);
         }
     }
 }

--- a/test/Faker/Provider/fr_FR/PersonTest.php
+++ b/test/Faker/Provider/fr_FR/PersonTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/id_ID/PersonTest.php
+++ b/test/Faker/Provider/id_ID/PersonTest.php
@@ -10,6 +10,11 @@ use Faker\Test\TestCase;
 final class PersonTest extends TestCase
 {
     /**
+     * @var Generator
+     */
+    private $faker;
+
+    /**
      * @see Person::$birthPlaceCode
      */
     protected static $birthPlaceCode = array(

--- a/test/Faker/Provider/it_CH/AddressTest.php
+++ b/test/Faker/Provider/it_CH/AddressTest.php
@@ -9,9 +9,8 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/it_CH/InternetTest.php
+++ b/test/Faker/Provider/it_CH/InternetTest.php
@@ -10,9 +10,8 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/it_CH/PersonTest.php
+++ b/test/Faker/Provider/it_CH/PersonTest.php
@@ -9,6 +9,9 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/it_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/it_CH/PhoneNumberTest.php
@@ -8,9 +8,8 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
-     * @var Faker\Generator
+     * @var Generator
      */
     private $faker;
 

--- a/test/Faker/Provider/it_IT/CompanyTest.php
+++ b/test/Faker/Provider/it_IT/CompanyTest.php
@@ -8,6 +8,11 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = new Generator();

--- a/test/Faker/Provider/it_IT/PersonTest.php
+++ b/test/Faker/Provider/it_IT/PersonTest.php
@@ -8,6 +8,11 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = new Generator();

--- a/test/Faker/Provider/ja_JP/InternetTest.php
+++ b/test/Faker/Provider/ja_JP/InternetTest.php
@@ -8,21 +8,26 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-    public function testUserName()
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Internet($faker));
         $faker->seed(1);
+        $this->faker = $faker;
+    }
 
-        $this->assertEquals('akira72', $faker->userName);
+    public function testUserName()
+    {
+        $this->assertEquals('akira72', $this->faker->userName);
     }
 
     public function testDomainName()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Internet($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('nakajima.com', $faker->domainName);
+        $this->assertEquals('nakajima.com', $this->faker->domainName);
     }
 }

--- a/test/Faker/Provider/ja_JP/PersonTest.php
+++ b/test/Faker/Provider/ja_JP/PersonTest.php
@@ -8,48 +8,41 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-    public function testKanaNameMaleReturns()
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));
         $faker->seed(1);
+        $this->faker = $faker;
+    }
 
-        $this->assertEquals('アオタ ミノル', $faker->kanaName('male'));
+    public function testKanaNameMaleReturns()
+    {
+        $this->assertEquals('アオタ ミノル', $this->faker->kanaName('male'));
     }
 
     public function testKanaNameFemaleReturns()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('アオタ ミキ', $faker->kanaName('female'));
+        $this->assertEquals('アオタ ミキ', $this->faker->kanaName('female'));
     }
 
     public function testFirstKanaNameMaleReturns()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('ヒデキ', $faker->firstKanaName('male'));
+        $this->assertEquals('ヒデキ', $this->faker->firstKanaName('male'));
     }
 
     public function testFirstKanaNameFemaleReturns()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('マアヤ', $faker->firstKanaName('female'));
+        $this->assertEquals('マアヤ', $this->faker->firstKanaName('female'));
     }
 
     public function testLastKanaNameReturnsNakajima()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('ナカジマ', $faker->lastKanaName);
+        $this->assertEquals('ナカジマ', $this->faker->lastKanaName);
     }
 }

--- a/test/Faker/Provider/ja_JP/PhoneNumberTest.php
+++ b/test/Faker/Provider/ja_JP/PhoneNumberTest.php
@@ -8,13 +8,22 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-    public function testPhoneNumber()
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));
+        $this->faker = $faker;
+    }
 
+    public function testPhoneNumber()
+    {
         for ($i = 0; $i < 10; $i++) {
-            $phoneNumber = $faker->phoneNumber;
+            $phoneNumber = $this->faker->phoneNumber;
             $this->assertNotEmpty($phoneNumber);
             $this->assertMatchesRegularExpression('/^0\d{1,4}-\d{1,4}-\d{3,4}$/', $phoneNumber);
         }

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -7,14 +7,14 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
-
     /**
-     * {@inheritdoc}
+     * @var Generator
      */
+    private $faker;
+
     protected function setUp(): void
     {
         $this->faker = new Generator();
-
         $this->faker->addProvider(new Company($this->faker));
     }
 

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -8,14 +8,14 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-
     /**
-     * {@inheritdoc}
+     * @var Generator
      */
+    private $faker;
+
     protected function setUp(): void
     {
         $this->faker = new Generator();
-
         $this->faker->addProvider(new Person($this->faker));
     }
 

--- a/test/Faker/Provider/lt_LT/AddressTest.php
+++ b/test/Faker/Provider/lt_LT/AddressTest.php
@@ -8,8 +8,10 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-    /** @var Generator */
-    protected $faker;
+    /**
+     * @var Generator
+     */
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/mn_MN/PersonTest.php
+++ b/test/Faker/Provider/mn_MN/PersonTest.php
@@ -8,21 +8,29 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-    public function testName()
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));
-        $faker->seed(1);
+        $this->faker = $faker;
+    }
 
-        $this->assertMatchesRegularExpression('/^[А-Я]{1}\.[\w\W]+$/u', $faker->name);
+    public function testName()
+    {
+        $this->faker->seed(1);
+
+        $this->assertMatchesRegularExpression('/^[А-Я]{1}\.[\w\W]+$/u', $this->faker->name);
     }
 
     public function testIdNumber()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(2);
+        $this->faker->seed(2);
 
-        $this->assertMatchesRegularExpression('/^[А-Я]{2}\d{8}$/u', $faker->idNumber);
+        $this->assertMatchesRegularExpression('/^[А-Я]{2}\d{8}$/u', $this->faker->idNumber);
     }
 }

--- a/test/Faker/Provider/nb_NO/PhoneNumberTest.php
+++ b/test/Faker/Provider/nb_NO/PhoneNumberTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/nl_NL/CompanyTest.php
+++ b/test/Faker/Provider/nl_NL/CompanyTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
     private $faker;
 
     protected function setUp(): void

--- a/test/Faker/Provider/pt_BR/CompanyTest.php
+++ b/test/Faker/Provider/pt_BR/CompanyTest.php
@@ -8,6 +8,10 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/pt_BR/PersonTest.php
+++ b/test/Faker/Provider/pt_BR/PersonTest.php
@@ -8,6 +8,10 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/pt_PT/AddressTest.php
+++ b/test/Faker/Provider/pt_PT/AddressTest.php
@@ -9,7 +9,6 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -8,6 +8,10 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_PT/PhoneNumberTest.php
@@ -8,6 +8,11 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = new Generator();

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -12,10 +12,9 @@ final class PersonTest extends TestCase
     const TEST_CNP_REGEX = '/^[1-9][0-9]{2}(?:0[1-9]|1[012])(?:0[1-9]|[12][0-9]|3[01])(?:0[1-9]|[123][0-9]|4[0-6]|5[12])[0-9]{3}[0-9]$/';
 
     /**
-     * @var \Faker\Generator
-     *
+     * @var Generator
      */
-    protected $faker;
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/ro_RO/PhoneNumberTest.php
+++ b/test/Faker/Provider/ro_RO/PhoneNumberTest.php
@@ -8,6 +8,11 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
+    /**
+     * @var Generator
+     */
+    private $faker;
+
     protected function setUp(): void
     {
         $faker = new Generator();

--- a/test/Faker/Provider/sv_SE/MunicipalityTest.php
+++ b/test/Faker/Provider/sv_SE/MunicipalityTest.php
@@ -2,16 +2,16 @@
 
 namespace Faker\Test\Provider\sv_SE;
 
-use Faker\Calculator\Luhn;
 use Faker\Generator;
 use Faker\Provider\sv_SE\Municipality;
-use Faker\Provider\sv_SE\Person;
 use Faker\Test\TestCase;
 
 final class MunicipalityTest extends TestCase
 {
-    /** @var Generator */
-    protected $faker;
+    /**
+     * @var Generator
+     */
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -9,8 +9,10 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-    /** @var Generator */
-    protected $faker;
+    /**
+     * @var Generator
+     */
+    private $faker;
 
     protected function setUp(): void
     {

--- a/test/Faker/Provider/tr_TR/CompanyTest.php
+++ b/test/Faker/Provider/tr_TR/CompanyTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class CompanyTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/tr_TR/PaymentTest.php
+++ b/test/Faker/Provider/tr_TR/PaymentTest.php
@@ -1,9 +1,9 @@
 <?php
 
-
-namespace Faker\Provider\tr_TR;
+namespace Faker\Test\Provider\tr_TR;
 
 use Faker\Generator;
+use Faker\Provider\tr_TR\Payment;
 use Faker\Test\TestCase;
 
 final class PaymentTest extends TestCase

--- a/test/Faker/Provider/tr_TR/PersonTest.php
+++ b/test/Faker/Provider/tr_TR/PersonTest.php
@@ -9,7 +9,6 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/tr_TR/PhoneNumberTest.php
+++ b/test/Faker/Provider/tr_TR/PhoneNumberTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class AddressTest extends TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/uk_UA/PersonTest.php
+++ b/test/Faker/Provider/uk_UA/PersonTest.php
@@ -8,49 +8,43 @@ use Faker\Test\TestCase;
 
 final class PersonTest extends TestCase
 {
-    public function testFirstNameMaleReturns()
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));
         $faker->seed(1);
 
-        $this->assertEquals('Максим', $faker->firstNameMale());
+        $this->faker = $faker;
+    }
+
+    public function testFirstNameMaleReturns()
+    {
+        $this->assertEquals('Максим', $this->faker->firstNameMale());
     }
 
     public function testFirstNameFemaleReturns()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('Людмила', $faker->firstNameFemale());
+        $this->assertEquals('Людмила', $this->faker->firstNameFemale());
     }
 
     public function testMiddleNameMaleReturns()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('Миколайович', $faker->middleNameMale());
+        $this->assertEquals('Миколайович', $this->faker->middleNameMale());
     }
 
     public function testMiddleNameFemaleReturns()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('Миколаївна', $faker->middleNameFemale());
+        $this->assertEquals('Миколаївна', $this->faker->middleNameFemale());
     }
 
     public function testLastNameReturns()
     {
-        $faker = new Generator();
-        $faker->addProvider(new Person($faker));
-        $faker->seed(1);
-
-        $this->assertEquals('Броваренко', $faker->lastName());
+        $this->assertEquals('Броваренко', $this->faker->lastName());
     }
 
 

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -8,7 +8,6 @@ use Faker\Test\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-
     /**
      * @var Generator
      */
@@ -30,7 +29,5 @@ final class PhoneNumberTest extends TestCase
             1,
             'Phone number format ' . $phoneNumber . ' is wrong!'
         );
-
     }
-
 }


### PR DESCRIPTION
The tests have a rather high variance of formatting, docblock usage, closing php tags and the test class namespaces were wrong in same cases.
This PR cleans the tests up somewhat.