### PR TITLE
add 172.16/12 local IPv4 block

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -31,6 +31,15 @@ class Internet extends Base
     ];
 
     /**
+     * @link https://tools.ietf.org/html/rfc1918#section-3
+     */
+    protected static $localIpBlocks = [
+        ['10.0.0.0', '10.255.255.255'],
+        ['172.16.0.0', '172.31.255.255'],
+        ['192.168.0.0', '192.168.255.255'],
+    ];
+
+    /**
      * @example 'jdoe@acme.biz'
      */
     public function email()
@@ -204,13 +213,9 @@ class Internet extends Base
      */
     public static function localIpv4()
     {
-        if (Miscellaneous::boolean()) {
-            // 10.x.x.x range
-            return long2ip(self::numberBetween(ip2long('10.0.0.0'), ip2long('10.255.255.255')));
-        }
+        $ipBlock = self::randomElement(static::$localIpBlocks);
 
-        // 192.168.x.x range
-        return long2ip(self::numberBetween(ip2long('192.168.0.0'), ip2long('192.168.255.255')));
+        return long2ip(static::numberBetween(ip2long($ipBlock[0]), ip2long($ipBlock[1])));
     }
 
     /**


### PR DESCRIPTION
### What is the reason for this PR?

This PR replaces #23 without additional style changes. Previous PR contained many unnecessary changes and author was not responding for some time already.

- [x] Adds 172.16/12 IPv4 block to `localIpv4()`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
