### PR TITLE
Remove usage of mt_rand

### DIFF
--- a/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
@@ -30,7 +30,7 @@ class ColumnTypeGuesser
                 };
             case 'biginteger':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, 9223372036854775807);
+                    return $generator->numberBetween(0, PHP_INT_MAX);
                 };
             case 'decimal':
             case 'float':

--- a/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
@@ -25,12 +25,12 @@ class ColumnTypeGuesser
                     return $generator->boolean;
                 };
             case 'integer':
-                return function () {
-                    return mt_rand(0, intval('2147483647'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 2147483647);
                 };
             case 'biginteger':
-                return function () {
-                    return mt_rand(0, intval('9223372036854775807'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, (int) '9223372036854775807');
                 };
             case 'decimal':
             case 'float':

--- a/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
@@ -30,7 +30,7 @@ class ColumnTypeGuesser
                 };
             case 'biginteger':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, (int) '9223372036854775807');
+                    return $generator->numberBetween(0, 9223372036854775807);
                 };
             case 'decimal':
             case 'float':

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -43,7 +43,7 @@ class ColumnTypeGuesser
                 };
             case 'bigint':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, 18446744073709551615);
+                    return $generator->numberBetween(0, PHP_INT_MAX);
                 };
             case 'float':
                 return function () use ($generator) {

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -3,15 +3,13 @@
 namespace Faker\ORM\Doctrine;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Faker\Generator;
 
 class ColumnTypeGuesser
 {
     protected $generator;
 
-    /**
-     * @param \Faker\Generator $generator
-     */
-    public function __construct(\Faker\Generator $generator)
+    public function __construct(Generator $generator)
     {
         $this->generator = $generator;
     }
@@ -36,20 +34,20 @@ class ColumnTypeGuesser
                     return $generator->randomNumber($size + 2) / 100;
                 };
             case 'smallint':
-                return function () {
-                    return mt_rand(0, 65535);
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 65535);
                 };
             case 'integer':
-                return function () {
-                    return mt_rand(0, intval('2147483647'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 2147483647);
                 };
             case 'bigint':
-                return function () {
-                    return mt_rand(0, intval('18446744073709551615'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, (int) '18446744073709551615');
                 };
             case 'float':
-                return function () {
-                    return mt_rand(0, intval('4294967295')) / mt_rand(1, intval('4294967295'));
+                return function () use ($generator) {
+                    return $generator->randomFloat();
                 };
             case 'string':
                 $size = $class->fieldMappings[$fieldName]['length'] ?? 255;

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -43,7 +43,7 @@ class ColumnTypeGuesser
                 };
             case 'bigint':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, (int) '18446744073709551615');
+                    return $generator->numberBetween(0, 18446744073709551615);
                 };
             case 'float':
                 return function () use ($generator) {

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -139,7 +139,7 @@ class EntityPopulator
             }
 
             $index = 0;
-            $formatters[$assocName] = function ($inserted) use ($relatedClass, &$index, $unique, $optional) {
+            $formatters[$assocName] = function ($inserted) use ($relatedClass, &$index, $unique, $optional, $generator) {
                 if (isset($inserted[$relatedClass])) {
                     if ($unique) {
                         $related = null;
@@ -152,7 +152,7 @@ class EntityPopulator
                         return $related;
                     }
 
-                    return $inserted[$relatedClass][mt_rand(0, count($inserted[$relatedClass]) - 1)];
+                    return $generator->randomElement($inserted[$relatedClass]);
                 }
 
                 return null;

--- a/src/Faker/ORM/Mandango/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Mandango/ColumnTypeGuesser.php
@@ -32,7 +32,7 @@ class ColumnTypeGuesser
                 };
             case 'integer':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, (int) '4294967295');
+                    return $generator->numberBetween(0, 4294967295);
                 };
             case 'float':
                 return function () use ($generator) {

--- a/src/Faker/ORM/Mandango/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Mandango/ColumnTypeGuesser.php
@@ -2,14 +2,19 @@
 
 namespace Faker\ORM\Mandango;
 
+use Faker\Generator;
+
 class ColumnTypeGuesser
 {
+    /**
+     * @var Generator
+     */
     protected $generator;
 
     /**
-     * @param \Faker\Generator $generator
+     * @param Generator $generator
      */
-    public function __construct(\Faker\Generator $generator)
+    public function __construct(Generator $generator)
     {
         $this->generator = $generator;
     }
@@ -26,12 +31,12 @@ class ColumnTypeGuesser
                     return $generator->boolean;
                 };
             case 'integer':
-                return function () {
-                    return mt_rand(0, intval('4294967295'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, (int) '4294967295');
                 };
             case 'float':
-                return function () {
-                    return mt_rand(0, intval('4294967295')) / mt_rand(1, intval('4294967295'));
+                return function () use ($generator) {
+                    return $generator->randomFloat();
                 };
             case 'string':
                 return function () use ($generator) {
@@ -39,7 +44,7 @@ class ColumnTypeGuesser
                 };
             case 'date':
                 return function () use ($generator) {
-                    return $generator->datetime;
+                    return $generator->dateTime;
                 };
             default:
                 // no smart way to guess what the user expects here

--- a/src/Faker/ORM/Propel/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel/ColumnTypeGuesser.php
@@ -63,7 +63,7 @@ class ColumnTypeGuesser
                 };
             case PropelColumnTypes::BIGINT:
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, 9223372036854775807);
+                    return $generator->numberBetween(0, PHP_INT_MAX);
                 };
             case PropelColumnTypes::FLOAT:
             case PropelColumnTypes::DOUBLE:

--- a/src/Faker/ORM/Propel/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel/ColumnTypeGuesser.php
@@ -59,11 +59,11 @@ class ColumnTypeGuesser
                 };
             case PropelColumnTypes::INTEGER:
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, (int) '2147483647');
+                    return $generator->numberBetween(0, 2147483647);
                 };
             case PropelColumnTypes::BIGINT:
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, (int) '9223372036854775807');
+                    return $generator->numberBetween(0, 9223372036854775807);
                 };
             case PropelColumnTypes::FLOAT:
             case PropelColumnTypes::DOUBLE:

--- a/src/Faker/ORM/Propel/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel/ColumnTypeGuesser.php
@@ -50,30 +50,27 @@ class ColumnTypeGuesser
                     return $generator->randomNumber($size + 2) / 100;
                 };
             case PropelColumnTypes::TINYINT:
-                return function () {
-                    return mt_rand(0, 127);
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 127);
                 };
             case PropelColumnTypes::SMALLINT:
-                return function () {
-                    return mt_rand(0, 32767);
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 32767);
                 };
             case PropelColumnTypes::INTEGER:
-                return function () {
-                    return mt_rand(0, intval('2147483647'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, (int) '2147483647');
                 };
             case PropelColumnTypes::BIGINT:
-                return function () {
-                    return mt_rand(0, intval('9223372036854775807'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, (int) '9223372036854775807');
                 };
             case PropelColumnTypes::FLOAT:
-                return function () {
-                    return mt_rand(0, intval('2147483647')) / mt_rand(1, intval('2147483647'));
-                };
             case PropelColumnTypes::DOUBLE:
             case PropelColumnTypes::REAL:
-                return function () {
-                    return mt_rand(0, intval('9223372036854775807')) / mt_rand(1, intval('9223372036854775807'));
-                };
+            return function () use ($generator) {
+                return $generator->randomFloat();
+            };
             case PropelColumnTypes::CHAR:
             case PropelColumnTypes::VARCHAR:
             case PropelColumnTypes::BINARY:

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -67,8 +67,8 @@ class EntityPopulator
             }
             if ($columnMap->isForeignKey()) {
                 $relatedClass = $columnMap->getRelation()->getForeignTable()->getClassname();
-                $formatters[$columnMap->getPhpName()] = function ($inserted) use ($relatedClass) {
-                    return isset($inserted[$relatedClass]) ? $inserted[$relatedClass][mt_rand(0, count($inserted[$relatedClass]) - 1)] : null;
+                $formatters[$columnMap->getPhpName()] = function ($inserted) use ($relatedClass, $generator) {
+                    return isset($inserted[$relatedClass]) ? $generator->randomElement($inserted[$relatedClass]) : null;
                 };
                 continue;
             }
@@ -157,9 +157,8 @@ class EntityPopulator
                     };
                     break;
                 case 'sortable':
-                    $modifiers['sortable'] = function ($obj, $inserted) use ($class) {
-                        $maxRank = isset($inserted[$class]) ? count($inserted[$class]) : 0;
-                        $obj->insertAtRank(mt_rand(1, $maxRank + 1));
+                    $modifiers['sortable'] = function ($obj, $inserted) use ($class, $generator) {
+                        $obj->insertAtRank($generator->numberBetween(1, count($inserted[$class] ?? []) + 1));
                     };
                     break;
             }

--- a/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
@@ -63,7 +63,7 @@ class ColumnTypeGuesser
                 };
             case PropelTypes::BIGINT:
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, (int) '9223372036854775807');
+                    return $generator->numberBetween(0, 9223372036854775807);
                 };
             case PropelTypes::FLOAT:
             case PropelTypes::DOUBLE:

--- a/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
@@ -50,29 +50,26 @@ class ColumnTypeGuesser
                     return $generator->randomNumber($size + 2) / 100;
                 };
             case PropelTypes::TINYINT:
-                return function () {
-                    return mt_rand(0, 127);
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 127);
                 };
             case PropelTypes::SMALLINT:
-                return function () {
-                    return mt_rand(0, 32767);
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 32767);
                 };
             case PropelTypes::INTEGER:
