### PR TITLE
Enhancement: Enable is_null fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -67,6 +67,7 @@ return $config
         ],
         'implode_call' => true,
         'increment_style' => true,
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,

--- a/src/Faker/ORM/CakePHP/EntityPopulator.php
+++ b/src/Faker/ORM/CakePHP/EntityPopulator.php
@@ -133,7 +133,7 @@ class EntityPopulator
         $entity = $table->newEntity();
 
         foreach ($this->columnFormatters as $column => $format) {
-            if (!is_null($format)) {
+            if (null !== $format) {
                 $entity->{$column} = is_callable($format) ? $format($insertedEntities, $table) : $format;
             }
         }

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -88,7 +88,7 @@ class Image extends Base
         $word = null,
         $gray = false
     ) {
-        $dir = is_null($dir) ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
+        $dir = null === $dir ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
         // Validate directory path
         if (!is_dir($dir) || !is_writable($dir)) {
             throw new \InvalidArgumentException(sprintf('Cannot write to directory "%s"', $dir));

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -161,7 +161,7 @@ class Payment extends Base
      */
     public static function creditCardNumber($type = null, $formatted = false, $separator = '-')
     {
-        if (is_null($type)) {
+        if (null === $type) {
             $type = static::creditCardType();
         }
         $mask = static::randomElement(static::$cardParams[$type]);
@@ -206,7 +206,7 @@ class Payment extends Base
      */
     public function creditCardExpirationDateString($valid = true, $expirationDateFormat = null)
     {
-        return $this->creditCardExpirationDate($valid)->format(is_null($expirationDateFormat) ? static::$expirationDateFormat : $expirationDateFormat);
+        return $this->creditCardExpirationDate($valid)->format(null === $expirationDateFormat ? static::$expirationDateFormat : $expirationDateFormat);
     }
 
     /**
@@ -239,7 +239,7 @@ class Payment extends Base
      */
     public static function iban($countryCode = null, $prefix = '', $length = null)
     {
-        $countryCode = is_null($countryCode) ? self::randomKey(self::$ibanFormats) : strtoupper($countryCode);
+        $countryCode = null === $countryCode ? self::randomKey(self::$ibanFormats) : strtoupper($countryCode);
 
         $format = !isset(static::$ibanFormats[$countryCode]) ? null : static::$ibanFormats[$countryCode];
 

--- a/src/Faker/Provider/ms_MY/Address.php
+++ b/src/Faker/Provider/ms_MY/Address.php
@@ -658,7 +658,7 @@ class Address extends \Faker\Provider\Address
             ]
         ];
 
-        $postcode = is_null($state) ? static::randomElement($format) : $format[$state];
+        $postcode = null === $state ? static::randomElement($format) : $format[$state];
 
         return (string) static::randomElement($postcode);
     }

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -127,7 +127,7 @@ class Person extends \Faker\Provider\Person
 
         $date = $this->getDateOfBirth($dateOfBirth);
 
-        if (is_null($county)) {
+        if (null === $county) {
             $countyCode = static::randomElement(array_values(static::$cnpCountyCodes));
         } elseif (!array_key_exists($county, static::$cnpCountyCodes)) {
             throw new \InvalidArgumentException("Invalid county code '{$county}' received");

--- a/src/Faker/ValidGenerator.php
+++ b/src/Faker/ValidGenerator.php
@@ -19,7 +19,7 @@ class ValidGenerator
      */
     public function __construct(Generator $generator, $validator = null, $maxRetries = 10000)
     {
-        if (is_null($validator)) {
+        if (null === $validator) {
             $validator = function () {
                 return true;
             };

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -24,7 +24,7 @@ final class PersonTest extends TestCase
     {
         $regex = '(([1,2,3,5,6,8]{1}[0-9]{8})|((45)|(70)|(71)|(72)|(77)|(79)|(90|(98|(99))))[0-9]{7})';
 
-        if (is_null($tin) || !is_numeric($tin) || !strlen($tin) == 9 || preg_match("/$regex/", $tin) !== 1) {
+        if (null === $tin || !is_numeric($tin) || !strlen($tin) == 9 || preg_match("/$regex/", $tin) !== 1) {
             return false;
         }
         $n = str_split($tin);


### PR DESCRIPTION
This PR

* [x] enables the `is_null` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/language_construct/is_null.rst.