### PR TITLE
Enhancement: Enable and configure general_phpdoc_annotation_remove fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -54,6 +54,11 @@ return $config
         ],
         'declare_equal_normalize' => true,
         'function_typehint_space' => true,
+        'general_phpdoc_annotation_remove' => [
+            'annotations' => [
+                'author',
+            ],
+        ],
         'implode_call' => true,
         'lambda_not_used_import' => true,
         'lowercase_cast' => true,

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider;
 
 /**
- * @author lsv
  */
 class Color extends Base
 {

--- a/src/Faker/Provider/da_DK/Address.php
+++ b/src/Faker/Provider/da_DK/Address.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\da_DK;
 
 /**
- * @author Antoine Corcy <contact@sbin.dk>
  */
 class Address extends \Faker\Provider\Address
 {

--- a/src/Faker/Provider/da_DK/Company.php
+++ b/src/Faker/Provider/da_DK/Company.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\da_DK;
 
 /**
- * @author Antoine Corcy <contact@sbin.dk>
  */
 class Company extends \Faker\Provider\Company
 {

--- a/src/Faker/Provider/da_DK/Internet.php
+++ b/src/Faker/Provider/da_DK/Internet.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\da_DK;
 
 /**
- * @author Antoine Corcy <contact@sbin.dk>
  */
 class Internet extends \Faker\Provider\Internet
 {

--- a/src/Faker/Provider/da_DK/Person.php
+++ b/src/Faker/Provider/da_DK/Person.php
@@ -6,8 +6,6 @@ use Faker\Provider\DateTime;
 
 /**
  * @link http://www.danskernesnavne.navneforskning.ku.dk/Personnavne.asp
- *
- * @author Antoine Corcy <contact@sbin.dk>
  */
 class Person extends \Faker\Provider\Person
 {

--- a/src/Faker/Provider/da_DK/PhoneNumber.php
+++ b/src/Faker/Provider/da_DK/PhoneNumber.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\da_DK;
 
 /**
- * @author Antoine Corcy <contact@sbin.dk>
  */
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {

--- a/src/Faker/Provider/et_EE/Person.php
+++ b/src/Faker/Provider/et_EE/Person.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\et_EE;
 
 /**
- * @author David Gegelija <code@imdavid.xyz>
  */
 class Person extends \Faker\Provider\Person
 {

--- a/src/Faker/Provider/is_IS/Address.php
+++ b/src/Faker/Provider/is_IS/Address.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\is_IS;
 
 /**
- * @author Birkir Gudjonsson <birkir.gudjonsson@gmail.com>
  */
 class Address extends \Faker\Provider\Address
 {

--- a/src/Faker/Provider/is_IS/Company.php
+++ b/src/Faker/Provider/is_IS/Company.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\is_IS;
 
 /**
- * @author Birkir Gudjonsson <birkir.gudjonsson@gmail.com>
  */
 class Company extends \Faker\Provider\Company
 {

--- a/src/Faker/Provider/is_IS/Internet.php
+++ b/src/Faker/Provider/is_IS/Internet.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\is_IS;
 
 /**
- * @author Birkir Gudjonsson <birkir.gudjonsson@gmail.com>
  */
 class Internet extends \Faker\Provider\Internet
 {

--- a/src/Faker/Provider/is_IS/Person.php
+++ b/src/Faker/Provider/is_IS/Person.php
@@ -5,7 +5,6 @@ namespace Faker\Provider\is_IS;
 use Faker\Provider\DateTime;
 
 /**
- * @author Birkir Gudjonsson <birkir.gudjonsson@gmail.com>
  */
 class Person extends \Faker\Provider\Person
 {

--- a/src/Faker/Provider/is_IS/PhoneNumber.php
+++ b/src/Faker/Provider/is_IS/PhoneNumber.php
@@ -3,7 +3,6 @@
 namespace Faker\Provider\is_IS;
 
 /**
- * @author Birkir Gudjonsson <birkir.gudjonsson@gmail.com>
  */
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {


### PR DESCRIPTION
This PR

* [x] enables and configures the `general_phpdoc_annotation_remove` fixer to remove `@author` annotations
* [x] runs `make cs`

Follows #157.
Related to https://github.com/FakerPHP/Faker/pull/154/files#r546353196.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/general_phpdoc_annotation_remove.rst.