### PR TITLE
Enhancement: Enable no_superfluous_elseif fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -80,6 +80,7 @@ return $config
         'no_extra_blank_lines' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
+        'no_superfluous_elseif' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,

--- a/src/Faker/Provider/Person.php
+++ b/src/Faker/Provider/Person.php
@@ -70,7 +70,8 @@ class Person extends Base
     {
         if ($gender === static::GENDER_MALE) {
             return static::firstNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::firstNameFemale();
         }
 
@@ -108,7 +109,8 @@ class Person extends Base
     {
         if ($gender === static::GENDER_MALE) {
             return static::titleMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::titleFemale();
         }
 

--- a/src/Faker/Provider/bg_BG/Person.php
+++ b/src/Faker/Provider/bg_BG/Person.php
@@ -96,7 +96,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }
 

--- a/src/Faker/Provider/cs_CZ/Company.php
+++ b/src/Faker/Provider/cs_CZ/Company.php
@@ -113,7 +113,8 @@ class Company extends \Faker\Provider\Company
         $mod = $prod % 11;
         if ($mod === 0 || $mod === 10) {
             return "{$ico}1";
-        } elseif ($mod === 1) {
+        }
+        if ($mod === 1) {
             return "{$ico}0";
         }
 

--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -515,7 +515,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }
 

--- a/src/Faker/Provider/el_GR/Person.php
+++ b/src/Faker/Provider/el_GR/Person.php
@@ -154,7 +154,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }
 

--- a/src/Faker/Provider/ja_JP/Person.php
+++ b/src/Faker/Provider/ja_JP/Person.php
@@ -112,7 +112,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::firstKanaNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::firstKanaNameFemale();
         }
 

--- a/src/Faker/Provider/kk_KZ/Person.php
+++ b/src/Faker/Provider/kk_KZ/Person.php
@@ -184,9 +184,11 @@ class Person extends \Faker\Provider\Person
     {
         if ($year >= 2000 && $year <= DateTime::year()) {
             return self::CENTURY_21ST;
-        } elseif ($year >= 1900) {
+        }
+        if ($year >= 1900) {
             return self::CENTURY_20TH;
-        } elseif ($year >= 1800) {
+        }
+        if ($year >= 1800) {
             return self::CENTURY_19TH;
         }
 

--- a/src/Faker/Provider/lt_LT/Person.php
+++ b/src/Faker/Provider/lt_LT/Person.php
@@ -262,7 +262,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }
 

--- a/src/Faker/Provider/pl_PL/Person.php
+++ b/src/Faker/Provider/pl_PL/Person.php
@@ -96,7 +96,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }
 

--- a/src/Faker/Provider/ru_RU/Person.php
+++ b/src/Faker/Provider/ru_RU/Person.php
@@ -149,7 +149,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return $this->middleNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return $this->middleNameFemale();
         }
 
@@ -173,7 +174,8 @@ class Person extends \Faker\Provider\Person
 
         if (static::GENDER_FEMALE === $gender) {
             return $lastName . 'а';
-        } elseif (static::GENDER_MALE === $gender) {
+        }
+        if (static::GENDER_MALE === $gender) {
             return $lastName;
         }
 

--- a/src/Faker/Provider/sk_SK/Person.php
+++ b/src/Faker/Provider/sk_SK/Person.php
@@ -142,7 +142,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }
 

--- a/src/Faker/Provider/uk_UA/Person.php
+++ b/src/Faker/Provider/uk_UA/Person.php
@@ -91,7 +91,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return $this->middleNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return $this->middleNameFemale();
         }
 

--- a/src/Faker/Provider/vi_VN/Person.php
+++ b/src/Faker/Provider/vi_VN/Person.php
@@ -165,7 +165,8 @@ class Person extends \Faker\Provider\Person
     {
         if ($gender === static::GENDER_MALE) {
             return static::middleNameMale();
-        } elseif ($gender === static::GENDER_FEMALE) {
+        }
+        if ($gender === static::GENDER_FEMALE) {
             return static::middleNameFemale();
         }
 


### PR DESCRIPTION
This PR

* [x] enables the `no_superfluous_elseif` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/control_structure/no_superfluous_elseif.rst.