### PR TITLE
Fix: Configure concat_space fixer to concatenate strings without space

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,7 +50,7 @@ return $config
         'combine_nested_dirname' => true,
         'compact_nullable_typehint' => true,
         'concat_space' => [
-            'spacing' => 'one',
+            'spacing' => 'none',
         ],
         'declare_equal_normalize' => true,
         'function_typehint_space' => true,


### PR DESCRIPTION
This PR

* [x] configures the `concat_space` fixer to concatenate strings without space

Follows #157.

❗ This reflects the reality of the code base after a57232a2, which was somehow magically applied after the configuration for StyleCI was removed.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/operator/concat_space.rst.