### PR TITLE
Fix: Do not configure deprecated php_unit_ordered_covers fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -97,7 +97,6 @@ return $config
         'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => true,
         'php_unit_no_expectation_annotation' => true,
-        'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',


### PR DESCRIPTION
This PR

* [x] stops configuring the deprecated `php_unit_ordered_covers` fixer

Follows #157.

💁‍♂️ It proxies to the `phpdoc_order_by_value` fixer, which is enabled.

For reference, see:

- https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/php_unit/php_unit_ordered_covers.rst
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/phpdoc_order_by_value.rst