### PR TITLE
Fix docblock dataProvider param type

### DIFF
--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -139,7 +139,7 @@ final class PersonTest extends TestCase
     }
 
     /**
-     * @param $value
+     * @param string $value
      * @dataProvider validCountyCodeProvider
      */
     public function test_validCountyCode_returnsValidCnp($value)
@@ -152,7 +152,7 @@ final class PersonTest extends TestCase
     }
 
     /**
-     * @param $value
+     * @param string $value
      * @dataProvider invalidCountyCodeProvider
      */
     public function test_invalidCountyCode_throwsException($value)
@@ -179,11 +179,11 @@ final class PersonTest extends TestCase
     }
 
     /**
-     * @param $gender
-     * @param $dateOfBirth
-     * @param $county
-     * @param $isResident
-     * @param $expectedCnpStart
+     * @param string $gender
+     * @param string $dateOfBirth
+     * @param string $county
+     * @param bool $isResident
+     * @param string $expectedCnpStart
      *
      * @dataProvider validInputDataProvider
      */


### PR DESCRIPTION
### What is the reason for this PR?

`ro_RO\PersonTest` had the parameter type missing in it's docblock `@dataProvider` `@param`s.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

Add the parameter types, see https://github.com/FakerPHP/Faker/pull/108#discussion_r542020571

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
