### PR TITLE
Deprecate zh_TW methods that only call base methods

### DIFF
--- a/src/Faker/Provider/zh_TW/Internet.php
+++ b/src/Faker/Provider/zh_TW/Internet.php
@@ -9,9 +9,6 @@ namespace Faker\Provider\zh_TW;
 class Internet extends \Faker\Provider\Internet
 {
     /**
-     * @return string
-     * @throws \Exception
-     *
      * @deprecated Use {@link \Faker\Provider\Internet::userName()} instead
      * @see \Faker\Provider\Internet::userName()
      */
@@ -21,9 +18,6 @@ class Internet extends \Faker\Provider\Internet
     }
 
     /**
-     * @return string
-     * @throws \Exception
-     *
      * @deprecated Use {@link \Faker\Provider\Internet::domainWord()} instead
      * @see \Faker\Provider\Internet::domainWord()
      */

--- a/src/Faker/Provider/zh_TW/Internet.php
+++ b/src/Faker/Provider/zh_TW/Internet.php
@@ -2,15 +2,33 @@
 
 namespace Faker\Provider\zh_TW;
 
+/**
+ * @deprecated Use {@link \Faker\Provider\Internet} instead
+ * @see \Faker\Provider\Internet
+ */
 class Internet extends \Faker\Provider\Internet
 {
+    /**
+     * @return string
+     * @throws \Exception
+     *
+     * @deprecated Use {@link \Faker\Provider\Internet::userName()} instead
+     * @see \Faker\Provider\Internet::userName()
+     */
     public function userName()
     {
-        return \Faker\Factory::create('en_US')->userName();
+        return parent::userName();
     }
 
+    /**
+     * @return string
+     * @throws \Exception
+     *
+     * @deprecated Use {@link \Faker\Provider\Internet::domainWord()} instead
+     * @see \Faker\Provider\Internet::domainWord()
+     */
     public function domainWord()
     {
-        return \Faker\Factory::create('en_US')->domainWord();
+        return parent::domainWord();
     }
 }

--- a/src/Faker/Provider/zh_TW/Payment.php
+++ b/src/Faker/Provider/zh_TW/Payment.php
@@ -10,7 +10,6 @@ class Payment extends \Faker\Provider\Payment
 {
     /**
      * @return array
-     * @throws \Exception
      * @deprecated Use {@link \Faker\Provider\Payment::creditCardDetails()} instead
      * @see \Faker\Provider\Payment::creditCardDetails()
      */

--- a/src/Faker/Provider/zh_TW/Payment.php
+++ b/src/Faker/Provider/zh_TW/Payment.php
@@ -9,7 +9,7 @@ namespace Faker\Provider\zh_TW;
 class Payment extends \Faker\Provider\Payment
 {
     /**
-     * @return string
+     * @return array
      * @throws \Exception
      * @deprecated Use {@link \Faker\Provider\Payment::creditCardDetails()} instead
      * @see \Faker\Provider\Payment::creditCardDetails()

--- a/src/Faker/Provider/zh_TW/Payment.php
+++ b/src/Faker/Provider/zh_TW/Payment.php
@@ -2,10 +2,20 @@
 
 namespace Faker\Provider\zh_TW;
 
+/**
+ * @deprecated Use {@link \Faker\Provider\Payment} instead
+ * @see \Faker\Provider\Payment
+ */
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * @return string
+     * @throws \Exception
+     * @deprecated Use {@link \Faker\Provider\Payment::creditCardDetails()} instead
+     * @see \Faker\Provider\Payment::creditCardDetails()
+     */
     public function creditCardDetails($valid = true)
     {
-        return \Faker\Factory::create('en_US')->creditCardDetails($valid);
+        return parent::creditCardDetails($valid);
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

In `zh_TW` there are two classes that use `Factory::create('en_US')` only to call base methods.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR deprecates these classes and methods. For BC the respective parent methods are called.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
