### PR TITLE
Enabled php_unit_test_case_self_method_calls fixer

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -32,6 +32,7 @@ enabled:
   - php_unit_no_expectation_annotation
   - php_unit_ordered_covers
   - php_unit_set_up_tear_down_visibility
+  - php_unit_test_case_self_method_calls
   - phpdoc_indent
   - phpdoc_inline_tag_normalizer
   - phpdoc_no_package

--- a/test/Faker/Calculator/IbanTest.php
+++ b/test/Faker/Calculator/IbanTest.php
@@ -85,7 +85,7 @@ final class IbanTest extends TestCase
      */
     public function testChecksum($iban, $checksum)
     {
-        $this->assertEquals($checksum, Iban::checksum($iban), $iban);
+        self::assertEquals($checksum, Iban::checksum($iban), $iban);
     }
 
     public function validatorProvider()
@@ -235,7 +235,7 @@ final class IbanTest extends TestCase
      */
     public function testIsValid($iban, $isValid)
     {
-        $this->assertEquals($isValid, Iban::isValid($iban), $iban);
+        self::assertEquals($isValid, Iban::isValid($iban), $iban);
     }
 
     public function alphaToNumberProvider()
@@ -275,7 +275,7 @@ final class IbanTest extends TestCase
      */
     public function testAlphaToNumber($letter, $number)
     {
-        $this->assertEquals($number, Iban::alphaToNumber($letter), $letter);
+        self::assertEquals($number, Iban::alphaToNumber($letter), $letter);
     }
 
     public function mod97Provider()
@@ -300,6 +300,6 @@ final class IbanTest extends TestCase
      */
     public function testMod97($number, $result)
     {
-        $this->assertEquals($result, Iban::mod97($number), $number);
+        self::assertEquals($result, Iban::mod97($number), $number);
     }
 }

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -13,7 +13,7 @@ final class BarcodeTest extends TestCase
     {
         $code = $this->faker->ean8();
         self::assertMatchesRegularExpression('/^\d{8}$/i', $code);
-        $this->assertTrue(Ean::isValid($code));
+        self::assertTrue(Ean::isValid($code));
     }
 
     public function testEan13()

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -34,8 +34,8 @@ final class BiasedTest extends TestCase
             $assumed = (1 / self::MAX * $number) - (1 / self::MAX * ($number - 1));
             // calculate the fraction of the whole area
             $assumed /= 1;
-            $this->assertGreaterThan(self::NUMBERS * $assumed * .95, $amount, 'Value was more than 5 percent under the expected value');
-            $this->assertLessThan(self::NUMBERS * $assumed * 1.05, $amount, 'Value was more than 5 percent over the expected value');
+            self::assertGreaterThan(self::NUMBERS * $assumed * .95, $amount, 'Value was more than 5 percent under the expected value');
+            self::assertLessThan(self::NUMBERS * $assumed * 1.05, $amount, 'Value was more than 5 percent over the expected value');
         }
     }
 
@@ -48,8 +48,8 @@ final class BiasedTest extends TestCase
             $assumed = 0.5 * (1 / self::MAX * $number) ** 2 - 0.5 * (1 / self::MAX * ($number - 1)) ** 2;
             // calculate the fraction of the whole area
             $assumed /= 1 ** 2 * .5;
-            $this->assertGreaterThan(self::NUMBERS * $assumed * .9, $amount, 'Value was more than 10 percent under the expected value');
-            $this->assertLessThan(self::NUMBERS * $assumed * 1.1, $amount, 'Value was more than 10 percent over the expected value');
+            self::assertGreaterThan(self::NUMBERS * $assumed * .9, $amount, 'Value was more than 10 percent under the expected value');
+            self::assertLessThan(self::NUMBERS * $assumed * 1.1, $amount, 'Value was more than 10 percent over the expected value');
         }
     }
 
@@ -64,8 +64,8 @@ final class BiasedTest extends TestCase
             $assumed += 1 / self::MAX;
             // calculate the fraction of the whole area
             $assumed /= 1 ** 2 * .5;
