### PR TITLE
Fix #133 regex dot in character class

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -495,7 +495,9 @@ class Base
         }, $regex);
         // All [ABC] become B (or A or C)
         $regex = preg_replace_callback('/\[([^\]]+)\]/', function ($matches) {
-            return Base::randomElement(str_split($matches[1]));
+            $randomElement = Base::randomElement(str_split($matches[1]));
+            //[.] should not be a random character, but a literal .
+            return str_replace('.', '\.', $randomElement);
         }, $regex);
         // replace \d with number and \w with letter and . with ascii
         $regex = preg_replace_callback('/\\\w/', 'static::randomLetter', $regex);

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -337,6 +337,7 @@ final class BaseTest extends TestCase
             ['[a-z]{2,3}', 'brackets quantifiers on character class range'],
             ['(a|b){2,3}', 'brackets quantifiers on alternation'],
             ['\.\*\?\+', 'escaped characters'],
+            ['[.]', 'dots'],
             ['[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}', 'complex regex']
         ];
     }

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -338,7 +338,8 @@ final class BaseTest extends TestCase
             ['[a-z]{2,3}', 'brackets quantifiers on character class range'],
             ['(a|b){2,3}', 'brackets quantifiers on alternation'],
             ['\.\*\?\+', 'escaped characters'],
-            ['[.]', 'literal dot'],
+            ['[.]', 'literal dot in character class'],
+            ['.', 'catch-all dot'],
             ['[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}', 'complex regex']
         ];
     }

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -337,7 +337,7 @@ final class BaseTest extends TestCase
             ['[a-z]{2,3}', 'brackets quantifiers on character class range'],
             ['(a|b){2,3}', 'brackets quantifiers on alternation'],
             ['\.\*\?\+', 'escaped characters'],
-            ['[.]', 'dots'],
+            ['[.]', 'literal dot'],
             ['[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}', 'complex regex']
         ];
     }

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -309,7 +309,8 @@ final class BaseTest extends TestCase
             ['azeQSDF1234', 'azeQSDF1234', 'does not change non regex chars'],
             ['foo(bar){1}', 'foobar', 'replaces regex characters'],
             ['', '', 'supports empty string'],
-            ['/^foo(bar){1}$/', 'foobar', 'ignores regex delimiters']
+            ['/^foo(bar){1}$/', 'foobar', 'ignores regex delimiters'],
+            ['/[.]/', '.', 'leaves literal dot in braces'],
         ];
     }
 


### PR DESCRIPTION
### What is the reason for this PR?

`regexify` produces a random character instead of a literal dot when called within a character class (e.g. `[.]`).

- [ ] Fixed an issue (resolve #133)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Fixes the issue, adds test to verify.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
