### PR TITLE
Remove ro street address

### DIFF
--- a/src/Faker/Provider/ro_MD/Address.php
+++ b/src/Faker/Provider/ro_MD/Address.php
@@ -139,11 +139,4 @@ class Address extends \Faker\Provider\Address
 
         return $this->generator->parse($format);
     }
-
-    public function streetAddress()
-    {
-        $format = static::randomElement(static::$streetAddressFormats);
-
-        return $this->generator->parse($format);
-    }
 }

--- a/src/Faker/Provider/ro_MD/Address.php
+++ b/src/Faker/Provider/ro_MD/Address.php
@@ -122,21 +122,4 @@ class Address extends \Faker\Provider\Address
     {
         return static::randomElement(static::$streetPlainName);
     }
-
-    /**
-     * @example 'Splaiul Independenței'
-     */
-    public function streetName()
-    {
-        $format = static::randomElement(static::$streetNameFormats);
-
-        return $this->generator->parse($format);
-    }
-
-    public function address()
-    {
-        $format = static::randomElement(static::$addressFormats);
-
-        return $this->generator->parse($format);
-    }
 }

--- a/src/Faker/Provider/ro_RO/Address.php
+++ b/src/Faker/Provider/ro_RO/Address.php
@@ -144,27 +144,10 @@ class Address extends \Faker\Provider\Address
     }
 
     /**
-     * @example 'Splaiul Independenței'
-     */
-    public function streetName()
-    {
-        $format = static::randomElement(static::$streetNameFormats);
-
-        return $this->generator->parse($format);
-    }
-
-    /**
      * @example 'Cluj'
      */
     public function county()
     {
         return static::randomElement(static::$counties);
-    }
-
-    public function address()
-    {
-        $format = static::randomElement(static::$addressFormats);
-
-        return $this->generator->parse($format);
     }
 }

--- a/src/Faker/Provider/ro_RO/Address.php
+++ b/src/Faker/Provider/ro_RO/Address.php
@@ -167,11 +167,4 @@ class Address extends \Faker\Provider\Address
 
         return $this->generator->parse($format);
     }
-
-    public function streetAddress()
-    {
-        $format = static::randomElement(static::$streetAddressFormats);
-
-        return $this->generator->parse($format);
-    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

`ro_RO` and `ro_MD\Address::streetAddress`/`address`/`streetName` just duplicate the base `Address::streetAddress`/`address`/`streetName` and are therefore unnecessary.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

Removed `ro_RO` and `ro_MD\Address::streetAddress`/`address`/`streetName`.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
