### PR TITLE
Refactor test providers

### DIFF
--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -10,19 +10,6 @@ use Faker\Test\TestCase;
 
 final class InternetTest extends TestCase
 {
-    public function localeDataProvider()
-    {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        $localePaths = array_filter(glob($providerPath . '/*', GLOB_ONLYDIR));
-        $locales = [];
-        foreach ($localePaths as $path) {
-            $parts = explode('/', $path);
-            $locales[] = [$parts[count($parts) - 1]];
-        }
-
-        return $locales;
-    }
-
     /**
      * @dataProvider localeDataProvider
      */
@@ -67,19 +54,9 @@ final class InternetTest extends TestCase
 
     public function loadLocalProviders($locale)
     {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        if (file_exists($providerPath . '/' . $locale . '/Internet.php')) {
-            $internet = "\\Faker\\Provider\\$locale\\Internet";
-            $this->faker->addProvider(new $internet($this->faker));
-        }
-        if (file_exists($providerPath . '/' . $locale . '/Person.php')) {
-            $person = "\\Faker\\Provider\\$locale\\Person";
-            $this->faker->addProvider(new $person($this->faker));
-        }
-        if (file_exists($providerPath . '/' . $locale . '/Company.php')) {
-            $company = "\\Faker\\Provider\\$locale\\Company";
-            $this->faker->addProvider(new $company($this->faker));
-        }
+        $this->loadLocalProvider($locale, 'Internet');
+        $this->loadLocalProvider($locale, 'Person');
+        $this->loadLocalProvider($locale, 'Company');
     }
 
     public function testPasswordIsValid()

--- a/test/Faker/Provider/LocalizationTest.php
+++ b/test/Faker/Provider/LocalizationTest.php
@@ -7,21 +7,13 @@ use Faker\Test\TestCase;
 
 final class LocalizationTest extends TestCase
 {
-    public function testLocalizedNameProvidersDoNotThrowErrors()
+    /**
+     * @dataProvider localeDataProvider
+     */
+    public function testLocalizedProvidersDoNotThrowErrors(string $locale): void
     {
-        foreach (glob(__DIR__ . '/../../../src/Faker/Provider/*/Person.php') as $localizedPerson) {
-            preg_match('#/([a-zA-Z_]+)/Person\.php#', $localizedPerson, $matches);
-            $faker = Factory::create($matches[1]);
-            self::assertNotNull($faker->name(), 'Localized Name Provider ' . $matches[1] . ' does not throw errors');
-        }
-    }
-
-    public function testLocalizedAddressProvidersDoNotThrowErrors()
-    {
-        foreach (glob(__DIR__ . '/../../../src/Faker/Provider/*/Address.php') as $localizedAddress) {
-            preg_match('#/([a-zA-Z_]+)/Address\.php#', $localizedAddress, $matches);
-            $faker = Factory::create($matches[1]);
-            self::assertNotNull($faker->address(), 'Localized Address Provider ' . $matches[1] . ' does not throw errors');
-        }
+        $faker = Factory::create($locale);
+        self::assertNotNull($faker->name, 'Localized Name Provider ' . $locale . ' does not throw errors');
+        self::assertNotNull($faker->address, 'Localized Address Provider ' . $locale . ' does not throw errors');
     }
 }

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -12,27 +12,6 @@ use Faker\Test\TestCase;
 
 final class PaymentTest extends TestCase
 {
-    public function localeDataProvider()
-    {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        $localePaths = array_filter(glob($providerPath . '/*', GLOB_ONLYDIR));
-        foreach ($localePaths as $path) {
-            $parts = explode('/', $path);
-            $locales[] = [$parts[count($parts) - 1]];
-        }
-
-        return $locales;
-    }
-
-    public function loadLocalProviders($locale)
-    {
-        $providerPath = realpath(__DIR__ . '/../../../src/Faker/Provider');
-        if (file_exists($providerPath . '/' . $locale . '/Payment.php')) {
-            $payment = "\\Faker\\Provider\\$locale\\Payment";
-            $this->faker->addProvider(new $payment($this->faker));
-        }
-    }
-
     public function testCreditCardTypeReturnsValidVendorName()
     {
         self::assertContains($this->faker->creditCardType, ['Visa', 'Visa Retired', 'MasterCard', 'American Express', 'Discover Card']);
@@ -156,7 +135,7 @@ final class PaymentTest extends TestCase
             return;
         }
 
-        $this->loadLocalProviders($locale);
+        $this->loadLocalProvider($locale, 'Payment');
 
         try {
             $iban = $this->faker->bankAccountNumber;

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -25,6 +25,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testAddress($locale = null)
@@ -40,6 +41,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testCompany($locale = null)
@@ -52,6 +54,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testDateTime($locale = null)
@@ -65,6 +68,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testInternet($locale = null)
@@ -86,6 +90,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testPerson($locale = null)
@@ -101,6 +106,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testPhoneNumber($locale = null)
@@ -113,6 +119,7 @@ final class ProviderOverrideTest extends TestCase
 
     /**
      * @dataProvider localeDataProvider
+     *
      * @param string $locale
      */
     public function testUserAgent($locale = null)
@@ -134,52 +141,5 @@ final class ProviderOverrideTest extends TestCase
         $faker = Faker\Factory::create($locale);
 
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->uuid);
-    }
-
-
-    /**
-     * @return array
-     */
-    public function localeDataProvider()
-    {
-        $locales = $this->getAllLocales();
-        $data = [];
-
-        foreach ($locales as $locale) {
-            $data[] = [
-                $locale
-            ];
-        }
-
-        return $data;
-    }
-
-
-    /**
-     * Returns all locales as array values
-     *
-     * @return array
-     */
-    private function getAllLocales()
-    {
-        static $locales = [];
-
-        if (! empty($locales)) {
-            return $locales;
-        }
-
-        // Finding all PHP files in the xx_XX directories
-        $providerDir = __DIR__ . '/../../../src/Faker/Provider';
-        foreach (glob($providerDir . '/*_*/*.php') as $file) {
-            $localisation = basename(dirname($file));
-
-            if (isset($locales[ $localisation ])) {
-                continue;
-            }
-
-            $locales[ $localisation ] = $localisation;
-        }
-
-        return $locales;
     }
 }

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -27,7 +27,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Asserts that a string matches a given regular expression.
      *
