### PR TITLE
Enhancement: Enable and configure php_unit_method_casing fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -86,6 +86,7 @@ return $config
         'php_unit_dedicate_assert_internal_type' => true,
         'php_unit_expectation' => true,
         'php_unit_fqcn_annotation' => true,
+        'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => true,

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -75,7 +75,7 @@ final class PersonTest extends TestCase
     /**
      *
      */
-    public function test_allRandom_returnsValidCnp()
+    public function testAllRandomReturnsValidCnp()
     {
         $cnp = $this->faker->cnp;
         self::assertTrue(
@@ -87,7 +87,7 @@ final class PersonTest extends TestCase
     /**
      *
      */
-    public function test_validGender_returnsValidCnp()
+    public function testValidGenderReturnsValidCnp()
     {
         $cnp = $this->faker->cnp(Person::GENDER_MALE);
         self::assertTrue(
@@ -107,7 +107,7 @@ final class PersonTest extends TestCase
      *
      * @dataProvider invalidGenderProvider
      */
-    public function test_invalidGender_throwsException($value)
+    public function testInvalidGenderThrowsException($value)
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->faker->cnp($value);
@@ -118,7 +118,7 @@ final class PersonTest extends TestCase
      *
      * @dataProvider validYearProvider
      */
-    public function test_validYear_returnsValidCnp($value)
+    public function testValidYearReturnsValidCnp($value)
     {
         $cnp = $this->faker->cnp(null, $value);
         self::assertTrue(
@@ -132,7 +132,7 @@ final class PersonTest extends TestCase
      *
      * @dataProvider invalidYearProvider
      */
-    public function test_invalidYear_throwsException($value)
+    public function testInvalidYearThrowsException($value)
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->faker->cnp(null, $value);
@@ -142,7 +142,7 @@ final class PersonTest extends TestCase
      * @param string $value
      * @dataProvider validCountyCodeProvider
      */
-    public function test_validCountyCode_returnsValidCnp($value)
+    public function testValidCountyCodeReturnsValidCnp($value)
     {
         $cnp = $this->faker->cnp(null, null, $value);
         self::assertTrue(
@@ -155,7 +155,7 @@ final class PersonTest extends TestCase
      * @param string $value
      * @dataProvider invalidCountyCodeProvider
      */
-    public function test_invalidCountyCode_throwsException($value)
+    public function testInvalidCountyCodeThrowsException($value)
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->faker->cnp(null, null, $value);
@@ -164,7 +164,7 @@ final class PersonTest extends TestCase
     /**
      *
      */
-    public function test_nonResident_returnsValidCnp()
+    public function testNonResidentReturnsValidCnp()
     {
         $cnp = $this->faker->cnp(null, null, null, false);
         self::assertTrue(
@@ -187,7 +187,7 @@ final class PersonTest extends TestCase
      *
      * @dataProvider validInputDataProvider
      */
-    public function test_validInputData_returnsValidCnp($gender, $dateOfBirth, $county, $isResident, $expectedCnpStart)
+    public function testValidInputDataReturnsValidCnp($gender, $dateOfBirth, $county, $isResident, $expectedCnpStart)
     {
         $cnp = $this->faker->cnp($gender, $dateOfBirth, $county, $isResident);
         self::assertStringStartsWith(


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_method_casing` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/php_unit/php_unit_method_casing.rst.