### PR TITLE
Change function param type declarations DateTime to DateTimeInterface 

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -297,12 +297,12 @@ class DateTime extends Base
     /**
      * Internal method to set the time zone on a DateTime.
      *
-     * @param \DateTimeInterface $dt
+     * @param \DateTime $dt
      * @param string|null $timezone
      *
      * @return \DateTime
      */
-    private static function setTimezone(\DateTimeInterface $dt, $timezone)
+    private static function setTimezone(\DateTime $dt, $timezone)
     {
         return $dt->setTimezone(new \DateTimeZone(static::resolveTimezone($timezone)));
     }

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -297,12 +297,12 @@ class DateTime extends Base
     /**
      * Internal method to set the time zone on a DateTime.
      *
-     * @param \DateTime $dt
+     * @param \DateTimeInterface $dt
      * @param string|null $timezone
      *
      * @return \DateTime
      */
-    private static function setTimezone(\DateTime $dt, $timezone)
+    private static function setTimezone(\DateTimeInterface $dt, $timezone)
     {
         return $dt->setTimezone(new \DateTimeZone(static::resolveTimezone($timezone)));
     }

--- a/src/Faker/Provider/de_AT/Person.php
+++ b/src/Faker/Provider/de_AT/Person.php
@@ -123,10 +123,10 @@ class Person extends \Faker\Provider\Person
     /**
      * Generates a random Austrian Social Security number.
      * @link https://de.wikipedia.org/wiki/Sozialversicherungsnummer#.C3.96sterreich
-     * @param  \DateTime|null  $birthdate
+     * @param  \DateTimeInterface|null  $birthdate
      * @return string
      */
