### PR TITLE
Fix real text too short

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -73,6 +73,7 @@ namespace Faker;
  * @method string text($maxNbChars = 200)
  *
  * @method string realText($maxNbChars = 200, $indexSize = 2)
+ * @method string realTextBetween($minNbChars = 150, $maxNbChars = 200, $indexSize = 2)
  *
  * @property string $email
  * @property string $safeEmail

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -28,6 +28,27 @@ abstract class Text extends Base
      */
     public function realText($maxNbChars = 200, $indexSize = 2)
     {
+        return $this->realTextBetween(round($maxNbChars * 0.8), $maxNbChars, $indexSize);
+    }
+
+    /**
+     * Generate a text string by the Markov chain algorithm.
+     *
+     * Depending on the $maxNbChars, returns a random valid looking text. The algorithm
+     * generates a weighted table with the specified number of words as the index and the
+     * possible following words as the value.
+     *
+     * @example 'Alice, swallowing down her flamingo, and began by taking the little golden key'
+     * @param int $minNbChars Minimum number of characters the text should contain (maximum: 8)
+     * @param int $maxNbChars Maximum number of characters the text should contain (minimum: 10)
+     * @param int $indexSize  Determines how many words are considered for the generation of the next word.
+     *                             The minimum is 1, and it produces a higher level of randomness, although the
+     *                             generated text usually doesn't make sense. Higher index sizes (up to 5)
+     *                             produce more correct text, at the price of less randomness.
+     * @return string
+     */
+    public function realTextBetween($minNbChars = 150, $maxNbChars = 200, $indexSize = 2)
+    {
         if ($maxNbChars < 10) {
             throw new \InvalidArgumentException('maxNbChars must be at least 10');
         }
@@ -40,19 +61,20 @@ abstract class Text extends Base
             throw new \InvalidArgumentException('indexSize must be at most 5');
         }
 
+        if ($minNbChars >= $maxNbChars) {
+            throw new \InvalidArgumentException('minNbChars must be smaller than maxNbChars');
+        }
+
         $words = $this->getConsecutiveWords($indexSize);
-
         $iterations = 0;
-        $minNbChars = $maxNbChars * 0.8;
-
         do {
-            $iterations ++;
+            $iterations++;
             if ($iterations >= 100) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a valid real text', $iterations));
             }
 
             $result = $this->generateText($maxNbChars, $words);
-        } while (strlen($result) < $minNbChars);
+        } while (strlen($result) <= $minNbChars);
 
         return static::appendEnd($result);
     }

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -49,6 +49,10 @@ abstract class Text extends Base
      */
     public function realTextBetween($minNbChars = 160, $maxNbChars = 200, $indexSize = 2)
     {
+        if ($minNbChars < 1) {
+            throw new \InvalidArgumentException('minNbChars must be at least 1');
+        }
+
         if ($maxNbChars < 10) {
             throw new \InvalidArgumentException('maxNbChars must be at least 10');
         }

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -40,27 +40,30 @@ abstract class Text extends Base
             throw new \InvalidArgumentException('indexSize must be at most 5');
         }
 
+        $words = $this->getConsecutiveWords($indexSize);
+
         $iterations = 0;
+        $minNbChars = $maxNbChars * 0.8;
+
         do {
             $iterations ++;
             if ($iterations >= 100) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a valid real text', $iterations));
             }
 
-            $result = $this->generateText($indexSize, $maxNbChars);
-        } while (strlen($result) < $maxNbChars * 0.8);
+            $result = $this->generateText($maxNbChars, $words);
+        } while (strlen($result) < $minNbChars);
 
         return static::appendEnd($result);
     }
 
     /**
-     * @param  int  $indexSize
-     * @param  int  $maxNbChars
+     * @param  int      $maxNbChars
+     * @param  array    $words
      * @return string
      */
