### PR TITLE
Fix: Move .PHONY declaration to targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,34 @@
-.PHONY: build cs coverage help test
-
+.PHONY: help
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: build
 build: cs test static ## Runs test targets
 
+.PHONY: cs
 cs: vendor/autoload.php ## Fixes coding standard issues with php-cs-fixer
 	mkdir -p .build/
 	vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --verbose
 
+.PHONY: coverage
 coverage: vendor/autoload.php ## Collects coverage with phpunit
 	vendor/bin/phpunit --coverage-text --coverage-clover=.build/logs/clover.xml
 
+.PHONY: test
 test: vendor/autoload.php ## Runs tests with phpunit
 	vendor/bin/phpunit
 
+.PHONY: static
 static: vendor/autoload.php ## Runs static analyzers
 	vendor/bin/phpstan analyze
 	vendor/bin/psalm
 
+.PHONY: baseline
 baseline: vendor/autoload.php ## Generate baseline files
 	vendor/bin/phpstan analyze --generate-baseline
 	vendor/bin/psalm --update-baseline
 
+.PHONY: clean
 clean: rm -rf vendor composer.lock .build  ## Cleans up build and vendor files
 
 vendor/autoload.php:


### PR DESCRIPTION
This PR

* [x] moves the `.PHONY` declarations in `Makefile` to their corresponding targets

💁‍♂️ This makes it easier to see immediately which target is phony and which is not.