### PR TITLE
Use symfony/phpunit-bridge

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,4 +59,7 @@ jobs:
 
       - name: Run tests with PHPUnit
         run: |
-          vendor/bin/phpunit
+          echo ::group::Install
+          ./vendor/bin/simple-phpunit install
+          echo ::endgroup::
+          ./vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.4.2"
+        "symfony/phpunit-bridge": "^4.4 || ^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -3,7 +3,6 @@
 namespace Faker\Test;
 
 use Faker\Generator;
-use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -3,7 +3,6 @@
 namespace Faker\Test;
 
 use Faker\Generator;
-use PHPUnit\Framework\Constraint\LogicalNot;
 use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -22,34 +21,6 @@ abstract class TestCase extends BaseTestCase
         foreach ($this->getProviders() as $provider) {
             $this->faker->addProvider($provider);
         }
-    }
-
-    /**
-     * Asserts that a string matches a given regular expression.
-     *
-     * @throws \PHPUnit\Framework\ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     */
-    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
-    {
-        self::assertThat($string, new RegularExpression($pattern), $message);
-    }
-
-    /**
-     * Asserts that a string does not match a given regular expression.
-     *
-     * @throws \PHPUnit\Framework\ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     */
-    public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
-    {
-        self::assertThat(
-            $string,
-            new LogicalNot(
-                new RegularExpression($pattern)
-            ),
-            $message
-        );
     }
 
     public static function localeDataProvider(): array


### PR DESCRIPTION
This might seam unnecessary. However, I believe it will be a great additions. 

1. The tests in #162 is failing on php 7.1 because the PHPUnit 7.5 does not include some methods. We worked our way around this by implementing an abstract `TestCase` ourselves. 
2. Our abstract `TestCase` always loads (soon to be legacy) providers and instantiating a new `Generator`. That is not required for most tests. See #162, #155 and #154
3. We will soon start to deprecate methods. The `symfony/phpunit-bridge` will make sure we are not using deprecated code internally. 
4. We can probably start to use features in PHPUnit 10 that will be released in a few months. 

And also, this is a dev dependency, so it does not really impact the project negatively. 
 