### PR TITLE
Enhancement: Enable and configure class_attributes_separation fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -47,6 +47,11 @@ return $config
             ],
         ],
         'cast_spaces' => true,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method' => 'one',
+            ],
+        ],
         'combine_nested_dirname' => true,
         'compact_nullable_typehint' => true,
         'concat_space' => [

--- a/src/Faker/ORM/Spot/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Spot/ColumnTypeGuesser.php
@@ -8,7 +8,6 @@ class ColumnTypeGuesser
 {
     protected $generator;
 
-
     /**
      * ColumnTypeGuesser constructor.
      * @param Generator $generator

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -94,6 +94,7 @@ class Internet extends Base
 
         return static::randomElement($domains);
     }
+
     /**
      * @example 'jdoe'
      */
@@ -115,6 +116,7 @@ class Internet extends Base
 
         return $username;
     }
+
     /**
      * @example 'fY4èHdZv68'
      */

--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -431,7 +431,6 @@ class Person extends \Faker\Provider\Person
      * @param  int         $maxAge maximal age of "generated person" in years
      * @return czech       birth number
      */
-
     public function birthNumber($gender = null, $minAge = 0, $maxAge = 100, $slashProbability = 50)
     {
         if ($gender === null) {

--- a/src/Faker/Provider/es_PE/Person.php
+++ b/src/Faker/Provider/es_PE/Person.php
@@ -88,7 +88,6 @@ class Person extends \Faker\Provider\Person
         return static::randomElement(static::$suffix);
     }
 
-
     /**
      * Generate a Documento Nacional de Identidad (DNI) number
      *

--- a/src/Faker/Provider/fa_IR/PhoneNumber.php
+++ b/src/Faker/Provider/fa_IR/PhoneNumber.php
@@ -68,6 +68,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         '0937#######',
         '0990#######', // MCI
     ];
+
     public static function mobileNumber()
     {
         return static::numerify(static::randomElement(static::$mobileNumberPrefixes));

--- a/src/Faker/Provider/fr_FR/PhoneNumber.php
+++ b/src/Faker/Provider/fr_FR/PhoneNumber.php
@@ -133,6 +133,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
         return static::numerify($this->generator->parse($format));
     }
+
     /**
      * @example '0891951357'
      */

--- a/src/Faker/Provider/ka_GE/Address.php
+++ b/src/Faker/Provider/ka_GE/Address.php
@@ -102,7 +102,6 @@ class Address extends \Faker\Provider\Address
         '{{cityPrefix}} {{cityName}}'
     ];
 
-
     public static function regionSuffix()
     {
         return static::randomElement(static::$regionSuffix);

--- a/src/Faker/Provider/ka_GE/Company.php
+++ b/src/Faker/Provider/ka_GE/Company.php
@@ -26,7 +26,6 @@ class Company extends \Faker\Provider\Company
         '{{companyPrefix}} {{companyNameElement}}{{companyNameElement}}{{companyNameElement}}{{companyNameSuffix}}',
     ];
 
-
     /**
      * @example 'იმ ელექტროალმასგეოსაბჭო'
      */

--- a/src/Faker/Provider/ko_KR/PhoneNumber.php
+++ b/src/Faker/Provider/ko_KR/PhoneNumber.php
@@ -31,8 +31,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return self::numerify($this->generator->parse($format));
     }
 
-
-
     public function cellPhoneNumber()
     {
         $format = self::randomElement(array_slice(static::$formats, 6, 1));

--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -63,7 +63,6 @@ class Company extends \Faker\Provider\Company
         'Café', 'Garage'
     ];
 
-
     /**
      * @example 'Fietsenmaker Zijlemans'
      *

--- a/src/Faker/Provider/pt_BR/Payment.php
+++ b/src/Faker/Provider/pt_BR/Payment.php
@@ -70,7 +70,6 @@ class Payment extends \Faker\Provider\Payment
         return static::iban($countryCode, $prefix, $length);
     }
 
-
     /**
      * @see list of Brazilians banks (2018-02-15), source: https://pt.wikipedia.org/wiki/Lista_de_bancos_do_Brasil
      */

--- a/test/Faker/Calculator/IbanTest.php
+++ b/test/Faker/Calculator/IbanTest.php
@@ -295,6 +295,7 @@ final class IbanTest extends TestCase
 
         return $return;
     }
+
     /**
      * @dataProvider mod97Provider
      */

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -24,7 +24,6 @@ final class BaseTest extends TestCase
         self::assertLessThan(10, BaseProvider::randomDigitNotNull());
     }
 