-    public static function ssn(\DateTime $birthdate = null)
+    public static function ssn(\DateTimeInterface $birthdate = null)
     {
         $birthdate = $birthdate ?? DateTime::dateTimeThisCentury();
 

--- a/src/Faker/Provider/en_SG/Person.php
+++ b/src/Faker/Provider/en_SG/Person.php
@@ -9,11 +9,11 @@ class Person extends \Faker\Provider\Person
     /**
      * National Registration Identity Card number
      *
-     * @param \DateTime|null $birthDate birth date
+     * @param \DateTimeInterface|null $birthDate birth date
      *
      * @return string in format S1234567D or T1234567J
      */
-    public static function nric(?\DateTime $birthDate = null): string
+    public static function nric(?\DateTimeInterface $birthDate = null): string
     {
         return self::singaporeId($birthDate, false);
     }
@@ -21,11 +21,11 @@ class Person extends \Faker\Provider\Person
     /**
      * Foreign Identification Number
      *
-     * @param \DateTime|null $issueDate issue date
+     * @param \DateTimeInterface|null $issueDate issue date
      *
      * @return string in format F1234567N or G1234567X
      */
-    public static function fin(?\DateTime $issueDate = null): string
+    public static function fin(?\DateTimeInterface $issueDate = null): string
     {
         return self::singaporeId($issueDate, true);
     }
@@ -33,12 +33,12 @@ class Person extends \Faker\Provider\Person
     /**
      * Singapore NRIC (citizens) or FIN (foreigners) number
      *
-     * @param \DateTime|null $issueDate birth/issue date
+     * @param \DateTimeInterface|null $issueDate birth/issue date
      * @param bool           $foreigner whether a person is foreigner or citizen
      *
      * @return string in format S1234567D, T1234567J, F1234567N or G1234567X
      */
-    public static function singaporeId(?\DateTime $issueDate = null, bool $foreigner = false): string
+    public static function singaporeId(?\DateTimeInterface $issueDate = null, bool $foreigner = false): string
     {
         if ($issueDate === null) {
             $issueDate = DateTime::dateTimeThisCentury();

--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -135,13 +135,13 @@ class Person extends \Faker\Provider\Person
     /**
      * @link https://en.wikipedia.org/wiki/National_identification_number#South_Africa
      *
-     * @param \DateTime $birthdate
+     * @param \DateTimeInterface|null $birthdate
      * @param bool      $citizen
      * @param string    $gender
      *
      * @return string
      */
-    public function idNumber(\DateTime $birthdate = null, $citizen = true, $gender = null)
+    public function idNumber(\DateTimeInterface $birthdate = null, $citizen = true, $gender = null)
     {
         if (!$birthdate) {
             $birthdate = $this->generator->dateTimeThisCentury();

--- a/src/Faker/Provider/fi_FI/Person.php
+++ b/src/Faker/Provider/fi_FI/Person.php
@@ -89,11 +89,11 @@ class Person extends \Faker\Provider\Person
     /**
      * National Personal Identity Number (Henkilötunnus)
      * @link http://www.finlex.fi/fi/laki/ajantasa/2010/20100128
-     * @param \DateTime $birthdate
+     * @param \DateTimeInterface|null $birthdate
      * @param string $gender Person::GENDER_MALE || Person::GENDER_FEMALE
      * @return string on format DDMMYYCZZZQ, where DDMMYY is the date of birth, C the century sign, ZZZ the individual number and Q the control character (checksum)
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null)
+    public function personalIdentityNumber(\DateTimeInterface $birthdate = null, $gender = null)
     {
         $checksumCharacters = '0123456789ABCDEFHJKLMNPRSTUVWXY';
 

--- a/src/Faker/Provider/id_ID/Person.php
+++ b/src/Faker/Provider/id_ID/Person.php
@@ -298,10 +298,10 @@ class Person extends \Faker\Provider\Person
      * @link https://en.wikipedia.org/wiki/National_identification_number#Indonesia
      *
      * @param null|string $gender
-     * @param null|\DateTime $birthDate
+     * @param \DateTimeInterface|null $birthDate
      * @return string
      */
-    public function nik($gender = null, $birthDate = null)
+    public function nik($gender = null, \DateTimeInterface $birthDate = null)
     {
         # generate first numbers (region data)
         $nik = $this->birthPlaceCode();

--- a/src/Faker/Provider/kk_KZ/Company.php
+++ b/src/Faker/Provider/kk_KZ/Company.php
@@ -53,10 +53,10 @@ class Company extends \Faker\Provider\Company
      * National Business Identification Numbers
      *
      * @link   http://egov.kz/wps/portal/Content?contentPath=%2Fegovcontent%2Fbus_business%2Ffor_businessmen%2Farticle%2Fbusiness_identification_number&lang=en
-     * @param  \DateTime $registrationDate
+     * @param  \DateTimeInterface|null $registrationDate
      * @return string 12 digits, like 150140000019
      */
-    public static function businessIdentificationNumber(\DateTime $registrationDate = null)
+    public static function businessIdentificationNumber(\DateTimeInterface $registrationDate = null)
     {
         if (!$registrationDate) {
             $registrationDate = \Faker\Provider\DateTime::dateTimeThisYear();

--- a/src/Faker/Provider/kk_KZ/Person.php
+++ b/src/Faker/Provider/kk_KZ/Person.php
@@ -199,12 +199,12 @@ class Person extends \Faker\Provider\Person
      * @link   http://egov.kz/wps/portal/Content?contentPath=%2Fegovcontent%2Fcitizen_migration%2Fpassport_id_card%2Farticle%2Fiin_info&lang=en
      * @link   https://ru.wikipedia.org/wiki/%D0%98%D0%BD%D0%B4%D0%B8%D0%B2%D0%B8%D0%B4%D1%83%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B9_%D0%B8%D0%B4%D0%B5%D0%BD%D1%82%D0%B8%D1%84%D0%B8%D0%BA%D0%B0%D1%86%D0%B8%D0%BE%D0%BD%D0%BD%D1%8B%D0%B9_%D0%BD%D0%BE%D0%BC%D0%B5%D1%80
      *
-     * @param  \DateTime $birthDate
+     * @param  \DateTimeInterface|null $birthDate
      * @param  int   $gender
      *
      * @return string 12 digits, like 780322300455
      */
-    public static function individualIdentificationNumber(\DateTime $birthDate = null, $gender = self::GENDER_MALE)
+    public static function individualIdentificationNumber(\DateTimeInterface $birthDate = null, $gender = self::GENDER_MALE)
     {
         if (!$birthDate) {
             $birthDate = DateTime::dateTimeBetween();

--- a/src/Faker/Provider/lt_LT/Person.php
+++ b/src/Faker/Provider/lt_LT/Person.php
@@ -312,11 +312,11 @@ class Person extends \Faker\Provider\Person
      * @link https://en.wikipedia.org/wiki/National_identification_number#Lithuania
      * @link https://lt.wikipedia.org/wiki/Asmens_kodas
      * @param string $gender [male|female]
-     * @param \DateTime $birthdate
+     * @param \DateTimeInterface|null $birthdate
      * @param string $randomNumber three integers
      * @return string on format XXXXXXXXXXX
      */
-    public function personalIdentityNumber($gender = 'male', \DateTime $birthdate = null, $randomNumber = '')
+    public function personalIdentityNumber($gender = 'male', \DateTimeInterface $birthdate = null, $randomNumber = '')
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();

--- a/src/Faker/Provider/lv_LV/Person.php
+++ b/src/Faker/Provider/lv_LV/Person.php
@@ -109,10 +109,10 @@ class Person extends \Faker\Provider\Person
     /**
      * National Personal Identity number (personas kods)
      * @link https://en.wikipedia.org/wiki/National_identification_number#Latvia
-     * @param \DateTime $birthdate
+     * @param \DateTimeInterface|null $birthdate
      * @return string on format XXXXXX-XXXXX
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null)
+    public function personalIdentityNumber(\DateTimeInterface $birthdate = null)
     {
         if (!$birthdate) {
             $birthdate = DateTime::dateTimeThisCentury();

--- a/src/Faker/Provider/nb_NO/Person.php
+++ b/src/Faker/Provider/nb_NO/Person.php
@@ -283,11 +283,11 @@ class Person extends \Faker\Provider\Person
     /**
      * National Personal Identity number (personnummer)
      * @link https://no.wikipedia.org/wiki/Personnummer
-     * @param \DateTime $birthdate
+     * @param \DateTimeInterface|null $birthdate
      * @param string $gender Person::GENDER_MALE || Person::GENDER_FEMALE
      * @return string on format DDMMYY#####
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null)
+    public function personalIdentityNumber(\DateTimeInterface $birthdate = null, $gender = null)
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -188,12 +188,12 @@ class Person extends \Faker\Provider\Person
     /**
      * https://ro.wikipedia.org/wiki/Cod_numeric_personal#S
      *
-     * @param \DateTime $dateOfBirth
+     * @param \DateTimeInterface $dateOfBirth
      * @param bool $isResident
      * @param string $gender
      * @return int
      */
-    protected static function getGenderDigit(\DateTime $dateOfBirth, $gender, $isResident)
+    protected static function getGenderDigit(\DateTimeInterface $dateOfBirth, $gender, $isResident)
     {
         if (!$isResident) {
             return 9;

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -116,11 +116,11 @@ class Person extends \Faker\Provider\Person
     /**
      * National Personal Identity number (personnummer)
      * @link http://en.wikipedia.org/wiki/Personal_identity_number_(Sweden)
-     * @param \DateTime $birthdate
+     * @param \DateTimeInterface|null $birthdate
      * @param string $gender Person::GENDER_MALE || Person::GENDER_FEMALE
      * @return string on format XXXXXX-XXXX
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null)
+    public function personalIdentityNumber(\DateTimeInterface $birthdate = null, $gender = null)
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();


### PR DESCRIPTION
### What is the reason for this PR?

Most functions use `DateTime` instead of `DateTimeInterface` as argument type declarations. `DateTimeInterface` makes more sense, as mentioned by @GrahamCampbell in https://github.com/FakerPHP/Faker/pull/109#discussion_r537629977

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Changed function param type declarations. Some also had optional `DateTime` params which was not reflected in the docblock.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
