### PR TITLE
Enhancement: Enable no_useless_else fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -83,6 +83,7 @@ return $config
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unused_imports' => true,
+        'no_useless_else' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,

--- a/src/Faker/Provider/ms_MY/PhoneNumber.php
+++ b/src/Faker/Provider/ms_MY/PhoneNumber.php
@@ -106,9 +106,9 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
         if ($countryCodePrefix) {
             return static::countryCodePrefix($formatting) . static::numerify($this->generator->parse($format));
-        } else {
-            return static::numerify($this->generator->parse($format));
         }
+
+        return static::numerify($this->generator->parse($format));
     }
 
     /**
@@ -167,9 +167,9 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
         if ($countryCodePrefix) {
             return static::countryCodePrefix($formatting) . static::numerify($this->generator->parse($format));
-        } else {
-            return static::numerify($this->generator->parse($format));
         }
+
+        return static::numerify($this->generator->parse($format));
     }
 
     /**
@@ -192,9 +192,9 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
         if ($countryCodePrefix) {
             return static::countryCodePrefix($formatting) . static::numerify($this->generator->parse($format));
-        } else {
-            return static::numerify($this->generator->parse($format));
         }
+
+        return static::numerify($this->generator->parse($format));
     }
 
     /**
@@ -210,8 +210,8 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
         if ($formatting) {
             return static::randomElement(static::$plusSymbol) . static::randomElement(static::$countryCodePrefix);
-        } else {
-            return static::randomElement(static::$countryCodePrefix);
         }
+
+        return static::randomElement(static::$countryCodePrefix);
     }
 }


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_else` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/control_structure/no_useless_else.rst