### PR TITLE
Fix link to VAT documentation in nl_NL Company provider

### DIFF
--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -94,7 +94,7 @@ class Company extends \Faker\Provider\Company
      *
      * @example 'NL123456789B01'
      *
-     * @see http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/btw/administratie_bijhouden/btw_nummers_controleren/uw_btw_nummer
+     * @see https://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/btw/administratie_bijhouden/btw_nummers_controleren/uw_btw_nummer
      *
      * @return string VAT Number
      */


### PR DESCRIPTION
### What is the reason for this PR?

The link to the VAT documentation was broken in `Faker\Provider\nl_NL\Company`.

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

I changed the link to the VAT documentation for the Dutch "Belastingdienst" (tax office).

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
