### PR TITLE
Fix: Remove trailing space

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         operating-system:
           - 'ubuntu-latest'
-        php-version: 
+        php-version:
           - '7.1'
           - '7.2'
           - '7.3'


### PR DESCRIPTION
This PR

* [x] removes trailing spaces from a workflow configuration file