### PR TITLE
Enhancement: Enable return_assignment fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -125,6 +125,7 @@ return $config
         'pow_to_exponentiation' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'short_scalar_cast' => true,
         'single_blank_line_before_namespace' => true,

--- a/src/Faker/Provider/fr_FR/PhoneNumber.php
+++ b/src/Faker/Provider/fr_FR/PhoneNumber.php
@@ -72,9 +72,8 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function phoneNumber07()
     {
         $phoneNumber = $this->phoneNumber07WithSeparator();
-        $phoneNumber = str_replace(' ', '', $phoneNumber);
 
-        return $phoneNumber;
+        return str_replace(' ', '', $phoneNumber);
     }
 
     /**
@@ -93,9 +92,8 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function phoneNumber08()
     {
         $phoneNumber = $this->phoneNumber08WithSeparator();
-        $phoneNumber = str_replace(' ', '', $phoneNumber);
 
-        return $phoneNumber;
+        return str_replace(' ', '', $phoneNumber);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] enables the `return_assignment` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/return_notation/return_assignment.rst.