### PR TITLE
toUpper and toLower usage consistency

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -102,7 +102,7 @@ class Internet extends Base
         $format = static::randomElement(static::$userNameFormats);
         $username = static::bothify($this->generator->parse($format));
 
-        $username = strtolower(static::transliterate($username));
+        $username = static::toLower(static::transliterate($username));
 
         // check if transliterate() didn't support the language and removed all letters
         if (trim($username, '._') === '') {
@@ -140,7 +140,7 @@ class Internet extends Base
     {
         $lastName = $this->generator->format('lastName');
 
-        $lastName = strtolower(static::transliterate($lastName));
+        $lastName = static::toLower(static::transliterate($lastName));
 
         // check if transliterate() didn't support the language and removed all letters
         if (trim($lastName, '._') === '') {

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -230,7 +230,7 @@ class Payment extends Base
      */
     public static function iban($countryCode = null, $prefix = '', $length = null)
     {
-        $countryCode = is_null($countryCode) ? self::randomKey(self::$ibanFormats) : strtoupper($countryCode);
+        $countryCode = is_null($countryCode) ? self::randomKey(self::$ibanFormats) : static::toUpper($countryCode);
 
         $format = !isset(static::$ibanFormats[$countryCode]) ? null : static::$ibanFormats[$countryCode];
         if ($length === null) {
@@ -260,10 +260,10 @@ class Payment extends Base
             switch ($class) {
                 default:
                 case 'c':
-                    $result .= Miscellaneous::boolean() ? static::randomDigit() : strtoupper(static::randomLetter());
+                    $result .= Miscellaneous::boolean() ? static::randomDigit() : static::toUpper(static::randomLetter());
                     break;
                 case 'a':
-                    $result .= strtoupper(static::randomLetter());
+                    $result .= static::toUpper(static::randomLetter());
                     break;
                 case 'n':
                     $result .= static::randomDigit();

--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -147,7 +147,7 @@ class Person extends \Faker\Provider\Person
             $birthdate = $this->generator->dateTimeThisCentury();
         }
         $birthDateString = $birthdate->format('ymd');
-        switch (strtolower($gender)) {
+        switch (static::toLower($gender)) {
             case static::GENDER_FEMALE:
                 $genderDigit = self::numberBetween(0, 4);
                 break;

--- a/src/Faker/Provider/it_IT/Person.php
+++ b/src/Faker/Provider/it_IT/Person.php
@@ -93,6 +93,6 @@ class Person extends \Faker\Provider\Person
      */
     public static function taxId()
     {
-        return strtoupper(static::bothify('??????##?##?###?'));
+        return static::toUpper(static::bothify('??????##?##?###?'));
     }
 }

--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -77,7 +77,7 @@ class Company extends \Faker\Provider\Company
                 $companyName = static::randomElement(static::$product) . ' ' . static::randomElement(static::$type);
                 break;
             case 1:
-                $companyName = static::randomElement(static::$product) . strtolower(static::randomElement(static::$type));
+                $companyName = static::randomElement(static::$product) . static::toLower(static::randomElement(static::$type));
                 break;
             case 2:
                 $companyName = static::randomElement(static::$store) . ' ' . $this->generator->lastName;


### PR DESCRIPTION
### What is the reason for this PR?

Usage of `strotupper`/`strtolower` and the `Base::toUpper()` and `Base::toLower()` is inconsistent. 

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Replaces all `strotupper`/`strtolower` with Base method usage.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
