### PR TITLE
Fix: Keep attributes sorted by name

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,10 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
+    cacheResultFile=".build/.phpunit.result.cache"
     colors="true"
     columns="max"
     verbose="true"
-    cacheResultFile=".build/.phpunit.result.cache"
 >
     <testsuites>
         <testsuite name="Faker Test Suite">


### PR DESCRIPTION
This PR

* [x] keeps attributes sorted by name in `phpunit/phpunit`

Somewhat related to #178.