### PR TITLE
Fix: Do not create directory that is not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ build: cs test static ## Runs test targets
 
 .PHONY: cs
 cs: vendor/autoload.php ## Fixes coding standard issues with php-cs-fixer
-	mkdir -p .build/
 	vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --verbose
 
 .PHONY: coverage


### PR DESCRIPTION
This PR

* [x] stops creating a directory that is not needed

Follows #157.