### PR TITLE
Enhancement: Enable trim_array_spaces fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -138,6 +138,7 @@ return $config
         'switch_case_space' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => true,
+        'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'visibility_required' => [
             'elements' => [

--- a/src/Faker/Provider/en_UG/Address.php
+++ b/src/Faker/Provider/en_UG/Address.php
@@ -71,9 +71,9 @@ class Address extends \Faker\Provider\en_US\Address
         'Zombo'
     ];
 
-    protected static $postcode = [ '#', '##', '###', '####', '#####' ];
+    protected static $postcode = ['#', '##', '###', '####', '#####'];
 
-    protected static $region = [ 'Central', 'East', 'North', 'West' ];
+    protected static $region = ['Central', 'East', 'North', 'West'];
 
     /**
      * @example 'Fort Portal'

--- a/src/Faker/Provider/es_PE/Address.php
+++ b/src/Faker/Provider/es_PE/Address.php
@@ -7,7 +7,7 @@ class Address extends \Faker\Provider\es_ES\Address
     protected static $cityPrefix = ['San', 'Puerto', 'Gral.', 'Don'];
     protected static $citySuffix = ['Alta', 'Baja', 'Norte', 'Este', ' Sur', ' Oeste'];
     protected static $buildingNumber = ['%####', '%###', '%##', '%#', '%'];
-    protected static $streetPrefix = ['Jr.', 'Av.', 'Cl.', 'Urb.' ];
+    protected static $streetPrefix = ['Jr.', 'Av.', 'Cl.', 'Urb.'];
     protected static $streetSuffix = [''];
     protected static $postcode = ['LIMA ##'];
     protected static $state = [

--- a/src/Faker/Provider/lt_LT/Person.php
+++ b/src/Faker/Provider/lt_LT/Person.php
@@ -373,9 +373,9 @@ class Person extends \Faker\Provider\Person
     private static function calculateSum($numbers, $time = 1)
     {
         if ($time == 1) {
-            $multipliers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 1 ];
+            $multipliers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 1];
         } else {
-            $multipliers = [3, 4, 5, 6, 7, 8, 9, 1, 2, 3 ];
+            $multipliers = [3, 4, 5, 6, 7, 8, 9, 1, 2, 3];
         }
 
         $sum = 0;


### PR DESCRIPTION
This PR

* [x] enables the `trim_array_spaces` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/array_notation/trim_array_spaces.rst.