### PR TITLE
Fix: Disable code coverage drivers when running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
+          coverage: none
           extensions: intl
           php-version: ${{ matrix.php-version }}
 


### PR DESCRIPTION
This PR

* [x] disables code coverage drivers when running tests

Related to #178.