### PR TITLE
Add used extensions to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "php": "^7.1 || ^8.0",
         "ext-dom": "*",
         "ext-iconv": "*",
-        "ext-intl": "*",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
-        "ext-dom": "*",
-        "ext-iconv": "*",
-        "ext-json": "*"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
         "ext-intl": "*",
@@ -36,6 +33,11 @@
     },
     "conflict": {
         "fzaninotto/faker": "*"
+    },
+    "suggest": {
+        "ext-dom": "(\\Faker\\Provider\\HtmlLorem) Required for generating random HTML.",
+        "ext-iconv": "(\\Faker\\Provider\\ru_RU\\Text::realText()) Required for generating real Russian text.",
+        "ext-json": "(\\Faker\\Provider\\Miscellaneous::emoji()) Required for generating random emojis."
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "fzaninotto/faker": "*"
     },
     "suggest": {
-        "ext-dom": "(\\Faker\\Provider\\HtmlLorem) Required for generating random HTML.",
-        "ext-iconv": "(\\Faker\\Provider\\ru_RU\\Text::realText()) Required for generating real Russian text."
+        "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+        "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text."
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
     },
     "suggest": {
         "ext-dom": "(\\Faker\\Provider\\HtmlLorem) Required for generating random HTML.",
-        "ext-iconv": "(\\Faker\\Provider\\ru_RU\\Text::realText()) Required for generating real Russian text.",
-        "ext-json": "(\\Faker\\Provider\\Miscellaneous::emoji()) Required for generating random emojis."
+        "symfony/polyfill-iconv": "(\\Faker\\Provider\\ru_RU\\Text::realText()) Required for generating real Russian text."
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,14 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.1 || ^8.0",
+        "ext-intl": "*",
+        "ext-dom": "*",
+        "ext-curl": "*",
+        "ext-json": "*",
+        "ext-iconv": "*"
     },
     "require-dev": {
-        "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
         "symfony/phpunit-bridge": "^4.4 || ^5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ext-json": "*"
     },
     "require-dev": {
+        "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
         "symfony/phpunit-bridge": "^4.4 || ^5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,10 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "ext-intl": "*",
         "ext-dom": "*",
-        "ext-curl": "*",
-        "ext-json": "*",
-        "ext-iconv": "*"
+        "ext-iconv": "*",
+        "ext-intl": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4.1",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "suggest": {
         "ext-dom": "(\\Faker\\Provider\\HtmlLorem) Required for generating random HTML.",
-        "symfony/polyfill-iconv": "(\\Faker\\Provider\\ru_RU\\Text::realText()) Required for generating real Russian text."
+        "ext-iconv": "(\\Faker\\Provider\\ru_RU\\Text::realText()) Required for generating real Russian text."
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,10 @@
         "fzaninotto/faker": "*"
     },
     "suggest": {
+        "ext-curl": "Required by Faker\\Provider\\Image to download images.",
         "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
-        "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text."
+        "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+        "ext-mbstring": "Required for multibyte Unicode string functionality."
     },
     "config": {
         "sort-packages": true

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -47,6 +47,10 @@ class HtmlLorem extends Base
      */
     public function randomHtml($maxDepth = 4, $maxWidth = 4)
     {
+        if (!class_exists('DOMDocument', false)) {
+            return new \RuntimeException('DOMDocument is required to use randomHtml.');
+        }
+
         $document = new \DOMDocument();
         $this->idGenerator = new UniqueGenerator($this->generator);
 

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -43,8 +43,6 @@ class HtmlLorem extends Base
      * @param int $maxDepth
      * @param int $maxWidth
      *
-     * @throws \RuntimeException
-     *
      * @return string
      */
     public function randomHtml($maxDepth = 4, $maxWidth = 4)

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -43,6 +43,8 @@ class HtmlLorem extends Base
      * @param int $maxDepth
      * @param int $maxWidth
      *
+     * @throws \RuntimeException
+     *
      * @return string
      */
     public function randomHtml($maxDepth = 4, $maxWidth = 4)

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -49,7 +49,7 @@ class HtmlLorem extends Base
      */
     public function randomHtml($maxDepth = 4, $maxWidth = 4)
     {
-        if (!class_exists('DOMDocument', false)) {
+        if (!class_exists(\DOMDocument::class, false)) {
             throw new \RuntimeException('ext-dom is required to use randomHtml.');
         }
 

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -50,7 +50,7 @@ class HtmlLorem extends Base
     public function randomHtml($maxDepth = 4, $maxWidth = 4)
     {
         if (!class_exists('DOMDocument', false)) {
-            return new \RuntimeException('DOMDocument is required to use randomHtml.');
+            throw new \RuntimeException('DOMDocument is required to use randomHtml.');
         }
 
         $document = new \DOMDocument();

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -50,7 +50,7 @@ class HtmlLorem extends Base
     public function randomHtml($maxDepth = 4, $maxWidth = 4)
     {
         if (!class_exists('DOMDocument', false)) {
-            throw new \RuntimeException('DOMDocument is required to use randomHtml.');
+            throw new \RuntimeException('ext-dom is required to use randomHtml.');
         }
 
         $document = new \DOMDocument();


### PR DESCRIPTION
### What is the reason for this PR?

Faker uses a couple of php extensions that are not included in composer.json's require.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR adds the required extensions:

- ext-dom is used e.g. in 
https://github.com/FakerPHP/Faker/blob/9f12db8c85c5d10ec1ca02be7097aabd5e1ee67c/src/Faker/Provider/HtmlLorem.php#L50

- ext-iconv is used in 
https://github.com/FakerPHP/Faker/blob/9f12db8c85c5d10ec1ca02be7097aabd5e1ee67c/src/Faker/Provider/ru_RU/Text.php#L11

- ext-json is used in 
https://github.com/FakerPHP/Faker/blob/9f12db8c85c5d10ec1ca02be7097aabd5e1ee67c/src/Faker/Provider/Miscellaneous.php#L321

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
