### PR TITLE
Enhancement: Enable and configure phpdoc_types_order fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -117,6 +117,10 @@ return $config
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'alpha',
+        ],
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'psr_autoloading' => true,

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -51,7 +51,6 @@
     <UndefinedDocblockClass occurrences="3">
       <code>$this-&gt;manager</code>
       <code>ObjectManager|null</code>
-      <code>null|EntityManager</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/Faker/ORM/Mandango/EntityPopulator.php">

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -58,17 +58,17 @@ namespace Faker;
  * @property string $vat
  *
  * @property string $word
- * @property string|array $words
- * @method string|array words($nb = 3, $asText = false)
+ * @property array|string $words
+ * @method array|string words($nb = 3, $asText = false)
  * @method string word()
  * @property string $sentence
  * @method string sentence($nbWords = 6, $variableNbWords = true)
- * @property string|array $sentences
- * @method string|array sentences($nb = 3, $asText = false)
+ * @property array|string $sentences
+ * @method array|string sentences($nb = 3, $asText = false)
  * @property string $paragraph
  * @method string paragraph($nbSentences = 3, $variableNbSentences = true)
- * @property string|array $paragraphs
- * @method string|array paragraphs($nb = 3, $asText = false)
+ * @property array|string $paragraphs
+ * @method array|string paragraphs($nb = 3, $asText = false)
  * @property string $text
  * @method string text($maxNbChars = 200)
  *

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -74,7 +74,7 @@ class Populator
      * Please note that large amounts of data will result in more memory usage since the the Populator will return
      * all newly created primary keys after executing.
      *
-     * @param null|EntityManager $entityManager A Doctrine connection object
+     * @param EntityManager|null $entityManager A Doctrine connection object
      *
      * @return array A list of the inserted PKs
      */

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -97,8 +97,8 @@ class Base
      * Return a random float number
      *
      * @param int       $nbMaxDecimals
-     * @param int|float $min
-     * @param int|float $max
+     * @param float|int $min
+     * @param float|int $max
      * @example 48.8932
      *
      * @return float

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -9,8 +9,8 @@ class DateTime extends Base
     protected static $defaultTimezone = null;
 
     /**
-     * @param  \DateTime|string|float|int $max
-     * @return int|false
+     * @param  \DateTime|float|int|string $max
+     * @return false|int
      */
     protected static function getMaxTimestamp($max = 'now')
     {
@@ -332,7 +332,7 @@ class DateTime extends Base
 
     /**
      * @param  string|null $timezone
-     * @return null|string
+     * @return string|null
      */
     private static function resolveTimezone($timezone)
     {

--- a/src/Faker/Provider/id_ID/Person.php
+++ b/src/Faker/Provider/id_ID/Person.php
@@ -297,8 +297,8 @@ class Person extends \Faker\Provider\Person
      *
      * @link https://en.wikipedia.org/wiki/National_identification_number#Indonesia
      *
-     * @param  null|string    $gender
-     * @param  null|\DateTime $birthDate
+     * @param  string|null    $gender
+     * @param  \DateTime|null $birthDate
      * @return string
      */
     public function nik($gender = null, $birthDate = null)

--- a/src/Faker/Provider/ms_MY/Address.php
+++ b/src/Faker/Provider/ms_MY/Address.php
@@ -597,7 +597,7 @@ class Address extends \Faker\Provider\Address
      * @example '55100'
      * @link https://en.wikipedia.org/wiki/Postal_codes_in_Malaysia#States
      *
-     * @param null|string $state 'state' or null
+     * @param string|null $state 'state' or null
      *
      * @return string
      */

--- a/src/Faker/Provider/pt_BR/check_digit.php
+++ b/src/Faker/Provider/pt_BR/check_digit.php
@@ -8,7 +8,7 @@ namespace Faker\Provider\pt_BR;
  * @link http://pt.wikipedia.org/wiki/CNPJ#Algoritmo_de_Valida.C3.A7.C3.A3o
  * @link http://en.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas#Validation
  *
- * @param  string|int $numbers Numbers on which generate the check digit
+ * @param  int|string $numbers Numbers on which generate the check digit
  * @return int
  */
 function check_digit($numbers)

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -107,10 +107,10 @@ class Person extends \Faker\Provider\Person
      * @link http://ro.wikipedia.org/wiki/Cod_numeric_personal
      * @example 1111111111118
      *
-     * @param  null|string $gender      Person::GENDER_MALE or Person::GENDER_FEMALE
-     * @param  null|string $dateOfBirth (1800-2099) 'Y-m-d', 'Y-m', 'Y'  I.E. '1981-06-16', '2085-03', '1900'
-     * @param  null|string $county      county code where the CNP was issued
-     * @param  null|bool   $isResident  flag if the person resides in Romania
+     * @param  string|null $gender      Person::GENDER_MALE or Person::GENDER_FEMALE
+     * @param  string|null $dateOfBirth (1800-2099) 'Y-m-d', 'Y-m', 'Y'  I.E. '1981-06-16', '2085-03', '1900'
+     * @param  string|null $county      county code where the CNP was issued
+     * @param  bool|null   $isResident  flag if the person resides in Romania
      * @return string      13 digits CNP code
      */
     public function cnp($gender = null, $dateOfBirth = null, $county = null, $isResident = true)
@@ -144,7 +144,7 @@ class Person extends \Faker\Provider\Person
     }
 
     /**
-     * @param  null|string $dateOfBirth
+     * @param  string|null $dateOfBirth
      * @return \DateTime
      */
     protected function getDateOfBirth($dateOfBirth)


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_types_order` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/phpdoc_types_order.rst.