### PR TITLE
Increase consistency of long arrays

### DIFF
--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -13,7 +13,15 @@ class Address extends \Faker\Provider\en_US\Address
     protected static $postcodeLetters = ['A', 'B', 'C', 'E', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'R', 'S', 'T', 'V', 'X', 'Y'];
 
     protected static $province = [
-        'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick', 'Newfoundland and Labrador', 'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island', 'Quebec', 'Saskatchewan', 'Yukon Territory',
+        'Alberta',
+        'British Columbia',
+        'Manitoba',
+        'New Brunswick', 'Newfoundland and Labrador', 'Northwest Territories', 'Nova Scotia', 'Nunavut',
+        'Ontario',
+        'Prince Edward Island',
+        'Quebec',
+        'Saskatchewan',
+        'Yukon Territory',
     ];
 
     protected static $provinceAbbr = [

--- a/src/Faker/Provider/en_GB/Address.php
+++ b/src/Faker/Provider/en_GB/Address.php
@@ -5,10 +5,42 @@ namespace Faker\Provider\en_GB;
 class Address extends \Faker\Provider\Address
 {
     protected static $cityPrefix = ['North', 'East', 'West', 'South', 'New', 'Lake', 'Port'];
-    protected static $citySuffix = ['town', 'ton', 'land', 'ville', 'berg', 'burgh', 'borough', 'bury', 'view', 'port', 'mouth', 'stad', 'furt', 'chester', 'mouth', 'fort', 'haven', 'side', 'shire'];
+    protected static $citySuffix = [
+        'berg', 'borough', 'burgh', 'bury',
+        'chester',
+        'fort', 'furt',
+        'haven',
+        'land',
+        'mouth', 'mouth',
+        'port',
+        'shire', 'side', 'stad',
+        'ton', 'town',
+        'view', 'ville',
+    ];
     protected static $buildingNumber = ['%##', '%#', '%'];
     protected static $streetSuffix = [
-        'Alley', 'Avenue', 'Branch', 'Bridge', 'Brook', 'Brooks', 'Burg', 'Burgs', 'Bypass', 'Camp', 'Canyon', 'Cape', 'Causeway', 'Center', 'Centers', 'Circle', 'Circles', 'Cliff', 'Cliffs', 'Club', 'Common', 'Corner', 'Corners', 'Course', 'Court', 'Courts', 'Cove', 'Coves', 'Creek', 'Crescent', 'Crest', 'Crossing', 'Crossroad', 'Curve', 'Dale', 'Dam', 'Divide', 'Drive', 'Drive', 'Drives', 'Estate', 'Estates', 'Expressway', 'Extension', 'Extensions', 'Fall', 'Falls', 'Ferry', 'Field', 'Fields', 'Flat', 'Flats', 'Ford', 'Fords', 'Forest', 'Forge', 'Forges', 'Fork', 'Forks', 'Fort', 'Garden', 'Gardens', 'Gateway', 'Glen', 'Glens', 'Green', 'Greens', 'Grove', 'Groves', 'Harbour', 'Harbours', 'Haven', 'Heights', 'Highway', 'Hill', 'Hills', 'Hollow', 'Inlet', 'Island', 'Islands', 'Isle', 'Junction', 'Junctions', 'Key', 'Keys', 'Knoll', 'Knolls', 'Lake', 'Lakes', 'Land', 'Landing', 'Lane', 'Light', 'Lights', 'Loaf', 'Lock', 'Locks', 'Locks', 'Lodge', 'Lodge', 'Loop', 'Manor', 'Manors', 'Meadow', 'Meadows', 'Mews', 'Mill', 'Mills', 'Motorway', 'Mount', 'Mountain', 'Mountains', 'Neck', 'Orchard', 'Oval', 'Overpass', 'Park', 'Parks', 'Parkway', 'Parkways', 'Pass', 'Passage', 'Path', 'Pike', 'Pine', 'Pines', 'Place', 'Plain', 'Plains', 'Plaza', 'Point', 'Points', 'Port', 'Ports', 'Radial', 'Ramp', 'Ranch', 'Rapid', 'Rapids', 'Rest', 'Ridge', 'Ridges', 'River', 'Road', 'Road', 'Roads', 'Roads', 'Route', 'Row', 'Rue', 'Run', 'Shoal', 'Shoals', 'Shore', 'Shores', 'Spring', 'Springs', 'Springs', 'Spur', 'Spurs', 'Square', 'Square', 'Squares', 'Squares', 'Station', 'Station', 'Stream', 'Stream', 'Street', 'Streets', 'Summit', 'Terrace', 'Throughway', 'Trace', 'Track', 'Trafficway', 'Trail', 'Tunnel', 'Turnpike', 'Underpass', 'Union', 'Unions', 'Valley', 'Valleys', 'Via', 'Viaduct', 'View', 'Views', 'Village', 'Villages', 'Ville', 'Vista', 'Vista', 'Walk', 'Walks', 'Wall', 'Way', 'Ways', 'Well', 'Wells'
+        'Avenue',
+        'Branch', 'Bridge', 'Brook', 'Brooks', 'Burg', 'Burgs', 'Bypass',
+        'Camp', 'Canyon', 'Cape', 'Causeway', 'Center', 'Centers', 'Circle', 'Circles', 'Cliff', 'Cliffs', 'Club', 'Common', 'Corner', 'Corners', 'Course', 'Court', 'Courts', 'Cove', 'Coves', 'Creek', 'Crescent', 'Crest', 'Crossing', 'Crossroad', 'Curve',
+        'Dale', 'Dam', 'Divide', 'Drive', 'Drive', 'Drives',
+        'Estate', 'Estates', 'Expressway', 'Extension', 'Extensions',
+        'Fall', 'Falls', 'Ferry', 'Field', 'Fields', 'Flat', 'Flats', 'Ford', 'Fords', 'Forest', 'Forge', 'Forges', 'Fork', 'Forks', 'Fort',
+        'Garden', 'Gardens', 'Gateway', 'Glen', 'Glens', 'Green', 'Greens', 'Grove', 'Groves',
+        'Harbour', 'Harbours', 'Haven', 'Heights', 'Highway', 'Hill', 'Hills', 'Hollow',
+        'Inlet', 'Island', 'Islands', 'Isle',
+        'Junction', 'Junctions',
+        'Key', 'Keys', 'Knoll', 'Knolls',
+        'Lake', 'Lakes', 'Land', 'Landing', 'Lane', 'Light', 'Lights', 'Loaf', 'Lock', 'Locks', 'Locks', 'Lodge', 'Lodge', 'Loop',
+        'Manor', 'Manors', 'Meadow', 'Meadows', 'Mews', 'Mill', 'Mills', 'Motorway', 'Mount', 'Mountain', 'Mountains',
+        'Neck',
+        'Orchard', 'Oval', 'Overpass',
+        'Park', 'Parks', 'Parkway', 'Parkways', 'Pass', 'Passage', 'Path', 'Pike', 'Pine', 'Pines', 'Place', 'Plain', 'Plains', 'Plaza', 'Point', 'Points', 'Port', 'Ports',
+        'Radial', 'Ramp', 'Ranch', 'Rapid', 'Rapids', 'Rest', 'Ridge', 'Ridges', 'River', 'Road', 'Road', 'Roads', 'Roads', 'Route', 'Row', 'Rue', 'Run',
+        'Shoal', 'Shoals', 'Shore', 'Shores', 'Spring', 'Springs', 'Springs', 'Spur', 'Spurs', 'Square', 'Square', 'Squares', 'Squares', 'Station', 'Station', 'Stream', 'Stream', 'Street', 'Streets', 'Summit',
+        'Terrace', 'Throughway', 'Trace', 'Track', 'Trafficway', 'Trail', 'Tunnel', 'Turnpike',
+        'Underpass', 'Union', 'Unions',
+        'Valley', 'Valleys', 'Via', 'Viaduct', 'View', 'Views', 'Village', 'Villages', 'Ville', 'Vista', 'Vista',
+        'Walk', 'Walks', 'Wall', 'Way', 'Ways', 'Well', 'Wells'
     ];
 
     protected static $postcode = [

--- a/src/Faker/Provider/en_GB/Address.php
+++ b/src/Faker/Provider/en_GB/Address.php
@@ -19,7 +19,7 @@ class Address extends \Faker\Provider\Address
     ];
     protected static $buildingNumber = ['%##', '%#', '%'];
     protected static $streetSuffix = [
-        'Avenue',
+        'Alley', 'Avenue',
         'Branch', 'Bridge', 'Brook', 'Brooks', 'Burg', 'Burgs', 'Bypass',
         'Camp', 'Canyon', 'Cape', 'Causeway', 'Center', 'Centers', 'Circle', 'Circles', 'Cliff', 'Cliffs', 'Club', 'Common', 'Corner', 'Corners', 'Course', 'Court', 'Courts', 'Cove', 'Coves', 'Creek', 'Crescent', 'Crest', 'Crossing', 'Crossroad', 'Curve',
         'Dale', 'Dam', 'Divide', 'Drive', 'Drive', 'Drives',
@@ -40,7 +40,7 @@ class Address extends \Faker\Provider\Address
         'Terrace', 'Throughway', 'Trace', 'Track', 'Trafficway', 'Trail', 'Tunnel', 'Turnpike',
         'Underpass', 'Union', 'Unions',
         'Valley', 'Valleys', 'Via', 'Viaduct', 'View', 'Views', 'Village', 'Villages', 'Ville', 'Vista', 'Vista',
-        'Walk', 'Walks', 'Wall', 'Way', 'Ways', 'Well', 'Wells'
+        'Walk', 'Walks', 'Wall', 'Way', 'Ways', 'Well', 'Wells',
     ];
 
     protected static $postcode = [


### PR DESCRIPTION
### What is the reason for this PR?

Formatting of long arrays is inconsistent. Some have all items in one line which makes comparisons difficult, others have newlines for each common starting letter.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR changes the sorting of long arrays in `en_CA\Address` and `en_DB\Address`  by 

- sorting the items alphabetically
- adding new lines after each first character group

If this PR is accepted I'll dig through the other providers to make all long arrays consistent.

Alternatively we could probably enable a fixer in StyleCI to have a newline after each array item for long arrays (though I couldn't find a fixer that does that right away), but then we'd likely lose the grouping by first character.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