-    protected function generateText(int $indexSize, int $maxNbChars)
+    protected function generateText($maxNbChars, $words)
     {
-        $words = $this->getConsecutiveWords($indexSize);
         $result = [];
         $resultLength = 0;
         // take a random starting point

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -47,7 +47,7 @@ abstract class Text extends Base
      *                             produce more correct text, at the price of less randomness.
      * @return string
      */
-    public function realTextBetween($minNbChars = 150, $maxNbChars = 200, $indexSize = 2)
+    public function realTextBetween($minNbChars = 160, $maxNbChars = 200, $indexSize = 2)
     {
         if ($maxNbChars < 10) {
             throw new \InvalidArgumentException('maxNbChars must be at least 10');

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -40,6 +40,26 @@ abstract class Text extends Base
             throw new \InvalidArgumentException('indexSize must be at most 5');
         }
 
+        $iterations = 0;
+        do {
+            $iterations ++;
+            if ($iterations >= 100) {
+                throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a valid real text', $iterations));
+            }
+
+            $result = $this->generateText($indexSize, $maxNbChars);
+        } while (strlen($result) < $maxNbChars * 0.8);
+
+        return static::appendEnd($result);
+    }
+
+    /**
+     * @param  int  $indexSize
+     * @param  int  $maxNbChars
+     * @return string
+     */
+    protected function generateText(int $indexSize, int $maxNbChars)
+    {
         $words = $this->getConsecutiveWords($indexSize);
         $result = [];
         $resultLength = 0;

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -76,7 +76,7 @@ abstract class Text extends Base
             $result = $this->generateText($maxNbChars, $words);
         } while (strlen($result) <= $minNbChars);
 
-        return static::appendEnd($result);
+        return $result;
     }
 
     /**

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -74,7 +74,7 @@ abstract class Text extends Base
             }
 
             $result = $this->generateText($maxNbChars, $words);
-        } while (strlen($result) <= $minNbChars);
+        } while (static::strlen($result) <= $minNbChars);
 
         return $result;
     }

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -28,7 +28,7 @@ abstract class Text extends Base
      */
     public function realText($maxNbChars = 200, $indexSize = 2)
     {
-        return $this->realTextBetween(round($maxNbChars * 0.8), $maxNbChars, $indexSize);
+        return $this->realTextBetween((int) round($maxNbChars * 0.8), $maxNbChars, $indexSize);
     }
 
     /**

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -67,7 +67,7 @@ final class TextTest extends TestCase
     }
 
     /**
-     * @testWith [0, 10]
+     * @testWith [1, 10]
      *           [5, 10]
      *           [8, 10]
      *           [18, 20]
@@ -87,9 +87,18 @@ final class TextTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $this->faker->realTextBetween(9, 9);
+        $this->faker->realTextBetween(25, 20);
 
         self::fail('minNbChars should be smaller than maxNbChars');
+    }
+
+    public function testRealTextBetweenMinNbCharsGreaterThan1()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->faker->realTextBetween(0, 30);
+
+        self::fail('minNbChars must be bigger than 0');
     }
 
     protected function getProviders(): iterable

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -70,10 +70,10 @@ final class TextTest extends TestCase
      * @testWith [0, 10]
      *           [5, 10]
      *           [8, 10]
-     *           [8, 20]
-     *           [10, 50]
-     *           [150, 200]
-     *           [1700, 2000]
+     *           [18, 20]
+     *           [45, 50]
+     *           [180, 200]
+     *           [1950, 2000]
      */
     public function testRealTextBetweenTextLength($min, $max)
     {

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -18,7 +18,7 @@ final class TextTest extends TestCase
      *           [200]
      *           [500]
      */
-    public function testTextMaxLength($length)
+    public function testRealTextMaxLength($length)
     {
         self::assertLessThan($length, strlen($this->faker->realText($length)));
     }
@@ -34,12 +34,12 @@ final class TextTest extends TestCase
      *           [200]
      *           [500]
      */
-    public function testTextMinLength($length)
+    public function testRealTextMinLength($length)
     {
         self::assertGreaterThanOrEqual($length * 0.8, strlen($this->faker->realText($length)));
     }
 
-    public function testTextMaxIndex()
+    public function testRealTextMaxIndex()
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -48,7 +48,7 @@ final class TextTest extends TestCase
         self::fail('The index should be less than or equal to 5.');
     }
 
-    public function testTextMinIndex()
+    public function testRealTextMinIndex()
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -57,13 +57,39 @@ final class TextTest extends TestCase
         self::fail('The index should be greater than or equal to 1.');
     }
 
-    public function testTextMinNbChars()
+    public function testRealTextMinNbChars()
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $this->faker->realText(9);
 
         self::fail('The text should be at least 10 characters.');
+    }
+
+    /**
+     * @testWith [0, 10]
+     *           [5, 10]
+     *           [8, 10]
+     *           [8, 20]
+     *           [10, 50]
+     *           [150, 200]
+     *           [1700, 2000]
+     */
+    public function testRealTextBetweenTextLength($min, $max)
+    {
+        $strlen = strlen($this->faker->realTextBetween($min, $max));
+
+        self::assertGreaterThan($min, $strlen);
+        self::assertLessThan($max, $strlen);
+    }
+
+    public function testRealTextBetweenMinNbChars()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->faker->realTextBetween(9, 9);
+
+        self::fail('minNbChars should be smaller than maxNbChars');
     }
 
     protected function getProviders(): iterable

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -23,6 +23,22 @@ final class TextTest extends TestCase
         self::assertLessThan($length, strlen($this->faker->realText($length)));
     }
 
+    /**
+     * @testWith [10]
+     *           [20]
+     *           [50]
+     *           [70]
+     *           [90]
+     *           [120]
+     *           [150]
+     *           [200]
+     *           [500]
+     */
+    public function testTextMinLength($length)
+    {
+        self::assertGreaterThanOrEqual($length * 0.8, strlen($this->faker->realText($length)));
+    }
+
     public function testTextMaxIndex()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -41,7 +57,7 @@ final class TextTest extends TestCase
         self::fail('The index should be greater than or equal to 1.');
     }
 
-    public function testTextMinLength()
+    public function testTextMinNbChars()
     {
         $this->expectException(\InvalidArgumentException::class);
 


### PR DESCRIPTION
### What is the reason for this PR?

This PR is related to #37, a more detailed description of the issues observed can be found there.

[`realText`](https://github.com/FakerPHP/Faker/blob/ab3f5364d01f2c2c16113442fb987d26e4004913/src/Faker/Provider/Text.php#L29) may produce text that is too short, e.g. by running:

```php
$faker = \Faker\Factory::create();
$faker->seed(252);
$text = $faker->realText(2000, 2);
```
which returns `THE.` (even though 2000 characters were requested).

- [x] A new feature (resolve #37)
- [x] Fixed an issue 

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR fixes the issue mentioned above while adding a new `Text::realTextBetween($minNbChars = 160, $maxNbChars = 200, $indexSize = 2)` method (as was suggested in #37). 

It adds a simple loop to make sure that the returned text from `realText` is at least 80% the length set with `$maxNbChars`. The same logic is used to provide the `realTextBetween` method.
Also made sure we have a maximum number of retries and added tests.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