-     * @throws ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
@@ -38,7 +38,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Asserts that a string does not match a given regular expression.
      *
-     * @throws ExpectationFailedException
+     * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
@@ -84,7 +84,7 @@ abstract class TestCase extends BaseTestCase
 
     protected function loadLocalProvider(string $locale, string $provider): void
     {
-        $providerClass = "Faker\\Provider\\$locale\\$provider";
+        $providerClass = "\\Faker\\Provider\\$locale\\$provider";
 
         if (class_exists($providerClass)) {
             $this->faker->addProvider(new $providerClass($this->faker));

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -52,6 +52,45 @@ abstract class TestCase extends BaseTestCase
         );
     }
 
+    public static function localeDataProvider(): array
+    {
+        return array_map(function ($locale) {
+            return [$locale];
+        }, self::getAllLocales());
+    }
+
+    protected static function getAllLocales(): array
+    {
+        static $locales = [];
+
+        if (!empty($locales)) {
+            return $locales;
+        }
+
+        // Finding all PHP files in the xx_XX directories
+        $providerDir = __DIR__ . '/../../src/Faker/Provider';
+        foreach (glob($providerDir . '/*_*/*.php') as $file) {
+            $localisation = basename(dirname($file));
+
+            if (isset($locales[$localisation])) {
+                continue;
+            }
+
+            $locales[$localisation] = $localisation;
+        }
+
+        return $locales;
+    }
+
+    protected function loadLocalProvider(string $locale, string $provider): void
+    {
+        $providerClass = "Faker\\Provider\\$locale\\$provider";
+
+        if (class_exists($providerClass)) {
+            $this->faker->addProvider(new $providerClass($this->faker));
+        }
+    }
+
     protected function getProviders(): iterable
     {
         return [];

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -54,32 +54,18 @@ abstract class TestCase extends BaseTestCase
 
     public static function localeDataProvider(): array
     {
-        return array_map(function ($locale) {
-            return [$locale];
-        }, self::getAllLocales());
+        $locales = [];
+
+        foreach (self::getAllLocales() as $locale) {
+            $locales[$locale] = [$locale];
+        }
+
+        return $locales;
     }
 
     protected static function getAllLocales(): array
     {
-        static $locales = [];
-
-        if (!empty($locales)) {
-            return $locales;
-        }
-
-        // Finding all PHP files in the xx_XX directories
-        $providerDir = __DIR__ . '/../../src/Faker/Provider';
-        foreach (glob($providerDir . '/*_*/*.php') as $file) {
-            $localisation = basename(dirname($file));
-
-            if (isset($locales[$localisation])) {
-                continue;
-            }
-
-            $locales[$localisation] = $localisation;
-        }
-
-        return $locales;
+        return array_map('basename', glob(__DIR__ . '/../../src/Faker/Provider/*_*', GLOB_ONLYDIR));
     }
 
     protected function loadLocalProvider(string $locale, string $provider): void


### PR DESCRIPTION
### What is the reason for this PR?

This change refactors tests to reduce `glob()` and `file_exists()` calls for localized providers.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

- Added method `loadLocalProvider` to load a provider for specific locale.
- Moved `getAllLocales` and `localeDataProvider` to base `TestCase` to avoid code duplication in tests.
- Removed `static` "cache" for locales
- Used named providers so that they will appear as following:

![image](https://user-images.githubusercontent.com/1985514/101604892-1d58c780-3a34-11eb-8c7b-8269b7186aa8.png)


### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
