### PR TITLE
Enhancement: Enable no_extra_blank_lines fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -76,6 +76,7 @@ return $config
         'no_blank_lines_after_class_opening' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_unneeded_curly_braces' => true,

--- a/src/Faker/ORM/CakePHP/EntityPopulator.php
+++ b/src/Faker/ORM/CakePHP/EntityPopulator.php
@@ -63,7 +63,6 @@ class EntityPopulator
             return false;
         };
 
-
         foreach ($schema->columns() as $column) {
             if ($column == $pk[0] || $isForeignKey($column)) {
                 continue;

--- a/src/Faker/ORM/Spot/EntityPopulator.php
+++ b/src/Faker/ORM/Spot/EntityPopulator.php
@@ -183,7 +183,6 @@ class EntityPopulator
 
         $this->mapper->insert($obj);
 
-
         return $obj;
     }
 

--- a/src/Faker/Provider/el_GR/Company.php
+++ b/src/Faker/Provider/el_GR/Company.php
@@ -18,7 +18,6 @@ class Company extends \Faker\Provider\Company
 
     protected static $grafm = ['#########'];
 
-
     protected static $doy = [
         'Α\' Αθήνας',
         'Β\' Αθήνας',
@@ -42,7 +41,6 @@ class Company extends \Faker\Provider\Company
         'ΔΟΥ ΠΛΟΙΩΝ',
         'ΦΑΕΕ ΑΘΗΝΩΝ'
     ];
-
 
     protected static $object = [
         'Προγραμματιστής',

--- a/src/Faker/Provider/en_HK/Address.php
+++ b/src/Faker/Provider/en_HK/Address.php
@@ -132,7 +132,6 @@ class Address extends \Faker\Provider\Address
         '{{town}} {{estateSuffix}}',
     ];
 
-
     protected static $villageSuffixes = ['Village', 'Tsuen', 'San Tsuen', 'New Village', 'Wai'];
 
     protected static $estateSuffixes = ['Estate', 'Court'];

--- a/src/Faker/Provider/hr_HR/Address.php
+++ b/src/Faker/Provider/hr_HR/Address.php
@@ -29,7 +29,6 @@ class Address extends \Faker\Provider\Address
 
     protected static $postcode = ['#####'];
 
-
     /**
      * @link https://hr.wikipedia.org/wiki/Dodatak:Popis_gradova_u_Hrvatskoj
      */

--- a/src/Faker/Provider/nb_NO/Address.php
+++ b/src/Faker/Provider/nb_NO/Address.php
@@ -96,7 +96,6 @@ class Address extends \Faker\Provider\Address
         'Berlevåg', 'Tana', 'Nesseby', 'Båtsfjord', 'Sør-Varanger'
     ];
 
-
     /**
      * @var array Norwegian county names
      * @link https://no.wikipedia.org/wiki/Norges_fylker

--- a/src/Faker/Provider/nb_NO/Person.php
+++ b/src/Faker/Provider/nb_NO/Person.php
@@ -315,7 +315,6 @@ class Person extends \Faker\Provider\Person
                 $genderDigit = (string) static::numerify('#');
         }
 
-
         $digits = $datePart . $randomDigits . $genderDigit;
 
         /**
@@ -323,7 +322,6 @@ class Person extends \Faker\Provider\Person
          * @link http://no.wikipedia.org/wiki/F%C3%B8dselsnummer
          */
         $checksum = (string) static::numerify('##');
-
 
         return $digits . $checksum;
     }

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -135,7 +135,6 @@ class Person extends \Faker\Provider\Person
             $randomDigits = (string) static::numerify('###');
         }
 
-
         $checksum = Luhn::computeCheckDigit($datePart . $randomDigits);
 
         return $datePart . '-' . $randomDigits . $checksum;

--- a/test/Faker/Calculator/IbanTest.php
+++ b/test/Faker/Calculator/IbanTest.php
@@ -159,7 +159,6 @@ final class IbanTest extends TestCase
             ['YY24KIHB12476423125915947930915268',     true],
             ['ZZ25VLQT382332233206588011313776421',    true],
 
-
             ['AL4721211009000000023569874',           false],
             ['AD120001203020035910010',               false],
             ['AT61190430023457320',                   false],

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -12,7 +12,6 @@ final class PersonTest extends TestCase
         $idNumber = $this->faker->idNumber();
         self::assertEquals(9, strlen($idNumber));
 
-
         $sum = -1 * $idNumber % 10;
 
         for ($multiplier = 2; $idNumber > 0; $multiplier++) {


### PR DESCRIPTION
This PR

* [x] enables the `no_extra_blank_lines` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/whitespace/no_extra_blank_lines.rst.