### PR TITLE
Deprecate property access

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "symfony/deprecation-contracts": "^2.2"
     },
     "require-dev": {
         "ext-intl": "*",

--- a/src/Faker/DefaultGenerator.php
+++ b/src/Faker/DefaultGenerator.php
@@ -17,9 +17,13 @@ class DefaultGenerator
 
     /**
      * @param string $attribute
+     *
+     * @deprecated Use a method instead.
      */
     public function __get($attribute)
     {
+        trigger_deprecation('fakerphp/faker', '1.14', 'Accessing property "%s" is deprecated, use "%s()" instead.', $attribute, $attribute);
+
         return $this->default;
     }
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -340,9 +340,13 @@ class Generator
 
     /**
      * @param string $attribute
+     *
+     * @deprecated Use a method instead.
      */
     public function __get($attribute)
     {
+        trigger_deprecation('fakerphp/faker', '1.14', 'Accessing property "%s" is deprecated, use "%s()" instead.', $attribute, $attribute);
+
         return $this->format($attribute);
     }
 

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -25,9 +25,13 @@ class UniqueGenerator
      * Catch and proxy all generator calls but return only unique values
      *
      * @param string $attribute
+     *
+     * @deprecated Use a method instead.
      */
     public function __get($attribute)
     {
+        trigger_deprecation('fakerphp/faker', '1.14', 'Accessing property "%s" is deprecated, use "%s()" instead.', $attribute, $attribute);
+
         return $this->__call($attribute, []);
     }
 

--- a/src/Faker/ValidGenerator.php
+++ b/src/Faker/ValidGenerator.php
@@ -34,9 +34,13 @@ class ValidGenerator
      * Catch and proxy all generator calls but return only valid values
      *
      * @param string $attribute
+     *
+     * @deprecated Use a method instead.
      */
     public function __get($attribute)
     {
+        trigger_deprecation('fakerphp/faker', '1.14', 'Accessing property "%s" is deprecated, use "%s()" instead.', $attribute, $attribute);
+
         return $this->__call($attribute, []);
     }
 

--- a/test/Faker/DefaultGeneratorTest.php
+++ b/test/Faker/DefaultGeneratorTest.php
@@ -6,12 +6,18 @@ use Faker\DefaultGenerator;
 
 final class DefaultGeneratorTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testGeneratorReturnsNullByDefault()
     {
         $generator = new DefaultGenerator();
         self::assertNull($generator->value);
     }
 
+    /**
+     * @group legacy
+     */
     public function testGeneratorReturnsDefaultValueForAnyPropertyGet()
     {
         $generator = new DefaultGenerator(123);

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -120,6 +120,9 @@ final class GeneratorTest extends TestCase
         self::assertEquals('This is foobar a text with foobar', $this->faker->parse('This is {{fooFormatter}} a text with {{ fooFormatter }}'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testMagicGetCallsFormat()
     {
         $this->faker->addProvider(new FooProvider());

--- a/test/Faker/Provider/AddressTest.php
+++ b/test/Faker/Provider/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testLatitude()

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -7,6 +7,9 @@ use Faker\Calculator\Isbn;
 use Faker\Provider\Barcode;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class BarcodeTest extends TestCase
 {
     public function testEan8()

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Base as BaseProvider;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class BaseTest extends TestCase
 {
     public function testRandomDigitReturnsInteger()
@@ -563,6 +566,9 @@ final class BaseTest extends TestCase
     }
 }
 
+/**
+ * @group legacy
+ */
 final class Collection extends \ArrayObject
 {
 }

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Biased;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class BiasedTest extends TestCase
 {
     public const MAX = 10;

--- a/test/Faker/Provider/ColorTest.php
+++ b/test/Faker/Provider/ColorTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Color;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class ColorTest extends TestCase
 {
     public function testHexColor()

--- a/test/Faker/Provider/CompanyTest.php
+++ b/test/Faker/Provider/CompanyTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\Company;
 use Faker\Provider\Lorem;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testJobTitle()

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\DateTime as DateTimeProvider;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class DateTimeTest extends TestCase
 {
     protected function setUp(): void

--- a/test/Faker/Provider/HtmlLoremTest.php
+++ b/test/Faker/Provider/HtmlLoremTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\HtmlLorem;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class HtmlLoremTest extends TestCase
 {
     public function testProvider()

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Image;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class ImageTest extends TestCase
 {
     public function testImageUrlUses640x680AsTheDefaultSize()

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -8,6 +8,9 @@ use Faker\Provider\Lorem;
 use Faker\Provider\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/LocalizationTest.php
+++ b/test/Faker/Provider/LocalizationTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Factory;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class LocalizationTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/LoremTest.php
+++ b/test/Faker/Provider/LoremTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Lorem;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class LoremTest extends TestCase
 {
     public function testTextThrowsExceptionWhenAskedTextSizeLessThan5()
@@ -87,6 +90,9 @@ final class LoremTest extends TestCase
     }
 }
 
+/**
+ * @group legacy
+ */
 final class TestableLorem extends Lorem
 {
     public static function word()

--- a/test/Faker/Provider/MedicalTest.php
+++ b/test/Faker/Provider/MedicalTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Medical;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class MedicalTest extends TestCase
 {
     public function testBloodType(): void

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Miscellaneous;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class MiscellaneousTest extends TestCase
 {
     public function testBoolean()

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -10,6 +10,9 @@ use Faker\Provider\Payment as PaymentProvider;
 use Faker\Provider\Person as PersonProvider;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testCreditCardTypeReturnsValidVendorName()

--- a/test/Faker/Provider/PersonTest.php
+++ b/test/Faker/Provider/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/PhoneNumberTest.php
+++ b/test/Faker/Provider/PhoneNumberTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Luhn;
 use Faker\Provider\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumberFormat()

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 /**
  * Class ProviderOverrideTest
  */
+/**
+ * @group legacy
+ */
 final class ProviderOverrideTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\en_US\Text;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/UserAgentTest.php
+++ b/test/Faker/Provider/UserAgentTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\UserAgent;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class UserAgentTest extends TestCase
 {
     public function testRandomUserAgent()

--- a/test/Faker/Provider/UuidTest.php
+++ b/test/Faker/Provider/UuidTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Uuid as BaseProvider;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class UuidTest extends TestCase
 {
     public function testUuidReturnsUuid()

--- a/test/Faker/Provider/ar_JO/InternetTest.php
+++ b/test/Faker/Provider/ar_JO/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\fi_FI\Internet;
 use Faker\Provider\fi_FI\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/ar_SA/CompanyTest.php
+++ b/test/Faker/Provider/ar_SA/CompanyTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Luhn;
 use Faker\Provider\ar_SA\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testCompanyIdNumberIsValid()

--- a/test/Faker/Provider/ar_SA/InternetTest.php
+++ b/test/Faker/Provider/ar_SA/InternetTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ar_SA;
 use Faker\Provider\ar_SA\Internet;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/ar_SA/PersonTest.php
+++ b/test/Faker/Provider/ar_SA/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Luhn;
 use Faker\Provider\ar_SA\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testIdNumber()

--- a/test/Faker/Provider/bg_BG/PaymentTest.php
+++ b/test/Faker/Provider/bg_BG/PaymentTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\bg_BG;
 use Faker\Provider\bg_BG\Payment;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testVatIsValid()

--- a/test/Faker/Provider/bn_BD/PersonTest.php
+++ b/test/Faker/Provider/bn_BD/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\bn_BD;
 use Faker\Provider\bn_BD\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testIfFirstNameMaleCanReturnData()

--- a/test/Faker/Provider/cs_CZ/PersonTest.php
+++ b/test/Faker/Provider/cs_CZ/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\cs_CZ\Person;
 use Faker\Provider\Miscellaneous;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testBirthNumber()

--- a/test/Faker/Provider/da_DK/InternetTest.php
+++ b/test/Faker/Provider/da_DK/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\da_DK\Internet;
 use Faker\Provider\da_DK\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/de_AT/AddressTest.php
+++ b/test/Faker/Provider/de_AT/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\de_AT;
 use Faker\Provider\de_AT\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/de_AT/InternetTest.php
+++ b/test/Faker/Provider/de_AT/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\de_AT\Internet;
 use Faker\Provider\de_AT\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/de_AT/PaymentTest.php
+++ b/test/Faker/Provider/de_AT/PaymentTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\de_AT;
 use Faker\Provider\de_AT\Payment;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testVatIsValid()

--- a/test/Faker/Provider/de_AT/PersonTest.php
+++ b/test/Faker/Provider/de_AT/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\de_AT;
 use Faker\Provider\de_AT\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testSsnWithDefaultValuesCorrect()

--- a/test/Faker/Provider/de_AT/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_AT/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\de_AT;
 use Faker\Provider\de_AT\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumberFormat()

--- a/test/Faker/Provider/de_CH/AddressTest.php
+++ b/test/Faker/Provider/de_CH/AddressTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\de_CH\Address;
 use Faker\Provider\de_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testCanton()

--- a/test/Faker/Provider/de_CH/InternetTest.php
+++ b/test/Faker/Provider/de_CH/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\de_CH\Internet;
 use Faker\Provider\de_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/de_CH/PersonTest.php
+++ b/test/Faker/Provider/de_CH/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Ean;
 use Faker\Provider\de_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testAvs13Number()

--- a/test/Faker/Provider/de_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_CH/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\de_CH;
 use Faker\Provider\de_CH\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()

--- a/test/Faker/Provider/de_DE/InternetTest.php
+++ b/test/Faker/Provider/de_DE/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\de_DE\Internet;
 use Faker\Provider\de_DE\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/el_GR/PhoneNumberTest.php
+++ b/test/Faker/Provider/el_GR/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\el_GR;
 use Faker\Provider\el_GR\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testFixedLineNumber()

--- a/test/Faker/Provider/el_GR/TextTest.php
+++ b/test/Faker/Provider/el_GR/TextTest.php
@@ -4,6 +4,9 @@ namespace Faker\Test\Provider\el_GR;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     private $textClass;

--- a/test/Faker/Provider/en_AU/AddressTest.php
+++ b/test/Faker/Provider/en_AU/AddressTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\en_AU;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testCityPrefix()

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\en_CA;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/en_GB/AddressTest.php
+++ b/test/Faker/Provider/en_GB/AddressTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\en_GB;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testPostcode()

--- a/test/Faker/Provider/en_GB/PersonTest.php
+++ b/test/Faker/Provider/en_GB/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_GB;
 use Faker\Provider\en_GB\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testNationalInsuranceNumber()

--- a/test/Faker/Provider/en_IN/AddressTest.php
+++ b/test/Faker/Provider/en_IN/AddressTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\en_IN;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testCity()

--- a/test/Faker/Provider/en_NG/AddressTest.php
+++ b/test/Faker/Provider/en_NG/AddressTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\en_NG;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testPostcodeIsNotEmptyAndIsValid()

--- a/test/Faker/Provider/en_NG/InternetTest.php
+++ b/test/Faker/Provider/en_NG/InternetTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\en_NG\Internet;
 use Faker\Provider\en_NG\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/en_NG/PersonTest.php
+++ b/test/Faker/Provider/en_NG/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_NG;
 use Faker\Provider\en_NG\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testPersonNameIsAValidString()

--- a/test/Faker/Provider/en_NG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NG/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_NG;
 use Faker\Provider\en_NG\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumberReturnsPhoneNumberWithOrWithoutCountryCode()

--- a/test/Faker/Provider/en_NZ/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NZ/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_NZ;
 use Faker\Provider\en_NZ\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testIfPhoneNumberCanReturnData()

--- a/test/Faker/Provider/en_PH/AddressTest.php
+++ b/test/Faker/Provider/en_PH/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_PH;
 use Faker\Provider\en_PH\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testProvince()

--- a/test/Faker/Provider/en_SG/AddressTest.php
+++ b/test/Faker/Provider/en_SG/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_SG;
 use Faker\Provider\en_SG\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testStreetNumber()

--- a/test/Faker/Provider/en_SG/PersonTest.php
+++ b/test/Faker/Provider/en_SG/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_SG;
 use Faker\Provider\en_SG\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testNric(): void

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_SG;
 use Faker\Provider\en_SG\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     // http://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore#Numbering_plan

--- a/test/Faker/Provider/en_UG/AddressTest.php
+++ b/test/Faker/Provider/en_UG/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_UG;
 use Faker\Provider\en_UG\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testCityName()

--- a/test/Faker/Provider/en_US/CompanyTest.php
+++ b/test/Faker/Provider/en_US/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_US;
 use Faker\Provider\en_US\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/en_US/PaymentTest.php
+++ b/test/Faker/Provider/en_US/PaymentTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\en_US;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testBankAccountNumber()

--- a/test/Faker/Provider/en_US/PersonTest.php
+++ b/test/Faker/Provider/en_US/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_US;
 use Faker\Provider\en_US\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testSsn()

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_US;
 use Faker\Provider\en_US\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()

--- a/test/Faker/Provider/en_ZA/CompanyTest.php
+++ b/test/Faker/Provider/en_ZA/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_ZA;
 use Faker\Provider\en_ZA\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testGenerateValidCompanyNumber()

--- a/test/Faker/Provider/en_ZA/InternetTest.php
+++ b/test/Faker/Provider/en_ZA/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\en_ZA\Internet;
 use Faker\Provider\en_ZA\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/en_ZA/PersonTest.php
+++ b/test/Faker/Provider/en_ZA/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\DateTime;
 use Faker\Provider\en_ZA\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testIdNumberWithDefaults()

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\en_ZA;
 use Faker\Provider\en_ZA\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\es_ES;
 use Faker\Provider\es_ES\Payment;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testVAT()

--- a/test/Faker/Provider/es_ES/PersonTest.php
+++ b/test/Faker/Provider/es_ES/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\es_ES;
 use Faker\Provider\es_ES\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testDNI()

--- a/test/Faker/Provider/es_ES/PhoneNumberTest.php
+++ b/test/Faker/Provider/es_ES/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\es_ES;
 use Faker\Provider\es_ES\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testMobileNumber()

--- a/test/Faker/Provider/es_ES/TextTest.php
+++ b/test/Faker/Provider/es_ES/TextTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\es_ES;
 use Faker\Provider\es_ES\Text;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     public function testText()

--- a/test/Faker/Provider/es_PE/PersonTest.php
+++ b/test/Faker/Provider/es_PE/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\es_PE;
 use Faker\Provider\es_PE\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testDNI()

--- a/test/Faker/Provider/es_VE/CompanyTest.php
+++ b/test/Faker/Provider/es_VE/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\es_VE;
 use Faker\Provider\es_VE\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/es_VE/PersonTest.php
+++ b/test/Faker/Provider/es_VE/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\es_VE;
 use Faker\Provider\es_VE\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testNationalId()

--- a/test/Faker/Provider/fa_IR/PersonTest.php
+++ b/test/Faker/Provider/fa_IR/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\fa_IR;
 use Faker\Provider\fa_IR\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testNationalCode()

--- a/test/Faker/Provider/fi_FI/InternetTest.php
+++ b/test/Faker/Provider/fi_FI/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\fi_FI\Internet;
 use Faker\Provider\fi_FI\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\DateTime;
 use Faker\Provider\fi_FI\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function provideSeedAndExpectedReturn()

--- a/test/Faker/Provider/fr_BE/PaymentTest.php
+++ b/test/Faker/Provider/fr_BE/PaymentTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\fr_BE;
 use Faker\Provider\fr_BE\Payment;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testVatIsValid()

--- a/test/Faker/Provider/fr_CH/AddressTest.php
+++ b/test/Faker/Provider/fr_CH/AddressTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\fr_CH\Address;
 use Faker\Provider\fr_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testCanton()

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\fr_CH\Internet;
 use Faker\Provider\fr_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/fr_CH/PersonTest.php
+++ b/test/Faker/Provider/fr_CH/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Ean;
 use Faker\Provider\fr_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testAvs13Number()

--- a/test/Faker/Provider/fr_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_CH/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\fr_CH;
 use Faker\Provider\fr_CH\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\fr_FR;
 use Faker\Provider\fr_FR\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testSecondaryAddress()

--- a/test/Faker/Provider/fr_FR/CompanyTest.php
+++ b/test/Faker/Provider/fr_FR/CompanyTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Luhn;
 use Faker\Provider\fr_FR\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testSiretReturnsAValidSiret()
@@ -61,6 +64,9 @@ final class CompanyTest extends TestCase
     }
 }
 
+/**
+ * @group legacy
+ */
 final class TestableCompany extends Company
 {
     public static function isCatchPhraseValid($catchPhrase)

--- a/test/Faker/Provider/fr_FR/PaymentTest.php
+++ b/test/Faker/Provider/fr_FR/PaymentTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Luhn;
 use Faker\Provider\fr_FR\Payment;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testFormattedVat()

--- a/test/Faker/Provider/fr_FR/PersonTest.php
+++ b/test/Faker/Provider/fr_FR/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\fr_FR;
 use Faker\Provider\fr_FR\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testNIRReturnsTheRightGender()

--- a/test/Faker/Provider/fr_FR/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_FR/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\fr_FR;
 use Faker\Provider\fr_FR\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testMobileNumber()

--- a/test/Faker/Provider/fr_FR/TextTest.php
+++ b/test/Faker/Provider/fr_FR/TextTest.php
@@ -4,6 +4,9 @@ namespace Faker\Test\Provider\fr_FR;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     private $textClass;

--- a/test/Faker/Provider/id_ID/PersonTest.php
+++ b/test/Faker/Provider/id_ID/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\DateTime;
 use Faker\Provider\id_ID\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/it_CH/AddressTest.php
+++ b/test/Faker/Provider/it_CH/AddressTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\it_CH\Address;
 use Faker\Provider\it_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testCanton()

--- a/test/Faker/Provider/it_CH/InternetTest.php
+++ b/test/Faker/Provider/it_CH/InternetTest.php
@@ -7,6 +7,9 @@ use Faker\Provider\it_CH\Internet;
 use Faker\Provider\it_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testEmailIsValid()

--- a/test/Faker/Provider/it_CH/PersonTest.php
+++ b/test/Faker/Provider/it_CH/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Ean;
 use Faker\Provider\it_CH\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testAvs13Number()

--- a/test/Faker/Provider/it_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/it_CH/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\it_CH;
 use Faker\Provider\it_CH\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()

--- a/test/Faker/Provider/it_IT/CompanyTest.php
+++ b/test/Faker/Provider/it_IT/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\it_IT;
 use Faker\Provider\it_IT\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testIfTaxIdCanReturnData()

--- a/test/Faker/Provider/it_IT/PersonTest.php
+++ b/test/Faker/Provider/it_IT/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\it_IT;
 use Faker\Provider\it_IT\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testIfTaxIdCanReturnData()

--- a/test/Faker/Provider/ja_JP/InternetTest.php
+++ b/test/Faker/Provider/ja_JP/InternetTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ja_JP;
 use Faker\Provider\ja_JP\Internet;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class InternetTest extends TestCase
 {
     public function testUserName()

--- a/test/Faker/Provider/ja_JP/PersonTest.php
+++ b/test/Faker/Provider/ja_JP/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ja_JP;
 use Faker\Provider\ja_JP\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testKanaNameMaleReturns()

--- a/test/Faker/Provider/ja_JP/PhoneNumberTest.php
+++ b/test/Faker/Provider/ja_JP/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ja_JP;
 use Faker\Provider\ja_JP\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()

--- a/test/Faker/Provider/ka_GE/TextTest.php
+++ b/test/Faker/Provider/ka_GE/TextTest.php
@@ -4,6 +4,9 @@ namespace Faker\Test\Provider\ka_GE;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     private $textClass;

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\kk_KZ;
 use Faker\Provider\kk_KZ\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testBusinessIdentificationNumberIsValid()

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\DateTime;
 use Faker\Provider\kk_KZ\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testIndividualIdentificationNumberIsValid()

--- a/test/Faker/Provider/kk_KZ/TextTest.php
+++ b/test/Faker/Provider/kk_KZ/TextTest.php
@@ -4,6 +4,9 @@ namespace Faker\Test\Provider\kk_KZ;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     private $textClass;

--- a/test/Faker/Provider/ko_KR/TextTest.php
+++ b/test/Faker/Provider/ko_KR/TextTest.php
@@ -4,6 +4,9 @@ namespace Faker\Test\Provider\ko_KR;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     private $textClass;

--- a/test/Faker/Provider/lt_LT/AddressTest.php
+++ b/test/Faker/Provider/lt_LT/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\lt_LT;
 use Faker\Provider\lt_LT\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testMunicipality()

--- a/test/Faker/Provider/mn_MN/PersonTest.php
+++ b/test/Faker/Provider/mn_MN/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\mn_MN;
 use Faker\Provider\mn_MN\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testName()

--- a/test/Faker/Provider/ms_MY/PersonTest.php
+++ b/test/Faker/Provider/ms_MY/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ms_MY;
 use Faker\Provider\ms_MY\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/nb_NO/PhoneNumberTest.php
+++ b/test/Faker/Provider/nb_NO/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\nb_NO;
 use Faker\Provider\nb_NO\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testMobileNumber()

--- a/test/Faker/Provider/nl_BE/PaymentTest.php
+++ b/test/Faker/Provider/nl_BE/PaymentTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\nl_BE;
 use Faker\Provider\nl_BE\Payment;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testVatIsValid()

--- a/test/Faker/Provider/nl_BE/PersonTest.php
+++ b/test/Faker/Provider/nl_BE/PersonTest.php
@@ -8,6 +8,9 @@ use Faker\Test\TestCase;
 /**
  * @group Person
  */
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testRrnIsValid()

--- a/test/Faker/Provider/nl_NL/CompanyTest.php
+++ b/test/Faker/Provider/nl_NL/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\nl_NL;
 use Faker\Provider\nl_NL\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testGenerateValidVatNumber()

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\nl_NL;
 use Faker\Provider\nl_NL\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testGenerateValidIdNumber()

--- a/test/Faker/Provider/pl_PL/AddressTest.php
+++ b/test/Faker/Provider/pl_PL/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\pl_PL;
 use Faker\Provider\pl_PL\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testState()

--- a/test/Faker/Provider/pl_PL/LicensePlateTest.php
+++ b/test/Faker/Provider/pl_PL/LicensePlateTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\pl_PL;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class LicensePlateTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -6,6 +6,9 @@ use DateTime;
 use Faker\Provider\pl_PL\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testPeselLenght()

--- a/test/Faker/Provider/pt_BR/CompanyTest.php
+++ b/test/Faker/Provider/pt_BR/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\pt_BR;
 use Faker\Provider\pt_BR\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testCnpjFormatIsValid()

--- a/test/Faker/Provider/pt_BR/PersonTest.php
+++ b/test/Faker/Provider/pt_BR/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\pt_BR;
 use Faker\Provider\pt_BR\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testCpfFormatIsValid()

--- a/test/Faker/Provider/pt_PT/AddressTest.php
+++ b/test/Faker/Provider/pt_PT/AddressTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\pt_PT\Address;
 use Faker\Provider\pt_PT\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testPostCodeIsValid()

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\pt_PT;
 use Faker\Provider\pt_PT\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testTaxpayerIdentificationNumberIsValid()

--- a/test/Faker/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_PT/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\pt_PT;
 use Faker\Provider\pt_PT\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumberReturnsPhoneNumberWithOrWithoutPrefix()

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Provider\DateTime;
 use Faker\Provider\ro_RO\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public const TEST_CNP_REGEX = '/^[1-9][0-9]{2}(?:0[1-9]|1[012])(?:0[1-9]|[12][0-9]|3[01])(?:0[1-9]|[123][0-9]|4[0-6]|5[12])[0-9]{3}[0-9]$/';

--- a/test/Faker/Provider/ro_RO/PhoneNumberTest.php
+++ b/test/Faker/Provider/ro_RO/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ro_RO;
 use Faker\Provider\ro_RO\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumberReturnsNormalPhoneNumber()

--- a/test/Faker/Provider/ru_RU/CompanyTest.php
+++ b/test/Faker/Provider/ru_RU/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ru_RU;
 use Faker\Provider\ru_RU\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testINN()

--- a/test/Faker/Provider/ru_RU/PersonTest.php
+++ b/test/Faker/Provider/ru_RU/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\ru_RU;
 use Faker\Provider\ru_RU\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testLastNameFemale()

--- a/test/Faker/Provider/ru_RU/TextTest.php
+++ b/test/Faker/Provider/ru_RU/TextTest.php
@@ -4,6 +4,9 @@ namespace Faker\Test\Provider\ru_RU;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     private $textClass;

--- a/test/Faker/Provider/sv_SE/MunicipalityTest.php
+++ b/test/Faker/Provider/sv_SE/MunicipalityTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\sv_SE;
 use Faker\Provider\sv_SE\Municipality;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class MunicipalityTest extends TestCase
 {
     public function testGenerate()

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -6,6 +6,9 @@ use Faker\Calculator\Luhn;
 use Faker\Provider\sv_SE\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function provideSeedAndExpectedReturn()

--- a/test/Faker/Provider/tr_TR/CompanyTest.php
+++ b/test/Faker/Provider/tr_TR/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\tr_TR;
 use Faker\Provider\tr_TR\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testCompany()

--- a/test/Faker/Provider/tr_TR/PaymentTest.php
+++ b/test/Faker/Provider/tr_TR/PaymentTest.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\tr_TR;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PaymentTest extends TestCase
 {
     public function testBankAccountNumber()

--- a/test/Faker/Provider/tr_TR/PersonTest.php
+++ b/test/Faker/Provider/tr_TR/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\tr_TR;
 use Faker\Provider\tr_TR\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testTCNo()

--- a/test/Faker/Provider/tr_TR/PhoneNumberTest.php
+++ b/test/Faker/Provider/tr_TR/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\tr_TR;
 use Faker\Provider\tr_TR\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\uk_UA;
 use Faker\Provider\uk_UA\Address;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class AddressTest extends TestCase
 {
     public function testPostCodeIsValid()

--- a/test/Faker/Provider/uk_UA/PersonTest.php
+++ b/test/Faker/Provider/uk_UA/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\uk_UA;
 use Faker\Provider\uk_UA\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     public function testFirstNameMaleReturns()

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\uk_UA;
 use Faker\Provider\uk_UA\PhoneNumber;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumberFormat()

--- a/test/Faker/Provider/zh_TW/CompanyTest.php
+++ b/test/Faker/Provider/zh_TW/CompanyTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\zh_TW;
 use Faker\Provider\zh_TW\Company;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class CompanyTest extends TestCase
 {
     public function testVAT()

--- a/test/Faker/Provider/zh_TW/PersonTest.php
+++ b/test/Faker/Provider/zh_TW/PersonTest.php
@@ -5,6 +5,9 @@ namespace Faker\Test\Provider\zh_TW;
 use Faker\Provider\zh_TW\Person;
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class PersonTest extends TestCase
 {
     /**

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -4,6 +4,9 @@ namespace Faker\Test\Provider\zh_TW;
 
 use Faker\Test\TestCase;
 
+/**
+ * @group legacy
+ */
 final class TextTest extends TestCase
 {
     private $textClass;


### PR DESCRIPTION
This PR deprecates access to `$faker->name`. One should always use `$faker->name()` instead. 

I also add `@group legacy` to all tests for the providers. This is too many, I know, but I'll soon deprecate all providers too. =)

Why we should use `trigger_deprecation()` and not writing the deprecations ourselves? Some benefits are described in the [readme](https://github.com/symfony/deprecation-contracts). But the major thing for me is that deprecations will be easier to write (and eventually remove). 

This is just the first of the many deprecations we will add the next few weeks. 

