### PR TITLE
Move US phone numbers with extension to own method

### DIFF
--- a/src/Faker/Provider/en_US/PhoneNumber.php
+++ b/src/Faker/Provider/en_US/PhoneNumber.php
@@ -25,8 +25,9 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         '({{areaCode}}) {{exchangeCode}}-####',
         '1-{{areaCode}}-{{exchangeCode}}-####',
         '{{areaCode}}.{{exchangeCode}}.####',
+    ];
 
-        // Extensions
+    protected static $formatsWithExtension = [
         '{{areaCode}}-{{exchangeCode}}-#### x###',
         '({{areaCode}}) {{exchangeCode}}-#### x###',
         '1-{{areaCode}}-{{exchangeCode}}-#### x###',
@@ -67,6 +68,15 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         $format = self::randomElement(static::$tollFreeFormats);
 
         return self::numerify($this->generator->parse($format));
+    }
+
+    /**
+     * @return string
+     * @example '555-123-546 x123'
+     */
+    public function phoneNumberWithExtension(): string
+    {
+        return static::numerify($this->generator->parse(static::randomElement(static::$formatsWithExtension)));
     }
 
     /**

--- a/src/Faker/Provider/en_US/PhoneNumber.php
+++ b/src/Faker/Provider/en_US/PhoneNumber.php
@@ -74,7 +74,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      * @return string
      * @example '555-123-546 x123'
      */
-    public function phoneNumberWithExtension(): string
+    public function phoneNumberWithExtension()
     {
         return static::numerify($this->generator->parse(static::randomElement(static::$formatsWithExtension)));
     }

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -109,5 +109,4 @@ final class PhoneNumberTest extends TestCase
             $this->assertNotEquals($digits[4], $digits[5]);
         }
     }
-
 }

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -25,8 +25,7 @@ final class PhoneNumberTest extends TestCase
     {
         for ($i = 0; $i < 100; $i++) {
             $number = $this->faker->phoneNumber;
-            $baseNumber = preg_replace('/ *x.*$/', '', $number); // Remove possible extension
-            $digits = array_values(array_filter(str_split($baseNumber), 'ctype_digit'));
+            $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
 
             // Prefix '1' allowed
             if (count($digits) === 11) {
@@ -46,7 +45,7 @@ final class PhoneNumberTest extends TestCase
             }
 
             // Test format
-            $this->assertMatchesRegularExpression('/^(\+?1)?([ -.]*\d{3}[ -.]*| *\(\d{3}\) *)\d{3}[-.]?\d{4}$/', $baseNumber);
+            $this->assertMatchesRegularExpression('/^(\+?1)?([ -.]*\d{3}[ -.]*| *\(\d{3}\) *)\d{3}[-.]?\d{4}$/', $number);
         }
     }
 
@@ -82,4 +81,33 @@ final class PhoneNumberTest extends TestCase
             $this->assertMatchesRegularExpression('/^(\+?1)?([ -.]*\d{3}[ -.]*| *\(\d{3}\) *)\d{3}[-.]?\d{4}$/', $number);
         }
     }
+
+    public function testPhoneNumberWithExtension()
+    {
+        $number = $this->faker->phoneNumberWithExtension;
+
+        // Test format
+        $this->assertMatchesRegularExpression('/^(\+?1)?([ -.]*\d{3}[ -.]*| *\(\d{3}\) *)(\d{3}[-.]?\d{4})(\sx\d{3,5})$/', $number);
+
+        $baseNumber = preg_replace('/ *x.*$/', '', $number); // Remove possible extension
+        $digits = array_values(array_filter(str_split($baseNumber), 'ctype_digit'));
+
+        // Prefix '1' allowed
+        if (count($digits) === 11) {
+            $this->assertEquals('1', $digits[0]);
+            $digits = array_slice($digits, 1);
+        }
+
+        // 10 digits
+        $this->assertCount(10, $digits);
+
+        // Last two digits of area code cannot be identical
+        $this->assertNotEquals($digits[1], $digits[2]);
+
+        // Last two digits of exchange code cannot be 1
+        if ($digits[4] === 1) {
+            $this->assertNotEquals($digits[4], $digits[5]);
+        }
+    }
+
 }


### PR DESCRIPTION
This PR:

- [x] Adds a new feature: generating US phone numbers with `phoneNumber()` now only returns numbers without extension. Numbers with extension can now be generated with `phoneNumberWithExtension()` 
- [x] Covered by tests
- [x] Fixes #18

Even though it definitely appears to be a thing, I could not find an authoritative source that mentions the usage of x to signify extensions, thus no `@link` source reference in the docblock.