### PR TITLE
Remove json_decode from emoji generation

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -1,4 +1,5 @@
 parameters:
     ignoreErrors:
+        - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-zA-Z]+::\$[a-zA-Z]+ changed default value#'
         - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-z_A-Z]+\\[a-zA-Z]+::\$[a-zA-Z]+ changed default value#'
         - '#\[BC\] CHANGED: Property Faker\\Factory::\$defaultProviders changed default value#'

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -319,7 +319,7 @@ class Miscellaneous extends Base
     public static function emoji()
     {
         $randomElement = static::randomElement(static::$emoji);
-        $unicodeHex = preg_replace("/\\\uD83D\\\uDE([0-9A-F]*)/", "&#x1F6\\1;", $randomElement);
+        $unicodeHex = preg_replace("/\\\uD83D\\\uDE([0-9A-F]*)/", '&#x1F6\\1;', $randomElement);
         return html_entity_decode($unicodeHex, ENT_NOQUOTES, 'UTF-8');
     }
 }

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -8,23 +8,23 @@ class Miscellaneous extends Base
      * @link https://en.wikipedia.org/wiki/Emoji#Unicode_blocks
      * On date of 2017-03-26
      *
-     * U+1F600 - U+1F637 as their UTF-8 Pairings
+     * U+1F600 - U+1F637 in Unicode Codepoint Escape Syntax
      */
-    protected static $emoji = [
-        '\uD83D\uDE00', '\uD83D\uDE01', '\uD83D\uDE02', '\uD83D\uDE03',
-        '\uD83D\uDE04', '\uD83D\uDE05', '\uD83D\uDE06', '\uD83D\uDE07',
-        '\uD83D\uDE08', '\uD83D\uDE09', '\uD83D\uDE0A', '\uD83D\uDE0B',
-        '\uD83D\uDE0C', '\uD83D\uDE0D', '\uD83D\uDE0E', '\uD83D\uDE0F',
-        '\uD83D\uDE10', '\uD83D\uDE11', '\uD83D\uDE12', '\uD83D\uDE13',
-        '\uD83D\uDE14', '\uD83D\uDE15', '\uD83D\uDE16', '\uD83D\uDE17',
-        '\uD83D\uDE18', '\uD83D\uDE19', '\uD83D\uDE1A', '\uD83D\uDE1B',
-        '\uD83D\uDE1C', '\uD83D\uDE1D', '\uD83D\uDE1E', '\uD83D\uDE1F',
-        '\uD83D\uDE20', '\uD83D\uDE21', '\uD83D\uDE22', '\uD83D\uDE23',
-        '\uD83D\uDE24', '\uD83D\uDE25', '\uD83D\uDE26', '\uD83D\uDE27',
-        '\uD83D\uDE28', '\uD83D\uDE29', '\uD83D\uDE2A', '\uD83D\uDE2B',
-        '\uD83D\uDE2C', '\uD83D\uDE2D', '\uD83D\uDE2E', '\uD83D\uDE2F',
-        '\uD83D\uDE30', '\uD83D\uDE31', '\uD83D\uDE32', '\uD83D\uDE33',
-        '\uD83D\uDE34', '\uD83D\uDE35', '\uD83D\uDE36', '\uD83D\uDE37',
+    public static $emoji = [
+        "\u{1F600}", "\u{1F601}", "\u{1F602}", "\u{1F603}",
+        "\u{1F604}", "\u{1F605}", "\u{1F606}", "\u{1F607}",
+        "\u{1F608}", "\u{1F609}", "\u{1F60A}", "\u{1F60B}",
+        "\u{1F60C}", "\u{1F60D}", "\u{1F60E}", "\u{1F60F}",
+        "\u{1F610}", "\u{1F611}", "\u{1F612}", "\u{1F613}",
+        "\u{1F614}", "\u{1F615}", "\u{1F616}", "\u{1F617}",
+        "\u{1F618}", "\u{1F619}", "\u{1F61A}", "\u{1F61B}",
+        "\u{1F61C}", "\u{1F61D}", "\u{1F61E}", "\u{1F61F}",
+        "\u{1F620}", "\u{1F621}", "\u{1F622}", "\u{1F623}",
+        "\u{1F624}", "\u{1F625}", "\u{1F626}", "\u{1F627}",
+        "\u{1F628}", "\u{1F629}", "\u{1F62A}", "\u{1F62B}",
+        "\u{1F62C}", "\u{1F62D}", "\u{1F62E}", "\u{1F62F}",
+        "\u{1F630}", "\u{1F631}", "\u{1F632}", "\u{1F633}",
+        "\u{1F634}", "\u{1F635}", "\u{1F636}", "\u{1F637}",
     ];
 
     /**
@@ -312,12 +312,12 @@ class Miscellaneous extends Base
     }
 
     /**
-     * Returns an encoded Unicode Character between U+1F600 and U+1F637.
+     * Returns an Emoji (Unicode character between U+1F600 and U+1F637).
      *
      * @link https://en.wikipedia.org/wiki/Emoji#Unicode_blocks
      */
     public static function emoji()
     {
-        return json_decode('"' . static::randomElement(static::$emoji) . '"');
+        return static::randomElement(static::$emoji);
     }
 }

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -8,23 +8,23 @@ class Miscellaneous extends Base
      * @link https://en.wikipedia.org/wiki/Emoji#Unicode_blocks
      * On date of 2017-03-26
      *
