### PR TITLE
Improve internet tests

### DIFF
--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -30,6 +30,7 @@ final class InternetTest extends TestCase
     {
         $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
         $localePaths = array_filter(glob($providerPath . '/*', GLOB_ONLYDIR));
+        $locales = [];
         foreach ($localePaths as $path) {
             $parts = explode('/', $path);
             $locales[] = array($parts[count($parts) - 1]);
@@ -39,20 +40,12 @@ final class InternetTest extends TestCase
     }
 
     /**
-     * @link http://stackoverflow.com/questions/12026842/how-to-validate-an-email-address-in-php
-     *
      * @dataProvider localeDataProvider
      */
     public function testEmailIsValid($locale)
     {
-        if ($locale !== 'en_US' && !class_exists('Transliterator')) {
-            $this->markTestSkipped('Transliterator class not available (intl extension)');
-        }
-
         $this->loadLocalProviders($locale);
-        $pattern = '/^(?!(?:(?:\\x22?\\x5C[\\x00-\\x7E]\\x22?)|(?:\\x22?[^\\x5C\\x22]\\x22?)){255,})(?!(?:(?:\\x22?\\x5C[\\x00-\\x7E]\\x22?)|(?:\\x22?[^\\x5C\\x22]\\x22?)){65,}@)(?:(?:[\\x21\\x23-\\x27\\x2A\\x2B\\x2D\\x2F-\\x39\\x3D\\x3F\\x5E-\\x7E]+)|(?:\\x22(?:[\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x21\\x23-\\x5B\\x5D-\\x7F]|(?:\\x5C[\\x00-\\x7F]))*\\x22))(?:\\.(?:(?:[\\x21\\x23-\\x27\\x2A\\x2B\\x2D\\x2F-\\x39\\x3D\\x3F\\x5E-\\x7E]+)|(?:\\x22(?:[\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x21\\x23-\\x5B\\x5D-\\x7F]|(?:\\x5C[\\x00-\\x7F]))*\\x22)))*@(?:(?:(?!.*[^.]{64,})(?:(?:(?:xn--)?[a-z0-9]+(?:-+[a-z0-9]+)*\\.){1,126}){1,}(?:(?:[a-z][a-z0-9]*)|(?:(?:xn--)[a-z0-9]+))(?:-+[a-z0-9]+)*)|(?:\\[(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){7})|(?:(?!(?:.*[a-f0-9][:\\]]){7,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?)))|(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){5}:)|(?:(?!(?:.*[a-f0-9]:){5,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3}:)?)))?(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))(?:\\.(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))){3}))\\]))$/iD';
-        $emailAddress = $this->faker->email();
-        $this->assertMatchesRegularExpression($pattern, $emailAddress);
+        $this->assertNotFalse(filter_var($this->faker->email(), FILTER_VALIDATE_EMAIL));
     }
 
     /**
@@ -60,10 +53,6 @@ final class InternetTest extends TestCase
      */
     public function testUsernameIsValid($locale)
     {
-        if ($locale !== 'en_US' && !class_exists('Transliterator')) {
-            $this->markTestSkipped('Transliterator class not available (intl extension)');
-        }
-
         $this->loadLocalProviders($locale);
         $pattern = '/^[A-Za-z0-9]+([._][A-Za-z0-9]+)*$/';
         $username = $this->faker->username();
@@ -75,10 +64,6 @@ final class InternetTest extends TestCase
      */
     public function testDomainnameIsValid($locale)
     {
-        if ($locale !== 'en_US' && !class_exists('Transliterator')) {
-            $this->markTestSkipped('Transliterator class not available (intl extension)');
-        }
-
         $this->loadLocalProviders($locale);
         $pattern = '/^[a-z]+(\.[a-z]+)+$/';
         $domainName = $this->faker->domainName();
@@ -90,10 +75,6 @@ final class InternetTest extends TestCase
      */
     public function testDomainwordIsValid($locale)
     {
-        if ($locale !== 'en_US' && !class_exists('Transliterator')) {
-            $this->markTestSkipped('Transliterator class not available (intl extension)');
-        }
-
         $this->loadLocalProviders($locale);
         $pattern = '/^[a-z]+$/';
         $domainWord = $this->faker->domainWord();
@@ -131,13 +112,12 @@ final class InternetTest extends TestCase
 
     public function testUrlIsValid()
     {
-        $url = $this->faker->url();
-        $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
+        $this->assertNotFalse(filter_var($this->faker->url(), FILTER_VALIDATE_URL));
     }
 
     public function testLocalIpv4()
     {
-        $this->assertNotFalse(filter_var(Internet::localIpv4(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));
+        $this->assertNotFalse(filter_var($this->faker->localIpv4(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));
     }
 
     public function testIpv4()
@@ -162,6 +142,6 @@ final class InternetTest extends TestCase
 
     public function testMacAddress()
     {
-        $this->assertMatchesRegularExpression('/^([0-9A-F]{2}[:]){5}([0-9A-F]{2})$/i', Internet::macAddress());
+        $this->assertNotFalse(filter_var($this->faker->macAddress(), FILTER_VALIDATE_MAC));
     }
 }


### PR DESCRIPTION
This PR improves the existing internet tests.

- `filter_var` is used to validate email and mac address (so the relevant regex rules are maintained by the php core team)
- phpunit markTestSkipped are removed, because the intl extension is required (-dev) anyways
- minor cleanups