### PR TITLE
Enhancement: Enable checkForThrowsDocblock option

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    checkForThrowsDocblock="true"
     errorBaseline="psalm.baseline.xml"
     errorLevel="5"
     resolveFromConfigFile="true"


### PR DESCRIPTION
This PR

* [x] enables the `checkForThrowsDocblock` for `vimeo/psalm`
* [ ] adds missing `@throws` DocBlocks