-
     public function testRandomDigitNotReturnsValidDigit()
     {
         for ($i = 0; $i <= 9; $i++) {

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -165,6 +165,7 @@ final class PaymentTest extends TestCase
 
         return $return;
     }
+
     /**
      * @dataProvider ibanFormatProvider
      */

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -38,7 +38,6 @@ final class ProviderOverrideTest extends TestCase
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->country);
     }
 
-
     /**
      * @dataProvider localeDataProvider
      *
@@ -50,7 +49,6 @@ final class ProviderOverrideTest extends TestCase
 
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->company);
     }
-
 
     /**
      * @dataProvider localeDataProvider
@@ -64,7 +62,6 @@ final class ProviderOverrideTest extends TestCase
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->century);
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->timezone);
     }
-
 
     /**
      * @dataProvider localeDataProvider
@@ -87,7 +84,6 @@ final class ProviderOverrideTest extends TestCase
         self::assertMatchesRegularExpression(static::TEST_EMAIL_REGEX, $faker->companyEmail);
     }
 
-
     /**
      * @dataProvider localeDataProvider
      *
@@ -103,7 +99,6 @@ final class ProviderOverrideTest extends TestCase
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->lastName);
     }
 
-
     /**
      * @dataProvider localeDataProvider
      *
@@ -116,7 +111,6 @@ final class ProviderOverrideTest extends TestCase
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->phoneNumber);
     }
 
-
     /**
      * @dataProvider localeDataProvider
      *
@@ -128,7 +122,6 @@ final class ProviderOverrideTest extends TestCase
 
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->userAgent);
     }
-
 
     /**
      * @dataProvider localeDataProvider

--- a/test/Faker/Provider/fr_FR/CompanyTest.php
+++ b/test/Faker/Provider/fr_FR/CompanyTest.php
@@ -55,7 +55,6 @@ final class CompanyTest extends TestCase
         self::assertTrue($isCatchPhraseValid);
     }
 
-
     protected function getProviders(): iterable
     {
         yield new Company($this->faker);

--- a/test/Faker/Provider/ja_JP/PhoneNumberTest.php
+++ b/test/Faker/Provider/ja_JP/PhoneNumberTest.php
@@ -16,7 +16,6 @@ final class PhoneNumberTest extends TestCase
         }
     }
 
-
     protected function getProviders(): iterable
     {
         yield new PhoneNumber($this->faker);

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -19,7 +19,6 @@ final class CompanyTest extends TestCase
         );
     }
 
-
     protected function getProviders(): iterable
     {
         yield new Company($this->faker);

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -17,7 +17,6 @@ final class PersonTest extends TestCase
         self::assertSame($controlDigit, (int) substr($individualIdentificationNumber, 11, 1));
     }
 
-
     protected function getProviders(): iterable
     {
         yield new Person($this->faker);

--- a/test/Faker/Provider/mn_MN/PersonTest.php
+++ b/test/Faker/Provider/mn_MN/PersonTest.php
@@ -17,7 +17,6 @@ final class PersonTest extends TestCase
         self::assertMatchesRegularExpression('/^[А-Я]{2}\d{8}$/u', $this->faker->idNumber);
     }
 
-
     protected function getProviders(): iterable
     {
         yield new Person($this->faker);

--- a/test/Faker/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_PT/PhoneNumberTest.php
@@ -11,6 +11,7 @@ final class PhoneNumberTest extends TestCase
     {
         self::assertMatchesRegularExpression('/^(9[1,2,3,6][0-9]{7})|(2[0-9]{8})|(\+351 [2][0-9]{8})|(\+351 9[1,2,3,6][0-9]{7})/', $this->faker->phoneNumber());
     }
+
     public function testMobileNumberReturnsMobileNumberWithOrWithoutPrefix()
     {
         self::assertMatchesRegularExpression('/^(9[1,2,3,6][0-9]{7})/', $this->faker->mobileNumber());

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -82,7 +82,6 @@ final class PersonTest extends TestCase
         );
     }
 
-
     public function testValidGenderReturnsValidCnp()
     {
         $cnp = $this->faker->cnp(Person::GENDER_MALE);
@@ -157,7 +156,6 @@ final class PersonTest extends TestCase
         $this->faker->cnp(null, null, $value);
     }
 
-
     public function testNonResidentReturnsValidCnp()
     {
         $cnp = $this->faker->cnp(null, null, null, false);
@@ -190,7 +188,6 @@ final class PersonTest extends TestCase
             sprintf("Invalid CNP '%' generated for non valid data", $cnp)
         );
     }
-
 
     protected function isValidFemaleCnp($value)
     {


### PR DESCRIPTION
This PR

* [x] enables and configures the `class_attributes_separation` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/class_notation/class_attributes_separation.rst.