-     * U+1F600 - U+1F637 in Unicode Codepoint Escape Syntax
+     * U+1F600 - U+1F637 as their UTF-8 Pairings
      */
     protected static $emoji = [
-        "\u{1F600}", "\u{1F601}", "\u{1F602}", "\u{1F603}",
-        "\u{1F604}", "\u{1F605}", "\u{1F606}", "\u{1F607}",
-        "\u{1F608}", "\u{1F609}", "\u{1F60A}", "\u{1F60B}",
-        "\u{1F60C}", "\u{1F60D}", "\u{1F60E}", "\u{1F60F}",
-        "\u{1F610}", "\u{1F611}", "\u{1F612}", "\u{1F613}",
-        "\u{1F614}", "\u{1F615}", "\u{1F616}", "\u{1F617}",
-        "\u{1F618}", "\u{1F619}", "\u{1F61A}", "\u{1F61B}",
-        "\u{1F61C}", "\u{1F61D}", "\u{1F61E}", "\u{1F61F}",
-        "\u{1F620}", "\u{1F621}", "\u{1F622}", "\u{1F623}",
-        "\u{1F624}", "\u{1F625}", "\u{1F626}", "\u{1F627}",
-        "\u{1F628}", "\u{1F629}", "\u{1F62A}", "\u{1F62B}",
-        "\u{1F62C}", "\u{1F62D}", "\u{1F62E}", "\u{1F62F}",
-        "\u{1F630}", "\u{1F631}", "\u{1F632}", "\u{1F633}",
-        "\u{1F634}", "\u{1F635}", "\u{1F636}", "\u{1F637}",
+        '\uD83D\uDE00', '\uD83D\uDE01', '\uD83D\uDE02', '\uD83D\uDE03',
+        '\uD83D\uDE04', '\uD83D\uDE05', '\uD83D\uDE06', '\uD83D\uDE07',
+        '\uD83D\uDE08', '\uD83D\uDE09', '\uD83D\uDE0A', '\uD83D\uDE0B',
+        '\uD83D\uDE0C', '\uD83D\uDE0D', '\uD83D\uDE0E', '\uD83D\uDE0F',
+        '\uD83D\uDE10', '\uD83D\uDE11', '\uD83D\uDE12', '\uD83D\uDE13',
+        '\uD83D\uDE14', '\uD83D\uDE15', '\uD83D\uDE16', '\uD83D\uDE17',
+        '\uD83D\uDE18', '\uD83D\uDE19', '\uD83D\uDE1A', '\uD83D\uDE1B',
+        '\uD83D\uDE1C', '\uD83D\uDE1D', '\uD83D\uDE1E', '\uD83D\uDE1F',
+        '\uD83D\uDE20', '\uD83D\uDE21', '\uD83D\uDE22', '\uD83D\uDE23',
+        '\uD83D\uDE24', '\uD83D\uDE25', '\uD83D\uDE26', '\uD83D\uDE27',
+        '\uD83D\uDE28', '\uD83D\uDE29', '\uD83D\uDE2A', '\uD83D\uDE2B',
+        '\uD83D\uDE2C', '\uD83D\uDE2D', '\uD83D\uDE2E', '\uD83D\uDE2F',
+        '\uD83D\uDE30', '\uD83D\uDE31', '\uD83D\uDE32', '\uD83D\uDE33',
+        '\uD83D\uDE34', '\uD83D\uDE35', '\uD83D\uDE36', '\uD83D\uDE37',
     ];
 
     /**
@@ -318,6 +318,8 @@ class Miscellaneous extends Base
      */
     public static function emoji()
     {
-        return static::randomElement(static::$emoji);
+        $randomElement = static::randomElement(static::$emoji);
+        $unicodeHex = preg_replace("/\\\uD83D\\\uDE([0-9A-F]*)/", "&#x1F6\\1;", $randomElement);
+        return html_entity_decode($unicodeHex, ENT_NOQUOTES, 'UTF-8');
     }
 }

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -10,7 +10,7 @@ class Miscellaneous extends Base
      *
      * U+1F600 - U+1F637 in Unicode Codepoint Escape Syntax
      */
