### PR TITLE
enable StyleCI single_quote

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -45,6 +45,7 @@ enabled:
   - pow_to_exponentiation
   - random_api_migration
   - short_array_syntax
+  - single_quote
   - standardize_not_equals
   - ternary_to_null_coalescing
   - whitespace_after_comma_in_array


### PR DESCRIPTION
### What is the reason for this PR?

String quotes are inconsistent (sometimes double, sometimes single).

- [ ] A new feature
- [x] Fixed an issue (resolve #114)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This enables `single_quote` in StyleCI.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