-                return function () {
-                    return mt_rand(0, intval('2147483647'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, 2147483647);
                 };
             case PropelTypes::BIGINT:
-                return function () {
-                    return mt_rand(0, intval('9223372036854775807'));
+                return function () use ($generator) {
+                    return $generator->numberBetween(0, (int) '9223372036854775807');
                 };
             case PropelTypes::FLOAT:
-                return function () {
-                    return mt_rand(0, intval('2147483647')) / mt_rand(1, intval('2147483647'));
-                };
             case PropelTypes::DOUBLE:
             case PropelTypes::REAL:
-                return function () {
-                    return mt_rand(0, intval('9223372036854775807')) / mt_rand(1, intval('9223372036854775807'));
+                return function () use ($generator) {
+                    return $generator->randomFloat();
                 };
             case PropelTypes::CHAR:
             case PropelTypes::VARCHAR:

--- a/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
@@ -63,7 +63,7 @@ class ColumnTypeGuesser
                 };
             case PropelTypes::BIGINT:
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, 9223372036854775807);
+                    return $generator->numberBetween(0, PHP_INT_MAX);
                 };
             case PropelTypes::FLOAT:
             case PropelTypes::DOUBLE:

--- a/src/Faker/ORM/Propel2/EntityPopulator.php
+++ b/src/Faker/ORM/Propel2/EntityPopulator.php
@@ -67,9 +67,9 @@ class EntityPopulator
             }
             if ($columnMap->isForeignKey()) {
                 $relatedClass = $columnMap->getRelation()->getForeignTable()->getClassname();
-                $formatters[$columnMap->getPhpName()] = function ($inserted) use ($relatedClass) {
+                $formatters[$columnMap->getPhpName()] = function ($inserted) use ($relatedClass, $generator) {
                     $relatedClass = trim($relatedClass, "\\");
-                    return isset($inserted[$relatedClass]) ? $inserted[$relatedClass][mt_rand(0, count($inserted[$relatedClass]) - 1)] : null;
+                    return isset($inserted[$relatedClass]) ? $generator->randomElement($inserted[$relatedClass]) : null;
                 };
                 continue;
             }
@@ -158,9 +158,8 @@ class EntityPopulator
                     };
                     break;
                 case 'sortable':
-                    $modifiers['sortable'] = function ($obj, $inserted) use ($class) {
-                        $maxRank = isset($inserted[$class]) ? count($inserted[$class]) : 0;
-                        $obj->insertAtRank(mt_rand(1, $maxRank + 1));
+                    $modifiers['sortable'] = function ($obj, $inserted) use ($class, $generator) {
+                        $obj->insertAtRank($generator->numberBetween(1, count($inserted[$class] ?? []) + 1));
                     };
                     break;
             }

--- a/src/Faker/ORM/Spot/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Spot/ColumnTypeGuesser.php
@@ -43,15 +43,15 @@ class ColumnTypeGuesser
                 };
             case 'integer':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, intval('2147483647'));
+                    return $generator->numberBetween(0, 2147483647);
                 };
             case 'bigint':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, intval('18446744073709551615'));
+                    return $generator->numberBetween(0, 18446744073709551615);
                 };
             case 'float':
                 return function () use ($generator) {
-                    return $generator->randomFloat(null, 0, intval('4294967295'));
+                    return $generator->randomFloat(null, 0, 4294967295);
                 };
             case 'string':
                 $size = $field['length'] ?? 255;

