### PR TITLE
Enhancement: Enable no_empty_phpdoc fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -69,6 +69,7 @@ return $config
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_blank_lines_after_class_opening' => true,
+        'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider;
 
-/**
- */
 class Color extends Base
 {
     protected static $safeColorNames = [

--- a/src/Faker/Provider/da_DK/Address.php
+++ b/src/Faker/Provider/da_DK/Address.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\da_DK;
 
-/**
- */
 class Address extends \Faker\Provider\Address
 {
     /**

--- a/src/Faker/Provider/da_DK/Company.php
+++ b/src/Faker/Provider/da_DK/Company.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\da_DK;
 
-/**
- */
 class Company extends \Faker\Provider\Company
 {
     /**

--- a/src/Faker/Provider/da_DK/Internet.php
+++ b/src/Faker/Provider/da_DK/Internet.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\da_DK;
 
-/**
- */
 class Internet extends \Faker\Provider\Internet
 {
     /**

--- a/src/Faker/Provider/da_DK/PhoneNumber.php
+++ b/src/Faker/Provider/da_DK/PhoneNumber.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\da_DK;
 
-/**
- */
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     /**

--- a/src/Faker/Provider/et_EE/Person.php
+++ b/src/Faker/Provider/et_EE/Person.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\et_EE;
 
-/**
- */
 class Person extends \Faker\Provider\Person
 {
     /**

--- a/src/Faker/Provider/is_IS/Address.php
+++ b/src/Faker/Provider/is_IS/Address.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\is_IS;
 
-/**
- */
 class Address extends \Faker\Provider\Address
 {
     /**

--- a/src/Faker/Provider/is_IS/Company.php
+++ b/src/Faker/Provider/is_IS/Company.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\is_IS;
 
-/**
- */
 class Company extends \Faker\Provider\Company
 {
     /**

--- a/src/Faker/Provider/is_IS/Internet.php
+++ b/src/Faker/Provider/is_IS/Internet.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\is_IS;
 
-/**
- */
 class Internet extends \Faker\Provider\Internet
 {
     /**

--- a/src/Faker/Provider/is_IS/Person.php
+++ b/src/Faker/Provider/is_IS/Person.php
@@ -4,8 +4,6 @@ namespace Faker\Provider\is_IS;
 
 use Faker\Provider\DateTime;
 
-/**
- */
 class Person extends \Faker\Provider\Person
 {
     /**

--- a/src/Faker/Provider/is_IS/PhoneNumber.php
+++ b/src/Faker/Provider/is_IS/PhoneNumber.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\is_IS;
 
-/**
- */
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     /**

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -72,9 +72,7 @@ final class PersonTest extends TestCase
             [Person::GENDER_FEMALE, '1981-06-16', 'B2', false, '981061642'],
         ];
     }
-    /**
-     *
-     */
+
     public function testAllRandomReturnsValidCnp()
     {
         $cnp = $this->faker->cnp;
@@ -84,9 +82,7 @@ final class PersonTest extends TestCase
         );
     }
 
-    /**
-     *
-     */
+
     public function testValidGenderReturnsValidCnp()
     {
         $cnp = $this->faker->cnp(Person::GENDER_MALE);
@@ -161,9 +157,7 @@ final class PersonTest extends TestCase
         $this->faker->cnp(null, null, $value);
     }
 
-    /**
-     *
-     */
+
     public function testNonResidentReturnsValidCnp()
     {
         $cnp = $this->faker->cnp(null, null, null, false);


### PR DESCRIPTION
This PR

* [x] enables the `no_empty_phpdoc` fixer
* [x] runs `make cs`

Follows #157.
Slightly related to #166.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/no_empty_phpdoc.rst.