### PR TITLE
Fix: Avoid exact version constraints

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,8 +1,8 @@
 {
     "require": {
         "php": "^7.1 || ^8.0",
-        "phpstan/phpstan": "0.12.59",
-        "phpstan/phpstan-deprecation-rules": "0.12.5"
+        "phpstan/phpstan": "^0.12.59",
+        "phpstan/phpstan-deprecation-rules": "^0.12.5"
     },
     "config": {
         "platform": {

--- a/vendor-bin/phpstan/composer.lock
+++ b/vendor-bin/phpstan/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "287b42083ac34da5b23c76d676fdaf13",
+    "content-hash": "4e5e60e61017f7cd08652c3a4843fea1",
     "packages": [
         {
             "name": "phpstan/phpstan",

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^7.1 || ^8.0",
-        "vimeo/psalm": "4.3.1"
+        "vimeo/psalm": "^4.3.1"
     },
     "config": {
         "platform": {

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90ca74459c01c701804f84c58518f14a",
+    "content-hash": "b313a9808361069a1c54cf7d15302080",
     "packages": [
         {
             "name": "amphp/amp",


### PR DESCRIPTION
This PR

* [x] avoids exact version constraints for development tools

Follows #131.