### PR TITLE
Fix en_SG phone number generator

### DIFF
--- a/src/Faker/Provider/en_SG/PhoneNumber.php
+++ b/src/Faker/Provider/en_SG/PhoneNumber.php
@@ -54,17 +54,17 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
     public function tollFreeInternationalNumber()
     {
-        return static::randomElement(static::$tollFreeInternationalNumber);
+        return static::numerify(static::randomElement(static::$tollFreeInternationalNumber));
     }
 
     public function tollFreeLineNumber()
     {
-        return static::randomElement(static::$tollFreeLineNumber);
+        return static::numerify(static::randomElement(static::$tollFreeLineNumber));
     }
 
     public function premiumPhoneNumber()
     {
-        return static::randomElement(static::$premiumPhoneNumber);
+        return static::numerify(static::randomElement(static::$premiumPhoneNumber));
     }
 
     public function mobileNumber()
@@ -85,14 +85,12 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
         $format = static::randomElement(static::$voipNumber);
 
-        return $this->generator->parse($format);
+        return static::numerify($this->generator->parse($format));
     }
 
     public function internationalCodePrefix()
     {
-        $format = static::randomElement(static::$internationalCodePrefix);
-
-        return $this->generator->parse($format);
+        return static::randomElement(static::$internationalCodePrefix);
     }
 
     public function zeroToEight()

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -47,4 +47,29 @@ final class PhoneNumberTest extends TestCase
         }
         $this->assertMatchesRegularExpression('/^(\+65|65)?\s*8\s*[1-8]\d{2}\s*\d{4}$/', $mobileNumber);
     }
+
+    public function testTollFreeInternationalNumber()
+    {
+        self::assertMatchesRegularExpression('/^800\s*\d{3}\s*\d{4}$/', $this->faker->tollFreeInternationalNumber);
+    }
+
+    public function testTollFreeLineNumber()
+    {
+        self::assertMatchesRegularExpression('/^1800\s*\d{3}\s*\d{4}$/', $this->faker->tollFreeLineNumber);
+    }
+
+    public function testPremiumPhoneNumber()
+    {
+        self::assertMatchesRegularExpression('/^1900\s*\d{3}\s*\d{4}$/', $this->faker->premiumPhoneNumber);
+    }
+
+    public function testFixedLineNumber()
+    {
+        self::assertMatchesRegularExpression('/^(\+65|65)?\s*6\d{3}\s*\d{4}$/', $this->faker->fixedLineNumber);
+    }
+
+    public function testVoipNumber()
+    {
+        self::assertMatchesRegularExpression('/^(\+65|65)?\s*3\d{3}\s*\d{4}$/', $this->faker->voipNumber);
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

This PR fixes an issue where some Singapore phone numbers were not passed to `numerify` method causing to always return `800 ### ####` instead of `800 301 8665` etc.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This issue was discovered while adding the documentation page for `en_SG` (https://github.com/FakerPHP/fakerphp.github.io/pull/19) and adding tests to the provider. This PR bumps the provider coverage to 100%.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