-    public static $emoji = [
+    protected static $emoji = [
         "\u{1F600}", "\u{1F601}", "\u{1F602}", "\u{1F603}",
         "\u{1F604}", "\u{1F605}", "\u{1F606}", "\u{1F607}",
         "\u{1F608}", "\u{1F609}", "\u{1F60A}", "\u{1F60B}",

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -8,23 +8,23 @@ class Miscellaneous extends Base
      * @link https://en.wikipedia.org/wiki/Emoji#Unicode_blocks
      * On date of 2017-03-26
      *
-     * U+1F600 - U+1F637 as their UTF-8 Pairings
+     * U+1F600 - U+1F637 in Unicode Codepoint Escape Syntax
      */
     protected static $emoji = [
-        '\uD83D\uDE00', '\uD83D\uDE01', '\uD83D\uDE02', '\uD83D\uDE03',
-        '\uD83D\uDE04', '\uD83D\uDE05', '\uD83D\uDE06', '\uD83D\uDE07',
-        '\uD83D\uDE08', '\uD83D\uDE09', '\uD83D\uDE0A', '\uD83D\uDE0B',
-        '\uD83D\uDE0C', '\uD83D\uDE0D', '\uD83D\uDE0E', '\uD83D\uDE0F',
-        '\uD83D\uDE10', '\uD83D\uDE11', '\uD83D\uDE12', '\uD83D\uDE13',
-        '\uD83D\uDE14', '\uD83D\uDE15', '\uD83D\uDE16', '\uD83D\uDE17',
-        '\uD83D\uDE18', '\uD83D\uDE19', '\uD83D\uDE1A', '\uD83D\uDE1B',
-        '\uD83D\uDE1C', '\uD83D\uDE1D', '\uD83D\uDE1E', '\uD83D\uDE1F',
-        '\uD83D\uDE20', '\uD83D\uDE21', '\uD83D\uDE22', '\uD83D\uDE23',
-        '\uD83D\uDE24', '\uD83D\uDE25', '\uD83D\uDE26', '\uD83D\uDE27',
-        '\uD83D\uDE28', '\uD83D\uDE29', '\uD83D\uDE2A', '\uD83D\uDE2B',
-        '\uD83D\uDE2C', '\uD83D\uDE2D', '\uD83D\uDE2E', '\uD83D\uDE2F',
-        '\uD83D\uDE30', '\uD83D\uDE31', '\uD83D\uDE32', '\uD83D\uDE33',
-        '\uD83D\uDE34', '\uD83D\uDE35', '\uD83D\uDE36', '\uD83D\uDE37',
+        "\u{1F600}", "\u{1F601}", "\u{1F602}", "\u{1F603}",
+        "\u{1F604}", "\u{1F605}", "\u{1F606}", "\u{1F607}",
+        "\u{1F608}", "\u{1F609}", "\u{1F60A}", "\u{1F60B}",
+        "\u{1F60C}", "\u{1F60D}", "\u{1F60E}", "\u{1F60F}",
+        "\u{1F610}", "\u{1F611}", "\u{1F612}", "\u{1F613}",
+        "\u{1F614}", "\u{1F615}", "\u{1F616}", "\u{1F617}",
+        "\u{1F618}", "\u{1F619}", "\u{1F61A}", "\u{1F61B}",
+        "\u{1F61C}", "\u{1F61D}", "\u{1F61E}", "\u{1F61F}",
+        "\u{1F620}", "\u{1F621}", "\u{1F622}", "\u{1F623}",
+        "\u{1F624}", "\u{1F625}", "\u{1F626}", "\u{1F627}",
+        "\u{1F628}", "\u{1F629}", "\u{1F62A}", "\u{1F62B}",
+        "\u{1F62C}", "\u{1F62D}", "\u{1F62E}", "\u{1F62F}",
+        "\u{1F630}", "\u{1F631}", "\u{1F632}", "\u{1F633}",
+        "\u{1F634}", "\u{1F635}", "\u{1F636}", "\u{1F637}",
     ];
 
     /**
@@ -318,8 +318,6 @@ class Miscellaneous extends Base
      */
     public static function emoji()
     {
-        $randomElement = static::randomElement(static::$emoji);
-        $unicodeHex = preg_replace("/\\\uD83D\\\uDE([0-9A-F]*)/", '&#x1F6\\1;', $randomElement);
-        return html_entity_decode($unicodeHex, ENT_NOQUOTES, 'UTF-8');
+        return static::randomElement(static::$emoji);
     }
 }

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -12,7 +12,7 @@ class Payment extends Base
     protected static $cardVendors = [
         'Visa', 'Visa', 'Visa', 'Visa', 'Visa',
         'MasterCard', 'MasterCard', 'MasterCard', 'MasterCard', 'MasterCard',
-        'American Express', 'Discover Card', 'Visa Retired'
+        'American Express', 'Discover Card', 'Visa Retired', 'JCB',
     ];
 
     /**
@@ -62,6 +62,10 @@ class Payment extends Base
         ],
         'Discover Card' => [
             '6011###########'
+        ],
+        'JCB' => [
+            '3528###########',
+            '3589###########',
         ],
     ];
 
@@ -146,9 +150,9 @@ class Payment extends Base
     /**
      * Returns the String of a credit card number.
      *
-     * @param string  $type      Supporting any of 'Visa', 'MasterCard', 'American Express', and 'Discover'
+     * @param string $type Supporting any of 'Visa', 'MasterCard', 'American Express', 'Discover' and 'JCB'
      * @param bool $formatted Set to true if the output string should contain one separator every 4 digits
-     * @param string  $separator Separator string for formatting card number. Defaults to dash (-).
+     * @param string $separator Separator string for formatting card number. Defaults to dash (-).
      * @return string
      *
      * @example '4485480221084675'

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -10,19 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-    public function localeDataProvider()
-    {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        $localePaths = array_filter(glob($providerPath . '/*', GLOB_ONLYDIR));
-        $locales = [];
-        foreach ($localePaths as $path) {
-            $parts = explode('/', $path);
-            $locales[] = [$parts[count($parts) - 1]];
-        }
-
-        return $locales;
-    }
-
     /**
      * @dataProvider localeDataProvider
      */
@@ -67,19 +54,9 @@ final class InternetTest extends TestCase
 
     public function loadLocalProviders($locale)
     {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        if (file_exists($providerPath . '/' . $locale . '/Internet.php')) {
-            $internet = "\\Faker\\Provider\\$locale\\Internet";
-            $this->faker->addProvider(new $internet($this->faker));
-        }
-        if (file_exists($providerPath . '/' . $locale . '/Person.php')) {
-            $person = "\\Faker\\Provider\\$locale\\Person";
-            $this->faker->addProvider(new $person($this->faker));
-        }
-        if (file_exists($providerPath . '/' . $locale . '/Company.php')) {
-            $company = "\\Faker\\Provider\\$locale\\Company";
-            $this->faker->addProvider(new $company($this->faker));
-        }
+        $this->loadLocalProvider($locale, 'Internet');
+        $this->loadLocalProvider($locale, 'Person');
+        $this->loadLocalProvider($locale, 'Company');
     }
 
     public function testPasswordIsValid()

--- a/test/Faker/Provider/LocalizationTest.php
+++ b/test/Faker/Provider/LocalizationTest.php
@@ -7,21 +7,13 @@ use Faker\Test\TestCase;
 
 final class LocalizationTest extends TestCase
 {
-    public function testLocalizedNameProvidersDoNotThrowErrors()
+    /**
+     * @dataProvider localeDataProvider
+     */
+    public function testLocalizedProvidersDoNotThrowErrors(string $locale): void
     {
-        foreach (glob(__DIR__ . '/../../../src/Faker/Provider/*/Person.php') as $localizedPerson) {
-            preg_match('#/([a-zA-Z_]+)/Person\.php#', $localizedPerson, $matches);
-            $faker = Factory::create($matches[1]);
-            self::assertNotNull($faker->name(), 'Localized Name Provider ' . $matches[1] . ' does not throw errors');
-        }
-    }
-
-    public function testLocalizedAddressProvidersDoNotThrowErrors()
-    {
-        foreach (glob(__DIR__ . '/../../../src/Faker/Provider/*/Address.php') as $localizedAddress) {
-            preg_match('#/([a-zA-Z_]+)/Address\.php#', $localizedAddress, $matches);
-            $faker = Factory::create($matches[1]);
-            self::assertNotNull($faker->address(), 'Localized Address Provider ' . $matches[1] . ' does not throw errors');
-        }
+        $faker = Factory::create($locale);
+        self::assertNotNull($faker->name, 'Localized Name Provider ' . $locale . ' does not throw errors');
+        self::assertNotNull($faker->address, 'Localized Address Provider ' . $locale . ' does not throw errors');
     }
 }

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -35,7 +35,7 @@ final class PaymentTest extends TestCase
 
     public function testCreditCardTypeReturnsValidVendorName()
     {
-        self::assertContains($this->faker->creditCardType, ['Visa', 'Visa Retired', 'MasterCard', 'American Express', 'Discover Card']);
+        self::assertContains($this->faker->creditCardType, ['Visa', 'Visa Retired', 'MasterCard', 'American Express', 'Discover Card', 'JCB']);
     }
 
     public function creditCardNumberProvider()
@@ -44,7 +44,8 @@ final class PaymentTest extends TestCase
             ['Discover Card', '/^6011\d{12}$/'],
             ['Visa', '/^4\d{15}$/'],
             ['Visa Retired', '/^4\d{12}$/'],
-            ['MasterCard', '/^(5[1-5]|2[2-7])\d{14}$/']
+            ['MasterCard', '/^(5[1-5]|2[2-7])\d{14}$/'],
+            ['JCB', '/^35(28|89)\d{12,15}$/'],
         ];
     }
 

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -12,27 +12,6 @@ use Faker\Test\TestCase;
 
 final class PaymentTest extends TestCase
 {
-    public function localeDataProvider()
-    {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        $localePaths = array_filter(glob($providerPath . '/*', GLOB_ONLYDIR));
-        foreach ($localePaths as $path) {
-            $parts = explode('/', $path);
-            $locales[] = [$parts[count($parts) - 1]];
-        }
-
-        return $locales;
-    }
-
-    public function loadLocalProviders($locale)
-    {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        if (file_exists($providerPath . '/' . $locale . '/Payment.php')) {
-            $payment = "\\Faker\\Provider\\$locale\\Payment";
-            $this->faker->addProvider(new $payment($this->faker));
-        }
-    }
-
     public function testCreditCardTypeReturnsValidVendorName()
     {
         self::assertContains($this->faker->creditCardType, ['Visa', 'Visa Retired', 'MasterCard', 'American Express', 'Discover Card', 'JCB']);
@@ -157,7 +136,7 @@ final class PaymentTest extends TestCase
             return;
         }
 
-        $this->loadLocalProviders($locale);
+        $this->loadLocalProvider($locale, 'Payment');
 
         try {
             $iban = $this->faker->bankAccountNumber;

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -25,6 +25,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testAddress($locale = null)
@@ -40,6 +41,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testCompany($locale = null)
@@ -52,6 +54,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testDateTime($locale = null)
@@ -65,6 +68,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testInternet($locale = null)
@@ -86,6 +90,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testPerson($locale = null)
@@ -101,6 +106,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testPhoneNumber($locale = null)
@@ -113,6 +119,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testUserAgent($locale = null)
@@ -134,52 +141,5 @@ final class ProviderOverrideTest extends TestCase
         $faker = Faker\Factory::create($locale);
 
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->uuid);
-    }
-
-
-    /**
-     * @return array
-     */
-    public function localeDataProvider()
-    {
-        $locales = $this->getAllLocales();
-        $data = [];
-
-        foreach ($locales as $locale) {
-            $data[] = [
-                $locale
-            ];
-        }
-
-        return $data;
-    }
-
-
-    /**
-     * Returns all locales as array values
-     *
-     * @return array
-     */
-    private function getAllLocales()
-    {
-        static $locales = [];
-
-        if (! empty($locales)) {
-            return $locales;
-        }
-
-        // Finding all PHP files in the xx_XX directories
-        $providerDir = __DIR__ . '/../../../src/Faker/Provider';
-        foreach (glob($providerDir . '/*_*/*.php') as $file) {
-            $localisation = basename(dirname($file));
-
-            if (isset($locales[ $localisation ])) {
-                continue;
-            }
-
-            $locales[ $localisation ] = $localisation;
-        }
-
-        return $locales;
     }
 }

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -27,7 +27,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Asserts that a string matches a given regular expression.
      *
-     * @throws ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
@@ -38,7 +38,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Asserts that a string does not match a given regular expression.
      *
-     * @throws ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
@@ -50,6 +50,31 @@ abstract class TestCase extends BaseTestCase
             ),
             $message
         );
+    }
+
+    public static function localeDataProvider(): array
+    {
+        $locales = [];
+
+        foreach (self::getAllLocales() as $locale) {
+            $locales[$locale] = [$locale];
+        }
+
+        return $locales;
+    }
+
+    protected static function getAllLocales(): array
+    {
+        return array_map('basename', glob(__DIR__ . '/../../src/Faker/Provider/*_*', GLOB_ONLYDIR));
+    }
+
+    protected function loadLocalProvider(string $locale, string $provider): void
+    {
+        $providerClass = "\\Faker\\Provider\\$locale\\$provider";
+
+        if (class_exists($providerClass)) {
+            $this->faker->addProvider(new $providerClass($this->faker));
+        }
     }
 
     protected function getProviders(): iterable


### PR DESCRIPTION
### What is the reason for this PR?

Currently emoji are listed as UTF-8 pairings and decoded via `json_decode`, which is our only reason to require `ext-json` (see #120).

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR changes the emoji generation so that `json_decode` is removed. The according unit test is still green.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
