### PR TITLE
Fix: Configure platform for development tools

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -5,6 +5,9 @@
         "phpstan/phpstan-deprecation-rules": "0.12.5"
     },
     "config": {
+        "platform": {
+            "php": "7.1.33"
+        },
         "preferred-install": "dist"
     }
 }

--- a/vendor-bin/phpstan/composer.lock
+++ b/vendor-bin/phpstan/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "760cb19781820fe1328102d73ac5f884",
+    "content-hash": "287b42083ac34da5b23c76d676fdaf13",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -132,5 +132,8 @@
         "php": "^7.1 || ^8.0"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.1.33"
+    },
     "plugin-api-version": "2.0.0"
 }

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -4,6 +4,9 @@
         "psalm/phar": "4.3.1"
     },
     "config": {
+        "platform": {
+            "php": "7.1.33"
+        },
         "preferred-install": "dist"
     }
 }

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcb37faa48c68b0884acf4bca42ded25",
+    "content-hash": "b9f7939ef31892400dd03830e09f90fb",
     "packages": [
         {
             "name": "psalm/phar",
@@ -52,5 +52,8 @@
         "php": "^7.1 || ^8.0"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.1.33"
+    },
     "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This PR

* [x] configures the platform for development tools

Follows #131.

💁‍♂️ We allow usage and development on PHP 7.1, and we do not want to install dependencies that can not be installed on PHP 7.1.