--- a/src/Faker/ORM/Spot/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Spot/ColumnTypeGuesser.php
@@ -47,7 +47,7 @@ class ColumnTypeGuesser
                 };
             case 'bigint':
                 return function () use ($generator) {
-                    return $generator->numberBetween(0, 18446744073709551615);
+                    return $generator->numberBetween(0, PHP_INT_MAX);
                 };
             case 'float':
                 return function () use ($generator) {

--- a/src/Faker/ORM/Spot/EntityPopulator.php
+++ b/src/Faker/ORM/Spot/EntityPopulator.php
@@ -140,9 +140,9 @@ class EntityPopulator
 
                 $locator = $this->locator;
 
-                $formatters[$fieldName] = function ($inserted) use ($required, $entityName, $locator) {
+                $formatters[$fieldName] = function ($inserted) use ($required, $entityName, $locator, $generator) {
                     if (!empty($inserted[$entityName])) {
-                        return $inserted[$entityName][mt_rand(0, count($inserted[$entityName]) - 1)]->get('id');
+                        return $generator->randomElement($inserted[$entityName])->get('id');
                     }
 
                     if ($required && $this->useExistingData) {
@@ -154,7 +154,7 @@ class EntityPopulator
                             return null;
                         }
 
-                        return $records[mt_rand(0, count($records) - 1)]['id'];
+                        return $generator->randomElement($records)['id'];
                     }
 
                     return null;

--- a/src/Faker/Provider/Barcode.php
+++ b/src/Faker/Provider/Barcode.php
@@ -91,7 +91,7 @@ class Barcode extends Base
      */
     public function isbn13()
     {
-        $code = '97' . static::numberBetween(8, 9) . static::numerify(str_repeat('#', 9));
+        $code = '97' . self::numberBetween(8, 9) . static::numerify(str_repeat('#', 9));
 
         return $code . Ean::checksum($code);
     }

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -47,7 +47,7 @@ class Color extends Base
      */
     public static function hexColor()
     {
-        return '#' . str_pad(dechex(mt_rand(1, 16777215)), 6, '0', STR_PAD_LEFT);
+        return '#' . str_pad(dechex(static::numberBetween(1, 16777215)), 6, '0', STR_PAD_LEFT);
     }
 
     /**
@@ -55,7 +55,7 @@ class Color extends Base
      */
     public static function safeHexColor()
     {
-        $color = str_pad(dechex(mt_rand(0, 255)), 3, '0', STR_PAD_LEFT);
+        $color = str_pad(dechex(static::numberBetween(0, 255)), 3, '0', STR_PAD_LEFT);
 
         return '#' . $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
     }

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -47,7 +47,7 @@ class Color extends Base
      */
     public static function hexColor()
     {
-        return '#' . str_pad(dechex(static::numberBetween(1, 16777215)), 6, '0', STR_PAD_LEFT);
+        return '#' . str_pad(dechex(self::numberBetween(1, 16777215)), 6, '0', STR_PAD_LEFT);
     }
 
     /**
@@ -55,7 +55,7 @@ class Color extends Base
      */
     public static function safeHexColor()
     {
-        $color = str_pad(dechex(static::numberBetween(0, 255)), 3, '0', STR_PAD_LEFT);
+        $color = str_pad(dechex(self::numberBetween(0, 255)), 3, '0', STR_PAD_LEFT);
 
         return '#' . $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
     }
@@ -122,9 +122,9 @@ class Color extends Base
     {
         return sprintf(
             '%s,%s,%s',
-            static::numberBetween(0, 360),
-            static::numberBetween(0, 100),
-            static::numberBetween(0, 100)
+            self::numberBetween(0, 360),
+            self::numberBetween(0, 100),
+            self::numberBetween(0, 100)
         );
     }
 
@@ -135,9 +135,9 @@ class Color extends Base
     public static function hslColorAsArray()
     {
         return [
-            static::numberBetween(0, 360),
-            static::numberBetween(0, 100),
-            static::numberBetween(0, 100)
+            self::numberBetween(0, 360),
+            self::numberBetween(0, 100),
+            self::numberBetween(0, 100)
         ];
     }
 }

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -35,7 +35,7 @@ class DateTime extends Base
      */
     public static function unixTime($max = 'now')
     {
-        return mt_rand(0, static::getMaxTimestamp($max));
+        return static::numberBetween(0, static::getMaxTimestamp($max));
     }
 
     /**
@@ -70,7 +70,7 @@ class DateTime extends Base
     {
         $min = (PHP_INT_SIZE > 4 ? -62135597361 : -PHP_INT_MAX);
         return static::setTimezone(
-            new \DateTime('@' . mt_rand($min, static::getMaxTimestamp($max))),
+            new \DateTime('@' . static::numberBetween($min, static::getMaxTimestamp($max))),
             $timezone
         );
     }
@@ -134,7 +134,7 @@ class DateTime extends Base
             throw new \InvalidArgumentException('Start date must be anterior to end date.');
         }
 
-        $timestamp = mt_rand($startTimestamp, $endTimestamp);
+        $timestamp = static::numberBetween($startTimestamp, $endTimestamp);
 
         return static::setTimezone(
             new \DateTime('@' . $timestamp),

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -35,7 +35,7 @@ class DateTime extends Base
      */
     public static function unixTime($max = 'now')
     {
-        return static::numberBetween(0, static::getMaxTimestamp($max));
+        return self::numberBetween(0, static::getMaxTimestamp($max));
     }
 
     /**
@@ -70,7 +70,7 @@ class DateTime extends Base
     {
         $min = (PHP_INT_SIZE > 4 ? -62135597361 : -PHP_INT_MAX);
         return static::setTimezone(
-            new \DateTime('@' . static::numberBetween($min, static::getMaxTimestamp($max))),
+            new \DateTime('@' . self::numberBetween($min, static::getMaxTimestamp($max))),
             $timezone
         );
     }
@@ -134,7 +134,7 @@ class DateTime extends Base
             throw new \InvalidArgumentException('Start date must be anterior to end date.');
         }
 
-        $timestamp = static::numberBetween($startTimestamp, $endTimestamp);
+        $timestamp = self::numberBetween($startTimestamp, $endTimestamp);
 
         return static::setTimezone(
             new \DateTime('@' . $timestamp),

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -72,7 +72,7 @@ class HtmlLorem extends Base
             return $root;
         }
 
-        $siblings = static::numberBetween(1, $maxWidth);
+        $siblings = self::numberBetween(1, $maxWidth);
         for ($i = 0; $i < $siblings; $i++) {
             if ($maxDepth == 1) {
                 $this->addRandomLeaf($root);
@@ -80,7 +80,7 @@ class HtmlLorem extends Base
                 $sibling = $root->ownerDocument->createElement("div");
                 $root->appendChild($sibling);
                 $this->addRandomAttribute($sibling);
-                $this->addRandomSubTree($sibling, static::numberBetween(0, $maxDepth), $maxWidth);
+                $this->addRandomSubTree($sibling, self::numberBetween(0, $maxDepth), $maxWidth);
             }
         }
         return $root;
@@ -88,7 +88,7 @@ class HtmlLorem extends Base
 
     private function addRandomLeaf(\DOMElement $node)
     {
-        $rand = static::numberBetween(1, 10);
+        $rand = self::numberBetween(1, 10);
         switch ($rand) {
             case 1:
                 $this->addRandomP($node);
@@ -122,7 +122,7 @@ class HtmlLorem extends Base
 
     private function addRandomAttribute(\DOMElement $node)
     {
-        $rand = static::numberBetween(1, 2);
+        $rand = self::numberBetween(1, 2);
         switch ($rand) {
             case 1:
                 $node->setAttribute("class", $this->generator->word);
@@ -136,19 +136,19 @@ class HtmlLorem extends Base
     private function addRandomP(\DOMElement $element, $maxLength = 10)
     {
         $node = $element->ownerDocument->createElement(static::P_TAG);
-        $node->textContent = $this->generator->sentence(static::numberBetween(1, $maxLength));
+        $node->textContent = $this->generator->sentence(self::numberBetween(1, $maxLength));
         $element->appendChild($node);
     }
 
     private function addRandomText(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(self::numberBetween(1, $maxLength)));
         $element->appendChild($text);
     }
 
     private function addRandomA(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(self::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::A_TAG);
         $node->setAttribute("href", $this->generator->safeEmailDomain);
         $node->appendChild($text);
@@ -157,7 +157,7 @@ class HtmlLorem extends Base
 
     private function addRandomTitle(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(self::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::TITLE_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -165,8 +165,8 @@ class HtmlLorem extends Base
 
     private function addRandomH(\DOMElement $element, $maxLength = 10)
     {
-        $h = static::H_TAG . (string) static::numberBetween(1, 3);
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
+        $h = static::H_TAG . (string) self::numberBetween(1, 3);
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(self::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement($h);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -174,7 +174,7 @@ class HtmlLorem extends Base
 
     private function addRandomB(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(self::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::B_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -182,7 +182,7 @@ class HtmlLorem extends Base
 
     private function addRandomI(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(self::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::I_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -190,7 +190,7 @@ class HtmlLorem extends Base
 
     private function addRandomSpan(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(self::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::SPAN_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -230,8 +230,8 @@ class HtmlLorem extends Base
 
     private function addRandomTable(\DOMElement $element, $maxRows = 10, $maxCols = 6, $maxTitle = 4, $maxLength = 10)
     {
-        $rows = static::numberBetween(1, $maxRows);
-        $cols = static::numberBetween(1, $maxCols);
+        $rows = self::numberBetween(1, $maxRows);
+        $cols = self::numberBetween(1, $maxCols);
 
         $table = $element->ownerDocument->createElement(static::TABLE_TAG);
         $thead = $element->ownerDocument->createElement(static::THEAD_TAG);
@@ -244,7 +244,7 @@ class HtmlLorem extends Base
         $thead->appendChild($tr);
         for ($i = 0; $i < $cols; $i++) {
             $th = $element->ownerDocument->createElement(static::TH_TAG);
-            $th->textContent = $this->generator->sentence(static::numberBetween(1, $maxTitle));
+            $th->textContent = $this->generator->sentence(self::numberBetween(1, $maxTitle));
             $tr->appendChild($th);
         }
         for ($i = 0; $i < $rows; $i++) {
@@ -252,7 +252,7 @@ class HtmlLorem extends Base
             $tbody->appendChild($tr);
             for ($j = 0; $j < $cols; $j++) {
                 $th = $element->ownerDocument->createElement(static::TD_TAG);
-                $th->textContent = $this->generator->sentence(static::numberBetween(1, $maxLength));
+                $th->textContent = $this->generator->sentence(self::numberBetween(1, $maxLength));
                 $tr->appendChild($th);
             }
         }
@@ -261,11 +261,11 @@ class HtmlLorem extends Base
 
     private function addRandomUL(\DOMElement $element, $maxItems = 11, $maxLength = 4)
     {
-        $num = static::numberBetween(1, $maxItems);
+        $num = self::numberBetween(1, $maxItems);
         $ul = $element->ownerDocument->createElement(static::UL_TAG);
         for ($i = 0; $i < $num; $i++) {
             $li = $element->ownerDocument->createElement(static::LI_TAG);
-            $li->textContent = $this->generator->sentence(static::numberBetween(1, $maxLength));
+            $li->textContent = $this->generator->sentence(self::numberBetween(1, $maxLength));
             $ul->appendChild($li);
         }
         $element->appendChild($ul);

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -72,7 +72,7 @@ class HtmlLorem extends Base
             return $root;
         }
 
-        $siblings = mt_rand(1, $maxWidth);
+        $siblings = static::numberBetween(1, $maxWidth);
         for ($i = 0; $i < $siblings; $i++) {
             if ($maxDepth == 1) {
                 $this->addRandomLeaf($root);
@@ -80,7 +80,7 @@ class HtmlLorem extends Base
                 $sibling = $root->ownerDocument->createElement("div");
                 $root->appendChild($sibling);
                 $this->addRandomAttribute($sibling);
-                $this->addRandomSubTree($sibling, mt_rand(0, $maxDepth), $maxWidth);
+                $this->addRandomSubTree($sibling, static::numberBetween(0, $maxDepth), $maxWidth);
             }
         }
         return $root;
@@ -88,7 +88,7 @@ class HtmlLorem extends Base
 
     private function addRandomLeaf(\DOMElement $node)
     {
-        $rand = mt_rand(1, 10);
+        $rand = static::numberBetween(1, 10);
         switch ($rand) {
             case 1:
                 $this->addRandomP($node);
@@ -122,7 +122,7 @@ class HtmlLorem extends Base
 
     private function addRandomAttribute(\DOMElement $node)
     {
-        $rand = mt_rand(1, 2);
+        $rand = static::numberBetween(1, 2);
         switch ($rand) {
             case 1:
                 $node->setAttribute("class", $this->generator->word);
@@ -136,19 +136,19 @@ class HtmlLorem extends Base
     private function addRandomP(\DOMElement $element, $maxLength = 10)
     {
         $node = $element->ownerDocument->createElement(static::P_TAG);
-        $node->textContent = $this->generator->sentence(mt_rand(1, $maxLength));
+        $node->textContent = $this->generator->sentence(static::numberBetween(1, $maxLength));
         $element->appendChild($node);
     }
 
     private function addRandomText(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(mt_rand(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
         $element->appendChild($text);
     }
 
     private function addRandomA(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(mt_rand(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::A_TAG);
         $node->setAttribute("href", $this->generator->safeEmailDomain);
         $node->appendChild($text);
@@ -157,7 +157,7 @@ class HtmlLorem extends Base
 
     private function addRandomTitle(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(mt_rand(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::TITLE_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -165,8 +165,8 @@ class HtmlLorem extends Base
 
     private function addRandomH(\DOMElement $element, $maxLength = 10)
     {
-        $h = static::H_TAG . (string) mt_rand(1, 3);
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(mt_rand(1, $maxLength)));
+        $h = static::H_TAG . (string) static::numberBetween(1, 3);
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement($h);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -174,7 +174,7 @@ class HtmlLorem extends Base
 
     private function addRandomB(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(mt_rand(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::B_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -182,7 +182,7 @@ class HtmlLorem extends Base
 
     private function addRandomI(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(mt_rand(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::I_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -190,7 +190,7 @@ class HtmlLorem extends Base
 
     private function addRandomSpan(\DOMElement $element, $maxLength = 10)
     {
-        $text = $element->ownerDocument->createTextNode($this->generator->sentence(mt_rand(1, $maxLength)));
+        $text = $element->ownerDocument->createTextNode($this->generator->sentence(static::numberBetween(1, $maxLength)));
         $node = $element->ownerDocument->createElement(static::SPAN_TAG);
         $node->appendChild($text);
         $element->appendChild($node);
@@ -230,8 +230,8 @@ class HtmlLorem extends Base
 
     private function addRandomTable(\DOMElement $element, $maxRows = 10, $maxCols = 6, $maxTitle = 4, $maxLength = 10)
     {
-        $rows = mt_rand(1, $maxRows);
-        $cols = mt_rand(1, $maxCols);
+        $rows = static::numberBetween(1, $maxRows);
+        $cols = static::numberBetween(1, $maxCols);
 
         $table = $element->ownerDocument->createElement(static::TABLE_TAG);
         $thead = $element->ownerDocument->createElement(static::THEAD_TAG);
@@ -244,7 +244,7 @@ class HtmlLorem extends Base
         $thead->appendChild($tr);
         for ($i = 0; $i < $cols; $i++) {
             $th = $element->ownerDocument->createElement(static::TH_TAG);
-            $th->textContent = $this->generator->sentence(mt_rand(1, $maxTitle));
+            $th->textContent = $this->generator->sentence(static::numberBetween(1, $maxTitle));
             $tr->appendChild($th);
         }
         for ($i = 0; $i < $rows; $i++) {
@@ -252,7 +252,7 @@ class HtmlLorem extends Base
             $tbody->appendChild($tr);
             for ($j = 0; $j < $cols; $j++) {
                 $th = $element->ownerDocument->createElement(static::TD_TAG);
-                $th->textContent = $this->generator->sentence(mt_rand(1, $maxLength));
+                $th->textContent = $this->generator->sentence(static::numberBetween(1, $maxLength));
                 $tr->appendChild($th);
             }
         }
@@ -261,11 +261,11 @@ class HtmlLorem extends Base
 
     private function addRandomUL(\DOMElement $element, $maxItems = 11, $maxLength = 4)
     {
-        $num = mt_rand(1, $maxItems);
+        $num = static::numberBetween(1, $maxItems);
         $ul = $element->ownerDocument->createElement(static::UL_TAG);
         for ($i = 0; $i < $num; $i++) {
             $li = $element->ownerDocument->createElement(static::LI_TAG);
-            $li->textContent = $this->generator->sentence(mt_rand(1, $maxLength));
+            $li->textContent = $this->generator->sentence(static::numberBetween(1, $maxLength));
             $ul->appendChild($li);
         }
         $element->appendChild($ul);

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -171,7 +171,7 @@ class Internet extends Base
             return '';
         }
         if ($variableNbWords) {
-            $nbWords = (int) ($nbWords * static::numberBetween(60, 140) / 100) + 1;
+            $nbWords = (int) ($nbWords * self::numberBetween(60, 140) / 100) + 1;
         }
         $words = $this->generator->words($nbWords);
 
@@ -183,7 +183,7 @@ class Internet extends Base
      */
     public function ipv4()
     {
-        return long2ip(Miscellaneous::boolean() ? static::numberBetween(-2147483648, -2) : static::numberBetween(16777216, 2147483647));
+        return long2ip(Miscellaneous::boolean() ? self::numberBetween(-2147483648, -2) : self::numberBetween(16777216, 2147483647));
     }
 
     /**
@@ -193,7 +193,7 @@ class Internet extends Base
     {
         $res = [];
         for ($i=0; $i < 8; $i++) {
-            $res []= dechex(static::numberBetween(0, 65535));
+            $res []= dechex(self::numberBetween(0, 65535));
         }
 
         return implode(':', $res);
@@ -206,11 +206,11 @@ class Internet extends Base
     {
         if (Miscellaneous::boolean()) {
             // 10.x.x.x range
-            return long2ip(static::numberBetween(ip2long("10.0.0.0"), ip2long("10.255.255.255")));
+            return long2ip(self::numberBetween(ip2long("10.0.0.0"), ip2long("10.255.255.255")));
         }
 
         // 192.168.x.x range
-        return long2ip(static::numberBetween(ip2long("192.168.0.0"), ip2long("192.168.255.255")));
+        return long2ip(self::numberBetween(ip2long("192.168.0.0"), ip2long("192.168.255.255")));
     }
 
     /**
@@ -221,7 +221,7 @@ class Internet extends Base
         $mac = [];
 
         for ($i=0; $i < 6; $i++) {
-            $mac[] = sprintf('%02X', static::numberBetween(0, 0xff));
+            $mac[] = sprintf('%02X', self::numberBetween(0, 0xff));
         }
 
         return implode(':', $mac);

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -171,7 +171,7 @@ class Internet extends Base
             return '';
         }
         if ($variableNbWords) {
-            $nbWords = (int) ($nbWords * mt_rand(60, 140) / 100) + 1;
+            $nbWords = (int) ($nbWords * static::numberBetween(60, 140) / 100) + 1;
         }
         $words = $this->generator->words($nbWords);
 
@@ -183,7 +183,7 @@ class Internet extends Base
      */
     public function ipv4()
     {
-        return long2ip(mt_rand(0, 1) == 0 ? mt_rand(-2147483648, -2) : mt_rand(16777216, 2147483647));
+        return long2ip(Miscellaneous::boolean() ? static::numberBetween(-2147483648, -2) : static::numberBetween(16777216, 2147483647));
     }
 
     /**
@@ -193,7 +193,7 @@ class Internet extends Base
     {
         $res = [];
         for ($i=0; $i < 8; $i++) {
-            $res []= dechex(mt_rand(0, "65535"));
+            $res []= dechex(static::numberBetween(0, 65535));
         }
 
         return implode(':', $res);
@@ -204,7 +204,7 @@ class Internet extends Base
      */
     public static function localIpv4()
     {
-        if (static::numberBetween(0, 1) === 0) {
+        if (Miscellaneous::boolean()) {
             // 10.x.x.x range
             return long2ip(static::numberBetween(ip2long("10.0.0.0"), ip2long("10.255.255.255")));
         }

--- a/src/Faker/Provider/Lorem.php
+++ b/src/Faker/Provider/Lorem.php
@@ -198,6 +198,6 @@ class Lorem extends Base
 
     protected static function randomizeNbElements($nbElements)
     {
-        return (int) ($nbElements * mt_rand(60, 140) / 100) + 1;
+        return (int) ($nbElements * static::numberBetween(60, 140) / 100) + 1;
     }
 }

--- a/src/Faker/Provider/Lorem.php
+++ b/src/Faker/Provider/Lorem.php
@@ -198,6 +198,6 @@ class Lorem extends Base
 
     protected static function randomizeNbElements($nbElements)
     {
-        return (int) ($nbElements * static::numberBetween(60, 140) / 100) + 1;
+        return (int) ($nbElements * self::numberBetween(60, 140) / 100) + 1;
     }
 }

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -238,7 +238,7 @@ class Miscellaneous extends Base
      */
     public static function boolean($chanceOfGettingTrue = 50)
     {
-        return static::numberBetween(1, 100) <= $chanceOfGettingTrue;
+        return self::numberBetween(1, 100) <= $chanceOfGettingTrue;
     }
 
     /**
@@ -246,7 +246,7 @@ class Miscellaneous extends Base
      */
     public static function md5()
     {
-        return md5(static::numberBetween());
+        return md5(self::numberBetween());
     }
 
     /**
@@ -254,7 +254,7 @@ class Miscellaneous extends Base
      */
     public static function sha1()
     {
-        return sha1(static::numberBetween());
+        return sha1(self::numberBetween());
     }
 
     /**
@@ -262,7 +262,7 @@ class Miscellaneous extends Base
      */
     public static function sha256()
     {
-        return hash('sha256', static::numberBetween());
+        return hash('sha256', self::numberBetween());
     }
 
     /**

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -238,7 +238,7 @@ class Miscellaneous extends Base
      */
     public static function boolean($chanceOfGettingTrue = 50)
     {
-        return mt_rand(1, 100) <= $chanceOfGettingTrue;
+        return static::numberBetween(1, 100) <= $chanceOfGettingTrue;
     }
 
     /**
@@ -246,7 +246,7 @@ class Miscellaneous extends Base
      */
     public static function md5()
     {
-        return md5(mt_rand());
+        return md5(static::numberBetween());
     }
 
     /**
@@ -254,7 +254,7 @@ class Miscellaneous extends Base
      */
     public static function sha1()
     {
-        return sha1(mt_rand());
+        return sha1(static::numberBetween());
     }
 
     /**
@@ -262,7 +262,7 @@ class Miscellaneous extends Base
      */
     public static function sha256()
     {
-        return hash('sha256', mt_rand());
+        return hash('sha256', static::numberBetween());
     }
 
     /**

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -256,7 +256,7 @@ class Payment extends Base
             switch ($class) {
                 default:
                 case 'c':
-                    $result .= mt_rand(0, 100) <= 50 ? static::randomDigit() : strtoupper(static::randomLetter());
+                    $result .= Miscellaneous::boolean() ? static::randomDigit() : strtoupper(static::randomLetter());
                     break;
                 case 'a':
                     $result .= strtoupper(static::randomLetter());

--- a/src/Faker/Provider/UserAgent.php
+++ b/src/Faker/Provider/UserAgent.php
@@ -66,12 +66,12 @@ class UserAgent extends Base
      */
     public static function chrome()
     {
-        $saf = mt_rand(531, 536) . mt_rand(0, 2);
+        $saf = static::numberBetween(531, 536) . static::numberBetween(0, 2);
 
         $platforms = [
-            '(' . static::linuxPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . mt_rand(36, 40) . '.0.' . mt_rand(800, 899) . ".0 Mobile Safari/$saf",
-            '(' . static::windowsPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . mt_rand(36, 40) . '.0.' . mt_rand(800, 899) . ".0 Mobile Safari/$saf",
-            '(' . static::macPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . mt_rand(36, 40) . '.0.' . mt_rand(800, 899) . ".0 Mobile Safari/$saf"
+            '(' . static::linuxPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . static::numberBetween(36, 40) . '.0.' . static::numberBetween(800, 899) . ".0 Mobile Safari/$saf",
+            '(' . static::windowsPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . static::numberBetween(36, 40) . '.0.' . static::numberBetween(800, 899) . ".0 Mobile Safari/$saf",
+            '(' . static::macPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . static::numberBetween(36, 40) . '.0.' . static::numberBetween(800, 899) . ".0 Mobile Safari/$saf"
         ];
 
         return 'Mozilla/5.0 ' . static::randomElement($platforms);
@@ -84,12 +84,12 @@ class UserAgent extends Base
      */
     public static function firefox()
     {
-        $ver = 'Gecko/' . date('Ymd', mt_rand(strtotime('2010-1-1'), time())) . ' Firefox/' . mt_rand(35, 37) . '.0';
+        $ver = 'Gecko/' . date('Ymd', static::numberBetween(strtotime('2010-1-1'), time())) . ' Firefox/' . static::numberBetween(35, 37) . '.0';
 
         $platforms = [
-            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . '; rv:1.9.' . mt_rand(0, 2) . '.20) ' . $ver,
-            '(' . static::linuxPlatformToken() . '; rv:' . mt_rand(5, 7) . '.0) ' . $ver,
-            '(' . static::macPlatformToken() . ' rv:' . mt_rand(2, 6) . '.0) ' . $ver
+            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . '; rv:1.9.' . static::numberBetween(0, 2) . '.20) ' . $ver,
+            '(' . static::linuxPlatformToken() . '; rv:' . static::numberBetween(5, 7) . '.0) ' . $ver,
+            '(' . static::macPlatformToken() . ' rv:' . static::numberBetween(2, 6) . '.0) ' . $ver
         ];
 
         return "Mozilla/5.0 " . static::randomElement($platforms);
@@ -102,11 +102,11 @@ class UserAgent extends Base
      */
     public static function safari()
     {
-        $saf = mt_rand(531, 535) . '.' . mt_rand(1, 50) . '.' . mt_rand(1, 7);
-        if (mt_rand(0, 1) == 0) {
-            $ver = mt_rand(4, 5) . '.' . mt_rand(0, 1);
+        $saf = static::numberBetween(531, 535) . '.' . static::numberBetween(1, 50) . '.' . static::numberBetween(1, 7);
+        if (Miscellaneous::boolean()) {
+            $ver = static::numberBetween(4, 5) . '.' . static::numberBetween(0, 1);
         } else {
-            $ver = mt_rand(4, 5) . '.0.' . mt_rand(1, 5);
+            $ver = static::numberBetween(4, 5) . '.0.' . static::numberBetween(1, 5);
         }
 
         $mobileDevices = [
@@ -116,8 +116,8 @@ class UserAgent extends Base
 
         $platforms = [
             '(Windows; U; ' . static::windowsPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Version/$ver Safari/$saf",
-            '(' . static::macPlatformToken() . ' rv:' . mt_rand(2, 6) . '.0; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/$ver Safari/$saf",
-            '(' . static::randomElement($mobileDevices) . ' ' . mt_rand(7, 8) . '_' . mt_rand(0, 2) . '_' . mt_rand(1, 2) . ' like Mac OS X; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/" . mt_rand(3, 4) . ".0.5 Mobile/8B" . mt_rand(111, 119) . " Safari/6$saf",
+            '(' . static::macPlatformToken() . ' rv:' . static::numberBetween(2, 6) . '.0; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/$ver Safari/$saf",
+            '(' . static::randomElement($mobileDevices) . ' ' . static::numberBetween(7, 8) . '_' . static::numberBetween(0, 2) . '_' . static::numberBetween(1, 2) . ' like Mac OS X; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/" . static::numberBetween(3, 4) . ".0.5 Mobile/8B" . static::numberBetween(111, 119) . " Safari/6$saf",
         ];
 
         return "Mozilla/5.0 " . static::randomElement($platforms);
@@ -131,11 +131,11 @@ class UserAgent extends Base
     public static function opera()
     {
         $platforms = [
-            '(' . static::linuxPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . mt_rand(8, 12) . '.' . mt_rand(160, 355) . ' Version/' . mt_rand(10, 12) . '.00',
-            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . mt_rand(8, 12) . '.' . mt_rand(160, 355) . ' Version/' . mt_rand(10, 12) . '.00'
+            '(' . static::linuxPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . static::numberBetween(8, 12) . '.' . static::numberBetween(160, 355) . ' Version/' . static::numberBetween(10, 12) . '.00',
+            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . static::numberBetween(8, 12) . '.' . static::numberBetween(160, 355) . ' Version/' . static::numberBetween(10, 12) . '.00'
         ];
 
-        return "Opera/" . mt_rand(8, 9) . '.' . mt_rand(10, 99) . ' ' . static::randomElement($platforms);
+        return "Opera/" . static::numberBetween(8, 9) . '.' . static::numberBetween(10, 99) . ' ' . static::randomElement($platforms);
     }
 
     /**
@@ -145,7 +145,7 @@ class UserAgent extends Base
      */
     public static function internetExplorer()
     {
-        return 'Mozilla/5.0 (compatible; MSIE ' . mt_rand(5, 11) . '.0; ' . static::windowsPlatformToken() . '; Trident/' . mt_rand(3, 5) . '.' . mt_rand(0, 1) . ')';
+        return 'Mozilla/5.0 (compatible; MSIE ' . static::numberBetween(5, 11) . '.0; ' . static::windowsPlatformToken() . '; Trident/' . static::numberBetween(3, 5) . '.' . static::numberBetween(0, 1) . ')';
     }
 
     public static function windowsPlatformToken()
@@ -155,7 +155,7 @@ class UserAgent extends Base
 
     public static function macPlatformToken()
     {
-        return 'Macintosh; ' . static::randomElement(static::$macProcessor) . ' Mac OS X 10_' . mt_rand(5, 8) . '_' . mt_rand(0, 9);
+        return 'Macintosh; ' . static::randomElement(static::$macProcessor) . ' Mac OS X 10_' . static::numberBetween(5, 8) . '_' . static::numberBetween(0, 9);
     }
 
     public static function linuxPlatformToken()

--- a/src/Faker/Provider/UserAgent.php
+++ b/src/Faker/Provider/UserAgent.php
@@ -66,12 +66,12 @@ class UserAgent extends Base
      */
     public static function chrome()
     {
-        $saf = static::numberBetween(531, 536) . static::numberBetween(0, 2);
+        $saf = self::numberBetween(531, 536) . self::numberBetween(0, 2);
 
         $platforms = [
-            '(' . static::linuxPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . static::numberBetween(36, 40) . '.0.' . static::numberBetween(800, 899) . ".0 Mobile Safari/$saf",
-            '(' . static::windowsPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . static::numberBetween(36, 40) . '.0.' . static::numberBetween(800, 899) . ".0 Mobile Safari/$saf",
-            '(' . static::macPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . static::numberBetween(36, 40) . '.0.' . static::numberBetween(800, 899) . ".0 Mobile Safari/$saf"
+            '(' . static::linuxPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . self::numberBetween(36, 40) . '.0.' . self::numberBetween(800, 899) . ".0 Mobile Safari/$saf",
+            '(' . static::windowsPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . self::numberBetween(36, 40) . '.0.' . self::numberBetween(800, 899) . ".0 Mobile Safari/$saf",
+            '(' . static::macPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Chrome/" . self::numberBetween(36, 40) . '.0.' . self::numberBetween(800, 899) . ".0 Mobile Safari/$saf"
         ];
 
         return 'Mozilla/5.0 ' . static::randomElement($platforms);
@@ -84,12 +84,12 @@ class UserAgent extends Base
      */
     public static function firefox()
     {
-        $ver = 'Gecko/' . date('Ymd', static::numberBetween(strtotime('2010-1-1'), time())) . ' Firefox/' . static::numberBetween(35, 37) . '.0';
+        $ver = 'Gecko/' . date('Ymd', self::numberBetween(strtotime('2010-1-1'), time())) . ' Firefox/' . self::numberBetween(35, 37) . '.0';
 
         $platforms = [
-            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . '; rv:1.9.' . static::numberBetween(0, 2) . '.20) ' . $ver,
-            '(' . static::linuxPlatformToken() . '; rv:' . static::numberBetween(5, 7) . '.0) ' . $ver,
-            '(' . static::macPlatformToken() . ' rv:' . static::numberBetween(2, 6) . '.0) ' . $ver
+            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . '; rv:1.9.' . self::numberBetween(0, 2) . '.20) ' . $ver,
+            '(' . static::linuxPlatformToken() . '; rv:' . self::numberBetween(5, 7) . '.0) ' . $ver,
+            '(' . static::macPlatformToken() . ' rv:' . self::numberBetween(2, 6) . '.0) ' . $ver
         ];
 
         return "Mozilla/5.0 " . static::randomElement($platforms);
@@ -102,11 +102,11 @@ class UserAgent extends Base
      */
     public static function safari()
     {
-        $saf = static::numberBetween(531, 535) . '.' . static::numberBetween(1, 50) . '.' . static::numberBetween(1, 7);
+        $saf = self::numberBetween(531, 535) . '.' . self::numberBetween(1, 50) . '.' . self::numberBetween(1, 7);
         if (Miscellaneous::boolean()) {
-            $ver = static::numberBetween(4, 5) . '.' . static::numberBetween(0, 1);
+            $ver = self::numberBetween(4, 5) . '.' . self::numberBetween(0, 1);
         } else {
-            $ver = static::numberBetween(4, 5) . '.0.' . static::numberBetween(1, 5);
+            $ver = self::numberBetween(4, 5) . '.0.' . self::numberBetween(1, 5);
         }
 
         $mobileDevices = [
@@ -116,8 +116,8 @@ class UserAgent extends Base
 
         $platforms = [
             '(Windows; U; ' . static::windowsPlatformToken() . ") AppleWebKit/$saf (KHTML, like Gecko) Version/$ver Safari/$saf",
-            '(' . static::macPlatformToken() . ' rv:' . static::numberBetween(2, 6) . '.0; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/$ver Safari/$saf",
-            '(' . static::randomElement($mobileDevices) . ' ' . static::numberBetween(7, 8) . '_' . static::numberBetween(0, 2) . '_' . static::numberBetween(1, 2) . ' like Mac OS X; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/" . static::numberBetween(3, 4) . ".0.5 Mobile/8B" . static::numberBetween(111, 119) . " Safari/6$saf",
+            '(' . static::macPlatformToken() . ' rv:' . self::numberBetween(2, 6) . '.0; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/$ver Safari/$saf",
+            '(' . static::randomElement($mobileDevices) . ' ' . self::numberBetween(7, 8) . '_' . self::numberBetween(0, 2) . '_' . self::numberBetween(1, 2) . ' like Mac OS X; ' . static::randomElement(static::$lang) . ") AppleWebKit/$saf (KHTML, like Gecko) Version/" . self::numberBetween(3, 4) . ".0.5 Mobile/8B" . self::numberBetween(111, 119) . " Safari/6$saf",
         ];
 
         return "Mozilla/5.0 " . static::randomElement($platforms);
@@ -131,11 +131,11 @@ class UserAgent extends Base
     public static function opera()
     {
         $platforms = [
-            '(' . static::linuxPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . static::numberBetween(8, 12) . '.' . static::numberBetween(160, 355) . ' Version/' . static::numberBetween(10, 12) . '.00',
-            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . static::numberBetween(8, 12) . '.' . static::numberBetween(160, 355) . ' Version/' . static::numberBetween(10, 12) . '.00'
+            '(' . static::linuxPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . self::numberBetween(8, 12) . '.' . self::numberBetween(160, 355) . ' Version/' . self::numberBetween(10, 12) . '.00',
+            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . ') Presto/2.' . self::numberBetween(8, 12) . '.' . self::numberBetween(160, 355) . ' Version/' . self::numberBetween(10, 12) . '.00'
         ];
 
-        return "Opera/" . static::numberBetween(8, 9) . '.' . static::numberBetween(10, 99) . ' ' . static::randomElement($platforms);
+        return "Opera/" . self::numberBetween(8, 9) . '.' . self::numberBetween(10, 99) . ' ' . static::randomElement($platforms);
     }
 
     /**
@@ -145,7 +145,7 @@ class UserAgent extends Base
      */
     public static function internetExplorer()
     {
-        return 'Mozilla/5.0 (compatible; MSIE ' . static::numberBetween(5, 11) . '.0; ' . static::windowsPlatformToken() . '; Trident/' . static::numberBetween(3, 5) . '.' . static::numberBetween(0, 1) . ')';
+        return 'Mozilla/5.0 (compatible; MSIE ' . self::numberBetween(5, 11) . '.0; ' . static::windowsPlatformToken() . '; Trident/' . self::numberBetween(3, 5) . '.' . self::numberBetween(0, 1) . ')';
     }
 
     public static function windowsPlatformToken()
@@ -155,7 +155,7 @@ class UserAgent extends Base
 
     public static function macPlatformToken()
     {
-        return 'Macintosh; ' . static::randomElement(static::$macProcessor) . ' Mac OS X 10_' . static::numberBetween(5, 8) . '_' . static::numberBetween(0, 9);
+        return 'Macintosh; ' . static::randomElement(static::$macProcessor) . ' Mac OS X 10_' . self::numberBetween(5, 8) . '_' . self::numberBetween(0, 9);
     }
 
     public static function linuxPlatformToken()

--- a/src/Faker/Provider/Uuid.php
+++ b/src/Faker/Provider/Uuid.php
@@ -12,7 +12,7 @@ class Uuid extends Base
     {
         // fix for compatibility with 32bit architecture; each mt_rand call is restricted to 32bit
         // two such calls will cause 64bits of randomness regardless of architecture
-        $seed = mt_rand(0, 2147483647) . '#' . mt_rand(0, 2147483647);
+        $seed = static::numberBetween(0, 2147483647) . '#' . static::numberBetween(0, 2147483647);
 
         // Hash the seed and convert to a byte array
         $val = md5($seed, true);

--- a/src/Faker/Provider/Uuid.php
+++ b/src/Faker/Provider/Uuid.php
@@ -12,7 +12,7 @@ class Uuid extends Base
     {
         // fix for compatibility with 32bit architecture; each mt_rand call is restricted to 32bit
         // two such calls will cause 64bits of randomness regardless of architecture
-        $seed = static::numberBetween(0, 2147483647) . '#' . static::numberBetween(0, 2147483647);
+        $seed = self::numberBetween(0, 2147483647) . '#' . self::numberBetween(0, 2147483647);
 
         // Hash the seed and convert to a byte array
         $val = md5($seed, true);

--- a/src/Faker/Provider/bn_BD/Address.php
+++ b/src/Faker/Provider/bn_BD/Address.php
@@ -300,7 +300,7 @@ class Address extends \Faker\Provider\Address
 
     public static function streetNumber()
     {
-        return Utils::getBanglaNumber(static::numberBetween(1, 100));
+        return Utils::getBanglaNumber(self::numberBetween(1, 100));
     }
 
     public static function banglaStreetName()

--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -440,12 +440,12 @@ class Person extends \Faker\Provider\Person
 
         $startTimestamp = strtotime("-${maxAge} year");
         $endTimestamp = strtotime("-${minAge} year");
-        $randTimestamp = static::numberBetween($startTimestamp, $endTimestamp);
+        $randTimestamp = self::numberBetween($startTimestamp, $endTimestamp);
 
         $year = intval(date('Y', $randTimestamp));
         $month = intval(date('n', $randTimestamp));
         $day = intval(date('j', $randTimestamp));
-        $suffix = static::numberBetween(0, 999);
+        $suffix = self::numberBetween(0, 999);
 
         // women has +50 to month
         if ($gender == static::GENDER_FEMALE) {

--- a/src/Faker/Provider/da_DK/Person.php
+++ b/src/Faker/Provider/da_DK/Person.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\da_DK;
 
+use Faker\Provider\DateTime;
+
 /**
  * @link http://www.danskernesnavne.navneforskning.ku.dk/Personnavne.asp
  *
@@ -188,7 +190,7 @@ class Person extends \Faker\Provider\Person
      */
     public static function cpr()
     {
-        $birthdate = new \DateTime('@' . mt_rand(0, time()));
+        $birthdate = DateTime::dateTimeThisCentury();
 
         return sprintf('%s-%s', $birthdate->format('dmy'), static::numerify('%###'));
     }

--- a/src/Faker/Provider/en_US/Company.php
+++ b/src/Faker/Provider/en_US/Company.php
@@ -109,7 +109,7 @@ class Company extends \Faker\Provider\Company
     public static function ein()
     {
         $prefix = static::randomElement(static::$einPrefixes);
-        $suffix = static::numberBetween(0, 9999999);
+        $suffix = self::numberBetween(0, 9999999);
 
         return sprintf("%02d-%07d", $prefix, $suffix);
     }

--- a/src/Faker/Provider/en_US/Person.php
+++ b/src/Faker/Provider/en_US/Person.php
@@ -124,9 +124,9 @@ class Person extends \Faker\Provider\Person
      */
     public static function ssn()
     {
-        $area = Miscellaneous::boolean() ? static::numberBetween(1, 665) : static::numberBetween(667, 899);
-        $group = static::numberBetween(1, 99);
-        $serial = static::numberBetween(1, 9999);
+        $area = Miscellaneous::boolean() ? self::numberBetween(1, 665) : self::numberBetween(667, 899);
+        $group = self::numberBetween(1, 99);
+        $serial = self::numberBetween(1, 9999);
 
         return sprintf("%03d-%02d-%04d", $area, $group, $serial);
     }

--- a/src/Faker/Provider/en_US/Person.php
+++ b/src/Faker/Provider/en_US/Person.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\en_US;
 
+use Faker\Provider\Miscellaneous;
+
 class Person extends \Faker\Provider\Person
 {
     protected static $maleNameFormats = [
@@ -122,7 +124,7 @@ class Person extends \Faker\Provider\Person
      */
     public static function ssn()
     {
-        $area = mt_rand(0, 1) ? static::numberBetween(1, 665) : static::numberBetween(667, 899);
+        $area = Miscellaneous::boolean() ? static::numberBetween(1, 665) : static::numberBetween(667, 899);
         $group = static::numberBetween(1, 99);
         $serial = static::numberBetween(1, 9999);
 

--- a/src/Faker/Provider/id_ID/Address.php
+++ b/src/Faker/Provider/id_ID/Address.php
@@ -312,6 +312,6 @@ class Address extends \Faker\Provider\Address
 
     public static function buildingNumber()
     {
-        return static::numberBetween(1, 999);
+        return self::numberBetween(1, 999);
     }
 }

--- a/src/Faker/Provider/is_IS/Person.php
+++ b/src/Faker/Provider/is_IS/Person.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\is_IS;
 
+use Faker\Provider\DateTime;
+
 /**
  * @author Birkir Gudjonsson <birkir.gudjonsson@gmail.com>
  */
@@ -101,7 +103,7 @@ class Person extends \Faker\Provider\Person
     public static function ssn()
     {
         // random birth date
-        $birthdate = new \DateTime('@' . mt_rand(0, time()));
+        $birthdate = DateTime::dateTimeThisCentury();
 
         // last four buffer
         $lastFour = null;

--- a/src/Faker/Provider/it_IT/Company.php
+++ b/src/Faker/Provider/it_IT/Company.php
@@ -71,7 +71,7 @@ class Company extends \Faker\Provider\Company
      */
     public static function vatId()
     {
-        $code = sprintf('%s%03d', static::numerify('#######'), static::numberBetween(1, 121));
+        $code = sprintf('%s%03d', static::numerify('#######'), self::numberBetween(1, 121));
 
         return sprintf('IT%s%d', $code, Luhn::computeCheckDigit($code));
     }

--- a/src/Faker/Provider/ja_JP/Address.php
+++ b/src/Faker/Provider/ja_JP/Address.php
@@ -72,7 +72,7 @@ class Address extends \Faker\Provider\Address
      */
     public static function postcode1()
     {
-        return static::numberBetween(100, 999);
+        return self::numberBetween(100, 999);
     }
 
     /**
@@ -80,7 +80,7 @@ class Address extends \Faker\Provider\Address
      */
     public static function postcode2()
     {
-        return static::numberBetween(1000, 9999);
+        return self::numberBetween(1000, 9999);
     }
 
     /**
@@ -120,12 +120,12 @@ class Address extends \Faker\Provider\Address
      */
     public static function areaNumber()
     {
-        return static::numberBetween(1, 10);
+        return self::numberBetween(1, 10);
     }
 
     public static function buildingNumber()
     {
-        return static::numberBetween(101, 110);
+        return self::numberBetween(101, 110);
     }
 
     public function secondaryAddress()

--- a/src/Faker/Provider/kk_KZ/Company.php
+++ b/src/Faker/Provider/kk_KZ/Company.php
@@ -63,8 +63,8 @@ class Company extends \Faker\Provider\Company
         }
 
         $dateAsString              = $registrationDate->format('ym');
-        $legalEntityType           = (string) static::numberBetween(4, 6);
-        $legalEntityAdditionalType = (string) static::numberBetween(0, 3);
+        $legalEntityType           = (string) self::numberBetween(4, 6);
+        $legalEntityAdditionalType = (string) self::numberBetween(0, 3);
         $randomDigits              = (string) static::numerify('######');
 
         return $dateAsString . $legalEntityType . $legalEntityAdditionalType . $randomDigits;

--- a/src/Faker/Provider/kk_KZ/Person.php
+++ b/src/Faker/Provider/kk_KZ/Person.php
@@ -211,7 +211,7 @@ class Person extends \Faker\Provider\Person
         }
 
         do {
-            $population = mt_rand(1000, 2000);
+            $population = static::numberBetween(1000, 2000);
             $century = self::getCenturyByYear((int) $birthDate->format('Y'));
 
             $iin = $birthDate->format('ymd');

--- a/src/Faker/Provider/kk_KZ/Person.php
+++ b/src/Faker/Provider/kk_KZ/Person.php
@@ -211,7 +211,7 @@ class Person extends \Faker\Provider\Person
         }
 
         do {
-            $population = static::numberBetween(1000, 2000);
+            $population = self::numberBetween(1000, 2000);
             $century = self::getCenturyByYear((int) $birthDate->format('Y'));
 
             $iin = $birthDate->format('ymd');

--- a/src/Faker/Provider/ms_MY/Address.php
+++ b/src/Faker/Provider/ms_MY/Address.php
@@ -605,55 +605,55 @@ class Address extends \Faker\Provider\Address
     {
         $format = [
             'perlis' => [ // (01000 - 02800)
-                '0' . static::numberBetween(1000, 2800)
+                '0' . self::numberBetween(1000, 2800)
             ],
             'kedah' => [ // (05000 - 09810)
-                '0' . static::numberBetween(5000, 9810)
+                '0' . self::numberBetween(5000, 9810)
             ],
             'penang' => [ // (10000 - 14400)
-                static::numberBetween(10000, 14400)
+                self::numberBetween(10000, 14400)
             ],
             'kelantan' => [ // (15000 - 18500)
-                static::numberBetween(15000, 18500)
+                self::numberBetween(15000, 18500)
             ],
             'terengganu' => [ // (20000 - 24300)
-                static::numberBetween(20000, 24300)
+                self::numberBetween(20000, 24300)
             ],
             'pahang' => [ // (25000 - 28800 | 39000 - 39200 | 49000, 69000)
-                static::numberBetween(25000, 28800),
-                static::numberBetween(39000, 39200),
-                static::numberBetween(49000, 69000)
+                self::numberBetween(25000, 28800),
+                self::numberBetween(39000, 39200),
+                self::numberBetween(49000, 69000)
             ],
             'perak' => [ // (30000 - 36810)
-                static::numberBetween(30000, 36810)
+                self::numberBetween(30000, 36810)
             ],
             'selangor' => [ // (40000 - 48300 | 63000 - 68100)
-                static::numberBetween(40000, 48300),
-                static::numberBetween(63000, 68100)
+                self::numberBetween(40000, 48300),
+                self::numberBetween(63000, 68100)
             ],
             'kl' => [ // (50000 - 60000)
-                static::numberBetween(50000, 60000),
+                self::numberBetween(50000, 60000),
             ],
             'putrajaya' => [ // (62000 - 62988)
-                static::numberBetween(62000, 62988)
+                self::numberBetween(62000, 62988)
             ],
             'nsembilan' => [ // (70000 - 73509)
-                static::numberBetween(70000, 73509)
+                self::numberBetween(70000, 73509)
             ],
             'melaka' => [ // (75000 - 78309)
-                static::numberBetween(75000, 78309)
+                self::numberBetween(75000, 78309)
             ],
             'johor' => [ // (79000 - 86900)
-                static::numberBetween(79000, 86900)
+                self::numberBetween(79000, 86900)
             ],
             'labuan' => [ // (87000 - 87033)
-                static::numberBetween(87000, 87033)
+                self::numberBetween(87000, 87033)
             ],
             'sabah' => [ // (88000 - 91309)
-                static::numberBetween(88000, 91309)
+                self::numberBetween(88000, 91309)
             ],
             'sarawak' => [ // (93000 - 98859)
-                static::numberBetween(93000, 98859)
+                self::numberBetween(93000, 98859)
             ]
         ];
 

--- a/src/Faker/Provider/ms_MY/Address.php
+++ b/src/Faker/Provider/ms_MY/Address.php
@@ -605,55 +605,55 @@ class Address extends \Faker\Provider\Address
     {
         $format = [
             'perlis' => [ // (01000 - 02800)
-                '0' . mt_rand(1000, 2800)
+                '0' . static::numberBetween(1000, 2800)
             ],
             'kedah' => [ // (05000 - 09810)
-                '0' . mt_rand(5000, 9810)
+                '0' . static::numberBetween(5000, 9810)
             ],
             'penang' => [ // (10000 - 14400)
-                mt_rand(10000, 14400)
+                static::numberBetween(10000, 14400)
             ],
             'kelantan' => [ // (15000 - 18500)
-                mt_rand(15000, 18500)
+                static::numberBetween(15000, 18500)
             ],
             'terengganu' => [ // (20000 - 24300)
-                mt_rand(20000, 24300)
+                static::numberBetween(20000, 24300)
             ],
             'pahang' => [ // (25000 - 28800 | 39000 - 39200 | 49000, 69000)
-                mt_rand(25000, 28800),
-                mt_rand(39000, 39200),
-                mt_rand(49000, 69000)
+                static::numberBetween(25000, 28800),
+                static::numberBetween(39000, 39200),
+                static::numberBetween(49000, 69000)
             ],
             'perak' => [ // (30000 - 36810)
-                mt_rand(30000, 36810)
+                static::numberBetween(30000, 36810)
             ],
             'selangor' => [ // (40000 - 48300 | 63000 - 68100)
-                mt_rand(40000, 48300),
-                mt_rand(63000, 68100)
+                static::numberBetween(40000, 48300),
+                static::numberBetween(63000, 68100)
             ],
             'kl' => [ // (50000 - 60000)
-                mt_rand(50000, 60000),
+                static::numberBetween(50000, 60000),
             ],
             'putrajaya' => [ // (62000 - 62988)
-                mt_rand(62000, 62988)
+                static::numberBetween(62000, 62988)
             ],
             'nsembilan' => [ // (70000 - 73509)
-                mt_rand(70000, 73509)
+                static::numberBetween(70000, 73509)
             ],
             'melaka' => [ // (75000 - 78309)
-                mt_rand(75000, 78309)
+                static::numberBetween(75000, 78309)
             ],
             'johor' => [ // (79000 - 86900)
-                mt_rand(79000, 86900)
+                static::numberBetween(79000, 86900)
             ],
             'labuan' => [ // (87000 - 87033)
-                mt_rand(87000, 87033)
+                static::numberBetween(87000, 87033)
             ],
             'sabah' => [ // (88000 - 91309)
-                mt_rand(88000, 91309)
+                static::numberBetween(88000, 91309)
             ],
             'sarawak' => [ // (93000 - 98859)
-                mt_rand(93000, 98859)
+                static::numberBetween(93000, 98859)
             ]
         ];
 

--- a/src/Faker/Provider/ms_MY/Miscellaneous.php
+++ b/src/Faker/Provider/ms_MY/Miscellaneous.php
@@ -164,6 +164,6 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      */
     public static function numberSequence()
     {
-        return static::numberBetween(1, 9999);
+        return self::numberBetween(1, 9999);
     }
 }

--- a/src/Faker/Provider/ms_MY/Miscellaneous.php
+++ b/src/Faker/Provider/ms_MY/Miscellaneous.php
@@ -164,6 +164,6 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      */
     public static function numberSequence()
     {
-        return mt_rand(1, 9999);
+        return static::numberBetween(1, 9999);
     }
 }

--- a/src/Faker/Provider/ms_MY/Person.php
+++ b/src/Faker/Provider/ms_MY/Person.php
@@ -775,7 +775,7 @@ class Person extends \Faker\Provider\Person
     public static function myKadNumber($gender = null, $hyphen = false)
     {
         // year of birth
-        $yy = mt_rand(0, 99);
+        $yy = static::numberBetween(0, 99);
 
         // month of birth
         $mm = DateTime::month();
@@ -784,14 +784,14 @@ class Person extends \Faker\Provider\Person
         $dd = DateTime::dayOfMonth();
 
         // place of birth (1-59 except 17-20)
-        while (in_array($pb = mt_rand(1, 59), [17, 18, 19, 20])) {
+        while (in_array($pb = static::numberBetween(1, 59), [17, 18, 19, 20])) {
         }
 
         // random number
-        $nnn = mt_rand(0, 999);
+        $nnn = static::numberBetween(0, 999);
 
         // gender digit. Odd = MALE, Even = FEMALE
-        $g = mt_rand(0, 9);
+        $g = static::numberBetween(0, 9);
         //Credit: https://gist.github.com/mauris/3629548
         if ($gender === static::GENDER_MALE) {
             $g = $g | 1;

--- a/src/Faker/Provider/ms_MY/Person.php
+++ b/src/Faker/Provider/ms_MY/Person.php
@@ -775,7 +775,7 @@ class Person extends \Faker\Provider\Person
     public static function myKadNumber($gender = null, $hyphen = false)
     {
         // year of birth
-        $yy = static::numberBetween(0, 99);
+        $yy = self::numberBetween(0, 99);
 
         // month of birth
         $mm = DateTime::month();
@@ -784,14 +784,14 @@ class Person extends \Faker\Provider\Person
         $dd = DateTime::dayOfMonth();
 
         // place of birth (1-59 except 17-20)
-        while (in_array($pb = static::numberBetween(1, 59), [17, 18, 19, 20])) {
+        while (in_array($pb = self::numberBetween(1, 59), [17, 18, 19, 20])) {
         }
 
         // random number
-        $nnn = static::numberBetween(0, 999);
+        $nnn = self::numberBetween(0, 999);
 
         // gender digit. Odd = MALE, Even = FEMALE
-        $g = static::numberBetween(0, 9);
+        $g = self::numberBetween(0, 9);
         //Credit: https://gist.github.com/mauris/3629548
         if ($gender === static::GENDER_MALE) {
             $g = $g | 1;

--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -71,7 +71,7 @@ class Company extends \Faker\Provider\Company
      */
     public function company()
     {
-        $determinator = static::numberBetween(0, 2);
+        $determinator = self::numberBetween(0, 2);
         switch ($determinator) {
             case 0:
                 $companyName = static::randomElement(static::$product) . ' ' . static::randomElement(static::$type);

--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\nl_NL;
 
+use Faker\Provider\Miscellaneous;
+
 class Company extends \Faker\Provider\Company
 {
     /**
@@ -82,7 +84,7 @@ class Company extends \Faker\Provider\Company
                 break;
         }
 
-        if (0 !== static::numberBetween(0, 1)) {
+        if (Miscellaneous::boolean()) {
             return $companyName . ' ' . static::randomElement(static::$companySuffix);
         }
 

--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -328,7 +328,7 @@ class Person extends \Faker\Provider\Person
         while (count($nr) < 8) {
             $nr[] = static::randomDigit();
         }
-        $nr[] = mt_rand(0, 6);
+        $nr[] = static::numberBetween(0, 6);
         if ($nr[7] == 0 && $nr[8] == 0) {
             $nr[7] = 0;
         }

--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -264,7 +264,7 @@ class Person extends \Faker\Provider\Person
      */
     public function lastName()
     {
-        $determinator = static::numberBetween(0, 25);
+        $determinator = self::numberBetween(0, 25);
         if ($determinator === 0) {
             $lastName = static::randomElement(static::$longLastNames);
         } elseif ($determinator <= 10) {
@@ -328,7 +328,7 @@ class Person extends \Faker\Provider\Person
         while (count($nr) < 8) {
             $nr[] = static::randomDigit();
         }
-        $nr[] = static::numberBetween(0, 6);
+        $nr[] = self::numberBetween(0, 6);
         if ($nr[7] == 0 && $nr[8] == 0) {
             $nr[7] = 0;
         }

--- a/src/Faker/Provider/pl_PL/Company.php
+++ b/src/Faker/Provider/pl_PL/Company.php
@@ -35,7 +35,7 @@ class Company extends \Faker\Provider\Company
     public static function regon()
     {
         $weights = [8, 9, 2, 3, 4, 5, 6, 7];
-        $regionNumber = static::numberBetween(0, 49) * 2 + 1;
+        $regionNumber = self::numberBetween(0, 49) * 2 + 1;
         $result = [(int) ($regionNumber / 10), $regionNumber % 10];
         for ($i = 2, $size = count($weights); $i < $size; $i++) {
             $result[$i] = static::randomDigit();

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -150,7 +150,7 @@ class Person extends \Faker\Provider\Person
     protected function getDateOfBirth($dateOfBirth)
     {
         if (empty($dateOfBirth)) {
-            $dateOfBirthParts = [static::numberBetween(1800, 2099)];
+            $dateOfBirthParts = [self::numberBetween(1800, 2099)];
         } else {
             $dateOfBirthParts = explode('-', $dateOfBirth);
         }

--- a/src/Faker/Provider/ru_RU/Company.php
+++ b/src/Faker/Provider/ru_RU/Company.php
@@ -100,7 +100,7 @@ class Company extends \Faker\Provider\Company
     {
         if ($area_code === "" || intval($area_code) == 0) {
             //Simple generation code for areas in Russian without check for valid
-            $area_code = static::numberBetween(1, 91);
+            $area_code = self::numberBetween(1, 91);
         } else {
             $area_code = intval($area_code);
         }

--- a/src/Faker/Provider/th_TH/Person.php
+++ b/src/Faker/Provider/th_TH/Person.php
@@ -78,9 +78,9 @@ class Person extends \Faker\Provider\Person
      */
     public static function ssn()
     {
-        $area = Miscellaneous::boolean() ? static::numberBetween(1, 665) : static::numberBetween(667, 899);
-        $group = static::numberBetween(1, 99);
-        $serial = static::numberBetween(1, 9999);
+        $area = Miscellaneous::boolean() ? self::numberBetween(1, 665) : self::numberBetween(667, 899);
+        $group = self::numberBetween(1, 99);
+        $serial = self::numberBetween(1, 9999);
 
         return sprintf("%03d-%02d-%04d", $area, $group, $serial);
     }

--- a/src/Faker/Provider/th_TH/Person.php
+++ b/src/Faker/Provider/th_TH/Person.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\th_TH;
 
+use Faker\Provider\Miscellaneous;
+
 class Person extends \Faker\Provider\Person
 {
     protected static $maleNameFormats = [
@@ -76,7 +78,7 @@ class Person extends \Faker\Provider\Person
      */
     public static function ssn()
     {
-        $area = mt_rand(0, 1) ? static::numberBetween(1, 665) : static::numberBetween(667, 899);
+        $area = Miscellaneous::boolean() ? static::numberBetween(1, 665) : static::numberBetween(667, 899);
         $group = static::numberBetween(1, 99);
         $serial = static::numberBetween(1, 9999);
 

--- a/src/Faker/Provider/uk_UA/Address.php
+++ b/src/Faker/Provider/uk_UA/Address.php
@@ -347,7 +347,7 @@ class Address extends \Faker\Provider\Address
      */
     public function cityAndRegion()
     {
-        $regionAndCityNumber = mt_rand(0, count(static::$region) - 1);
+        $regionAndCityNumber = static::numberBetween(0, count(static::$region) - 1);
         $region = static::$region[$regionAndCityNumber];
         $city = static::$city[$regionAndCityNumber];
         $format = "$region {{regionSuffix}}, {{cityPrefix}} $city";

--- a/src/Faker/Provider/uk_UA/Address.php
+++ b/src/Faker/Provider/uk_UA/Address.php
@@ -347,7 +347,7 @@ class Address extends \Faker\Provider\Address
      */
     public function cityAndRegion()
     {
-        $regionAndCityNumber = static::numberBetween(0, count(static::$region) - 1);
+        $regionAndCityNumber = self::numberBetween(0, count(static::$region) - 1);
         $region = static::$region[$regionAndCityNumber];
         $city = static::$city[$regionAndCityNumber];
         $format = "$region {{regionSuffix}}, {{cityPrefix}} $city";

--- a/src/Faker/Provider/zh_CN/Address.php
+++ b/src/Faker/Provider/zh_CN/Address.php
@@ -140,9 +140,9 @@ class Address extends \Faker\Provider\Address
 
     public static function postcode()
     {
-        $prefix = str_pad(mt_rand(1, 85), 2, 0, STR_PAD_LEFT);
+        $prefix = str_pad(static::numberBetween(1, 85), 2, 0, STR_PAD_LEFT);
         $suffix = '00';
 
-        return $prefix . mt_rand(10, 88) . $suffix;
+        return $prefix . static::numberBetween(10, 88) . $suffix;
     }
 }

--- a/src/Faker/Provider/zh_CN/Address.php
+++ b/src/Faker/Provider/zh_CN/Address.php
@@ -140,9 +140,9 @@ class Address extends \Faker\Provider\Address
 
     public static function postcode()
     {
-        $prefix = str_pad(static::numberBetween(1, 85), 2, 0, STR_PAD_LEFT);
+        $prefix = str_pad(self::numberBetween(1, 85), 2, 0, STR_PAD_LEFT);
         $suffix = '00';
 
-        return $prefix . static::numberBetween(10, 88) . $suffix;
+        return $prefix . self::numberBetween(10, 88) . $suffix;
     }
 }

--- a/src/Faker/Provider/zh_TW/Address.php
+++ b/src/Faker/Provider/zh_TW/Address.php
@@ -377,12 +377,12 @@ class Address extends \Faker\Provider\Address
 
     public static function localLatitude()
     {
-        return number_format(mt_rand(22000000, 25000000) / 1000000, 6);
+        return static::randomFloat(6, 22, 25);
     }
 
     public static function localLongitude()
     {
-        return number_format(mt_rand(120000000, 122000000) / 1000000, 6);
+        return static::randomFloat(6, 120, 122);
     }
 
     public function city()

--- a/src/Faker/Provider/zh_TW/Person.php
+++ b/src/Faker/Provider/zh_TW/Person.php
@@ -150,12 +150,12 @@ class Person extends \Faker\Provider\Person
 
     public static function firstNameMale()
     {
-        return static::randomName(static::$characterMale, mt_rand(1, 2));
+        return static::randomName(static::$characterMale, static::numberBetween(1, 2));
     }
 
     public static function firstNameFemale()
     {
-        return static::randomName(static::$characterFemale, mt_rand(1, 2));
+        return static::randomName(static::$characterFemale, static::numberBetween(1, 2));
     }
 
     public static function suffix()

--- a/src/Faker/Provider/zh_TW/Person.php
+++ b/src/Faker/Provider/zh_TW/Person.php
@@ -150,12 +150,12 @@ class Person extends \Faker\Provider\Person
 
     public static function firstNameMale()
     {
-        return static::randomName(static::$characterMale, static::numberBetween(1, 2));
+        return static::randomName(static::$characterMale, self::numberBetween(1, 2));
     }
 
     public static function firstNameFemale()
     {
-        return static::randomName(static::$characterFemale, static::numberBetween(1, 2));
+        return static::randomName(static::$characterFemale, self::numberBetween(1, 2));
     }
 
     public static function suffix()


### PR DESCRIPTION
This PR 
- removes usage of `mt_rand` where it's not necessary and uses `static::numberBetween()` or 
- `mt_rand(0, 1)` usages were replaced with `Miscellaneous::boolean()`
- Random dates generation (mostly for national IDs) were replaced by `DateTime::dateTimeThisCentury()` for consistency.