-            $this->assertGreaterThan(self::NUMBERS * $assumed * .9, $amount, 'Value was more than 10 percent under the expected value');
-            $this->assertLessThan(self::NUMBERS * $assumed * 1.1, $amount, 'Value was more than 10 percent over the expected value');
+            self::assertGreaterThan(self::NUMBERS * $assumed * .9, $amount, 'Value was more than 10 percent under the expected value');
+            self::assertLessThan(self::NUMBERS * $assumed * 1.1, $amount, 'Value was more than 10 percent over the expected value');
         }
     }
 

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -33,8 +33,8 @@ final class DateTimeTest extends TestCase
          * timezone over the system timezone.
          */
         $date = DateTimeProvider::dateTime();
-        $this->assertNotSame($systemTimezone, $date->getTimezone()->getName());
-        $this->assertSame($this->defaultTz, $date->getTimezone()->getName());
+        self::assertNotSame($systemTimezone, $date->getTimezone()->getName());
+        self::assertSame($this->defaultTz, $date->getTimezone()->getName());
 
         /**
          * Restore the system timezone.
@@ -59,8 +59,8 @@ final class DateTimeTest extends TestCase
          * and not the system timezone.
          */
         $date = DateTimeProvider::dateTime();
-        $this->assertSame($systemTimezone, $date->getTimezone()->getName());
-        $this->assertNotSame($this->defaultTz, $date->getTimezone()->getName());
+        self::assertSame($systemTimezone, $date->getTimezone()->getName());
+        self::assertNotSame($this->defaultTz, $date->getTimezone()->getName());
 
         /**
          * Restore the system timezone.
@@ -71,115 +71,115 @@ final class DateTimeTest extends TestCase
     public function testUnixTime()
     {
         $timestamp = DateTimeProvider::unixTime();
-        $this->assertIsInt($timestamp);
-        $this->assertGreaterThanOrEqual(0, $timestamp);
-        $this->assertLessThanOrEqual(time(), $timestamp);
+        self::assertIsInt($timestamp);
+        self::assertGreaterThanOrEqual(0, $timestamp);
+        self::assertLessThanOrEqual(time(), $timestamp);
     }
 
     public function testDateTime()
     {
         $date = DateTimeProvider::dateTime();
-        $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('@0'), $date);
-        $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+        self::assertInstanceOf('\DateTime', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('@0'), $date);
+        self::assertLessThanOrEqual(new \DateTime(), $date);
+        self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testDateTimeWithTimezone()
     {
         $date = DateTimeProvider::dateTime('now', 'America/New_York');
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+        self::assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
     public function testDateTimeAD()
     {
         $date = DateTimeProvider::dateTimeAD();
-        $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('0000-01-01 00:00:00'), $date);
-        $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+        self::assertInstanceOf('\DateTime', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('0000-01-01 00:00:00'), $date);
+        self::assertLessThanOrEqual(new \DateTime(), $date);
+        self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testDateTimeThisCentury()
     {
         $date = DateTimeProvider::dateTimeThisCentury();
-        $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('-100 year'), $date);
-        $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+        self::assertInstanceOf('\DateTime', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('-100 year'), $date);
+        self::assertLessThanOrEqual(new \DateTime(), $date);
+        self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testDateTimeThisDecade()
     {
         $date = DateTimeProvider::dateTimeThisDecade();
-        $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('-10 year'), $date);
-        $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+        self::assertInstanceOf('\DateTime', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('-10 year'), $date);
+        self::assertLessThanOrEqual(new \DateTime(), $date);
+        self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testDateTimeThisYear()
     {
         $date = DateTimeProvider::dateTimeThisYear();
-        $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('first day of january this year'), $date);
-        $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+        self::assertInstanceOf('\DateTime', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('first day of january this year'), $date);
+        self::assertLessThanOrEqual(new \DateTime(), $date);
+        self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testDateTimeThisMonth()
     {
         $date = DateTimeProvider::dateTimeThisMonth();
-        $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('-1 month'), $date);
-        $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+        self::assertInstanceOf('\DateTime', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('-1 month'), $date);
+        self::assertLessThanOrEqual(new \DateTime(), $date);
+        self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testDateTimeThisCenturyWithTimezone()
     {
         $date = DateTimeProvider::dateTimeThisCentury('now', 'America/New_York');
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+        self::assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
     public function testDateTimeThisDecadeWithTimezone()
     {
         $date = DateTimeProvider::dateTimeThisDecade('now', 'America/New_York');
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+        self::assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
     public function testDateTimeThisYearWithTimezone()
     {
         $date = DateTimeProvider::dateTimeThisYear('now', 'America/New_York');
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+        self::assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
     public function testDateTimeThisMonthWithTimezone()
     {
         $date = DateTimeProvider::dateTimeThisMonth('now', 'America/New_York');
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+        self::assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
     public function testIso8601()
     {
         $date = DateTimeProvider::iso8601();
-        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-Z](\d{4})?$/', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('@0'), new \DateTime($date));
-        $this->assertLessThanOrEqual(new \DateTime(), new \DateTime($date));
+        self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-Z](\d{4})?$/', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('@0'), new \DateTime($date));
+        self::assertLessThanOrEqual(new \DateTime(), new \DateTime($date));
     }
 
     public function testDate()
     {
         $date = DateTimeProvider::date();
-        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('@0'), new \DateTime($date));
-        $this->assertLessThanOrEqual(new \DateTime(), new \DateTime($date));
+        self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $date);
+        self::assertGreaterThanOrEqual(new \DateTime('@0'), new \DateTime($date));
+        self::assertLessThanOrEqual(new \DateTime(), new \DateTime($date));
     }
 
     public function testTime()
     {
         $date = DateTimeProvider::time();
-        $this->assertMatchesRegularExpression('/^\d{2}:\d{2}:\d{2}$/', $date);
+        self::assertMatchesRegularExpression('/^\d{2}:\d{2}:\d{2}$/', $date);
     }
 
     /**
@@ -188,10 +188,10 @@ final class DateTimeTest extends TestCase
     public function testDateTimeBetween($start, $end)
     {
         $date = DateTimeProvider::dateTimeBetween($start, $end);
-        $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime($start), $date);
-        $this->assertLessThanOrEqual(new \DateTime($end), $date);
-        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+        self::assertInstanceOf('\DateTime', $date);
+        self::assertGreaterThanOrEqual(new \DateTime($start), $date);
+        self::assertLessThanOrEqual(new \DateTime($end), $date);
+        self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function providerDateTimeBetween()
@@ -210,16 +210,16 @@ final class DateTimeTest extends TestCase
     public function testDateTimeInInterval($start, $interval, $isInFuture)
     {
         $date = DateTimeProvider::dateTimeInInterval($start, $interval);
-        $this->assertInstanceOf('\DateTime', $date);
+        self::assertInstanceOf('\DateTime', $date);
 
         $_interval = \DateInterval::createFromDateString($interval);
         $_start = new \DateTime($start);
         if ($isInFuture) {
-            $this->assertGreaterThanOrEqual($_start, $date);
-            $this->assertLessThanOrEqual($_start->add($_interval), $date);
+            self::assertGreaterThanOrEqual($_start, $date);
+            self::assertLessThanOrEqual($_start->add($_interval), $date);
         } else {
-            $this->assertLessThanOrEqual($_start, $date);
-            $this->assertGreaterThanOrEqual($_start->add($_interval), $date);
+            self::assertLessThanOrEqual($_start, $date);
+            self::assertGreaterThanOrEqual($_start->add($_interval), $date);
         }
     }
 
@@ -258,23 +258,23 @@ final class DateTimeTest extends TestCase
 
         //regenerate Random Date with same seed and same maximum end timestamp
         mt_srand(1);
-        $this->assertEquals($unixTime, DateTimeProvider::unixTime($max));
-        $this->assertEquals($datetimeAD, DateTimeProvider::dateTimeAD($max));
-        $this->assertEquals($dateTime1, DateTimeProvider::dateTime($max));
-        $this->assertEquals($dateTimeBetween, DateTimeProvider::dateTimeBetween('2014-03-01 06:00:00', $max));
-        $this->assertEquals($date, DateTimeProvider::date('Y-m-d', $max));
-        $this->assertEquals($time, DateTimeProvider::time('H:i:s', $max));
-        $this->assertEquals($iso8601, DateTimeProvider::iso8601($max));
-        $this->assertEquals($dateTimeThisCentury, DateTimeProvider::dateTimeThisCentury($max));
-        $this->assertEquals($dateTimeThisDecade, DateTimeProvider::dateTimeThisDecade($max));
-        $this->assertEquals($dateTimeThisMonth, DateTimeProvider::dateTimeThisMonth($max));
-        $this->assertEquals($amPm, DateTimeProvider::amPm($max));
-        $this->assertEquals($dayOfMonth, DateTimeProvider::dayOfMonth($max));
-        $this->assertEquals($dayOfWeek, DateTimeProvider::dayOfWeek($max));
-        $this->assertEquals($month, DateTimeProvider::month($max));
-        $this->assertEquals($monthName, DateTimeProvider::monthName($max));
-        $this->assertEquals($year, DateTimeProvider::year($max));
-        $this->assertEquals($dateTimeThisYear, DateTimeProvider::dateTimeThisYear($max));
+        self::assertEquals($unixTime, DateTimeProvider::unixTime($max));
+        self::assertEquals($datetimeAD, DateTimeProvider::dateTimeAD($max));
+        self::assertEquals($dateTime1, DateTimeProvider::dateTime($max));
+        self::assertEquals($dateTimeBetween, DateTimeProvider::dateTimeBetween('2014-03-01 06:00:00', $max));
+        self::assertEquals($date, DateTimeProvider::date('Y-m-d', $max));
+        self::assertEquals($time, DateTimeProvider::time('H:i:s', $max));
+        self::assertEquals($iso8601, DateTimeProvider::iso8601($max));
+        self::assertEquals($dateTimeThisCentury, DateTimeProvider::dateTimeThisCentury($max));
+        self::assertEquals($dateTimeThisDecade, DateTimeProvider::dateTimeThisDecade($max));
+        self::assertEquals($dateTimeThisMonth, DateTimeProvider::dateTimeThisMonth($max));
+        self::assertEquals($amPm, DateTimeProvider::amPm($max));
+        self::assertEquals($dayOfMonth, DateTimeProvider::dayOfMonth($max));
+        self::assertEquals($dayOfWeek, DateTimeProvider::dayOfWeek($max));
+        self::assertEquals($month, DateTimeProvider::month($max));
+        self::assertEquals($monthName, DateTimeProvider::monthName($max));
+        self::assertEquals($year, DateTimeProvider::year($max));
+        self::assertEquals($dateTimeThisYear, DateTimeProvider::dateTimeThisYear($max));
         mt_srand();
     }
 }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -94,7 +94,7 @@ final class ImageTest extends TestCase
         curl_close($curlPing);
 
         if ($httpCode < 200 | $httpCode > 300) {
-            $this->markTestSkipped('Placeholder.com is offline, skipping image download');
+            self::markTestSkipped('Placeholder.com is offline, skipping image download');
         }
 
         $file = Image::image(sys_get_temp_dir());

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -75,19 +75,19 @@ final class InternetTest extends TestCase
     {
         $pattern = '/^[a-z0-9-]+$/';
         $slug = $this->faker->slug(6, false);
-        $this->assertSame(preg_match($pattern, $slug), 1);
+        self::assertSame(preg_match($pattern, $slug), 1);
     }
 
     public function testSlugWithoutVariableNbWordsProducesCorrectNumberOfNbWords()
     {
         $slug = $this->faker->slug(3, false);
-        $this->assertCount(3, explode('-', $slug));
+        self::assertCount(3, explode('-', $slug));
     }
 
     public function testSlugWithoutNbWordsIsEmpty()
     {
         $slug = $this->faker->slug(0);
-        $this->assertSame('', $slug);
+        self::assertSame('', $slug);
     }
 
     public function testUrlIsValid()

--- a/test/Faker/Provider/fr_FR/TextTest.php
+++ b/test/Faker/Provider/fr_FR/TextTest.php
@@ -24,32 +24,32 @@ final class TextTest extends TestCase
 
     public function testItShouldAppendEndPunctToTheEndOfString()
     {
-        $this->assertSame(
+        self::assertSame(
             'Que faisaient-elles maintenant? À.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À '])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'Que faisaient-elles maintenant? À.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À—   '])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'Que faisaient-elles maintenant? À.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À,'])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'Que faisaient-elles maintenant? À!.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À! '])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'Que faisaient-elles maintenant? À.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À: '])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'Que faisaient-elles maintenant? À.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À; '])
         );

--- a/test/Faker/Provider/ru_RU/TextTest.php
+++ b/test/Faker/Provider/ru_RU/TextTest.php
@@ -24,32 +24,32 @@ final class TextTest extends TestCase
 
     public function testItShouldAppendEndPunctToTheEndOfString()
     {
-        $this->assertSame(
+        self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер '])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер—'])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер,'])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'На другой день Чичиков отправился на обед и вечер!.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер! '])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер; '])
         );
 
-        $this->assertSame(
+        self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
             $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер: '])
         );

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -24,12 +24,12 @@ final class TextTest extends TestCase
 
     public function testItShouldExplodeTheStringToArray()
     {
-        $this->assertSame(
+        self::assertSame(
             ['中', '文', '測', '試', '真', '有', '趣'],
             $this->getMethod('explode')->invokeArgs(null, ['中文測試真有趣'])
         );
 
-        $this->assertSame(
+        self::assertSame(
             ['標', '點', '，', '符', '號', '！'],
             $this->getMethod('explode')->invokeArgs(null, ['標點，符號！'])
         );
@@ -37,7 +37,7 @@ final class TextTest extends TestCase
 
     public function testItShouldReturnTheStringLength()
     {
-        $this->assertContains(
+        self::assertContains(
             $this->getMethod('strlen')->invokeArgs(null, ['中文測試真有趣']),
             [7, 21]
         );
@@ -45,30 +45,30 @@ final class TextTest extends TestCase
 
     public function testItShouldReturnTheCharacterIsValidStartOrNot()
     {
-        $this->assertTrue($this->getMethod('validStart')->invokeArgs(null, ['中']));
+        self::assertTrue($this->getMethod('validStart')->invokeArgs(null, ['中']));
 
-        $this->assertTrue($this->getMethod('validStart')->invokeArgs(null, ['2']));
+        self::assertTrue($this->getMethod('validStart')->invokeArgs(null, ['2']));
 
-        $this->assertTrue($this->getMethod('validStart')->invokeArgs(null, ['Hello']));
+        self::assertTrue($this->getMethod('validStart')->invokeArgs(null, ['Hello']));
 
-        $this->assertFalse($this->getMethod('validStart')->invokeArgs(null, ['。']));
+        self::assertFalse($this->getMethod('validStart')->invokeArgs(null, ['。']));
 
-        $this->assertFalse($this->getMethod('validStart')->invokeArgs(null, ['！']));
+        self::assertFalse($this->getMethod('validStart')->invokeArgs(null, ['！']));
     }
 
     public function testItShouldAppendEndPunctToTheEndOfString()
     {
-        $this->assertSame(
+        self::assertSame(
             '中文測試真有趣。',
             $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣'])
         );
 
-        $this->assertSame(
+        self::assertSame(
             '中文測試真有趣。',
             $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣，'])
         );
 
-        $this->assertSame(
+        self::assertSame(
             '中文測試真有趣！',
             $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣！'])
         );

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -32,7 +32,7 @@ abstract class TestCase extends BaseTestCase
      */
     public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
     {
-        static::assertThat($string, new RegularExpression($pattern), $message);
+        self::assertThat($string, new RegularExpression($pattern), $message);
     }
 
     /**
@@ -43,7 +43,7 @@ abstract class TestCase extends BaseTestCase
      */
     public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
     {
-        static::assertThat(
+        self::assertThat(
             $string,
             new LogicalNot(
                 new RegularExpression($pattern)


### PR DESCRIPTION
StyleCI now supports fixing these to `self`, `static`, or `$this`.

---

Follows https://github.com/FakerPHP/Faker/pull/99.