### PR TITLE
Enhancement: Configure blank_line_before_statement fixer to add blank line before if statement

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,6 +34,7 @@ return $config
                 'exit',
                 'for',
                 'foreach',
+                'if',
                 'include',
                 'include_once',
                 'require',

--- a/src/Faker/Calculator/Luhn.php
+++ b/src/Faker/Calculator/Luhn.php
@@ -44,6 +44,7 @@ class Luhn
     public static function computeCheckDigit($partialNumber)
     {
         $checkDigit = self::checksum($partialNumber . '0');
+
         if ($checkDigit === 0) {
             return 0;
         }

--- a/src/Faker/Documentor.php
+++ b/src/Faker/Documentor.php
@@ -33,6 +33,7 @@ class Documentor
                     continue;
                 }
                 $methodName = $reflmethod->name;
+
                 if ($reflmethod->isConstructor()) {
                     continue;
                 }
@@ -40,6 +41,7 @@ class Documentor
 
                 foreach ($reflmethod->getParameters() as $reflparameter) {
                     $parameter = '$' . $reflparameter->getName();
+
                     if ($reflparameter->isDefaultValueAvailable()) {
                         $parameter .= ' = ' . var_export($reflparameter->getDefaultValue(), true);
                     }
@@ -52,6 +54,7 @@ class Documentor
                 } catch (\InvalidArgumentException $e) {
                     $example = '';
                 }
+
                 if (is_array($example)) {
                     $example = "array('" . implode("', '", $example) . "')";
                 } elseif ($example instanceof \DateTime) {

--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -59,6 +59,7 @@ class Factory
     protected static function findProviderClassname($provider, $locale = '')
     {
         $providerClass = 'Faker\\' . ($locale ? sprintf('Provider\%s\%s', $locale, $provider) : sprintf('Provider\%s', $provider));
+
         if (class_exists($providerClass, true)) {
             return $providerClass;
         }

--- a/src/Faker/Guesser/Name.php
+++ b/src/Faker/Guesser/Name.php
@@ -26,11 +26,13 @@ class Name
     {
         $name = Base::toLower($name);
         $generator = $this->generator;
+
         if (preg_match('/^is[_A-Z]/', $name)) {
             return function () use ($generator) {
                 return $generator->boolean;
             };
         }
+
         if (preg_match('/(_a|A)t$/', $name)) {
             return function () use ($generator) {
                 return $generator->dateTime;

--- a/src/Faker/ORM/CakePHP/EntityPopulator.php
+++ b/src/Faker/ORM/CakePHP/EntityPopulator.php
@@ -96,6 +96,7 @@ class EntityPopulator
                 $foreignModel = $table->alias();
 
                 $foreignKeys = [];
+
                 if (!empty($insertedEntities[$foreignModel])) {
                     $foreignKeys = $insertedEntities[$foreignModel];
                 } else {
@@ -146,6 +147,7 @@ class EntityPopulator
         }
 
         $pk = $table->primaryKey();
+
         if (is_string($pk)) {
             return $entity->{$pk};
         }
@@ -161,6 +163,7 @@ class EntityPopulator
     protected function getTable($class)
     {
         $options = [];
+
         if (!empty($this->connectionName)) {
             $options['connection'] = $this->connectionName;
         }

--- a/src/Faker/ORM/CakePHP/Populator.php
+++ b/src/Faker/ORM/CakePHP/Populator.php
@@ -78,11 +78,13 @@ class Populator
         }
 
         $entity->columnFormatters = $entity->guessColumnFormatters($this);
+
         if ($customColumnFormatters) {
             $entity->mergeColumnFormattersWith($customColumnFormatters);
         }
 
         $entity->modifiers = $entity->guessModifiers($this);
+
         if ($customModifiers) {
             $entity->mergeModifiersWith($customModifiers);
         }

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -98,11 +98,13 @@ class EntityPopulator
             }
 
             $size = $this->class->fieldMappings[$fieldName]['length'] ?? null;
+
             if ($formatter = $nameGuesser->guessFormat($fieldName, $size)) {
                 $formatters[$fieldName] = $formatter;
 
                 continue;
             }
+
             if ($formatter = $columnTypeGuesser->guessFormat($fieldName, $this->class)) {
                 $formatters[$fieldName] = $formatter;
 
@@ -118,6 +120,7 @@ class EntityPopulator
             $relatedClass = $this->class->getAssociationTargetClass($assocName);
 
             $unique = $optional = false;
+
             if ($this->class instanceof \Doctrine\ORM\Mapping\ClassMetadata) {
                 $mappings = $this->class->getAssociationMappings();
 
@@ -151,6 +154,7 @@ class EntityPopulator
                 if (isset($inserted[$relatedClass])) {
                     if ($unique) {
                         $related = null;
+
                         if (isset($inserted[$relatedClass][$index]) || !$optional) {
                             $related = $inserted[$relatedClass][$index];
                         }
@@ -216,6 +220,7 @@ class EntityPopulator
                 }
                 // Try a standard setter if it's available, otherwise fall back on reflection
                 $setter = sprintf('set%s', ucfirst($field));
+
                 if (is_callable([$obj, $setter])) {
                     $obj->$setter($value);
                 } else {

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -58,6 +58,7 @@ class Populator
             $entity = new \Faker\ORM\Doctrine\EntityPopulator($this->manager->getClassMetadata($entity));
         }
         $entity->setColumnFormatters($entity->guessColumnFormatters($this->generator));
+
         if ($customColumnFormatters) {
             $entity->mergeColumnFormattersWith($customColumnFormatters);
         }
@@ -84,6 +85,7 @@ class Populator
         if (null === $entityManager) {
             $entityManager = $this->manager;
         }
+
         if (null === $entityManager) {
             throw new \InvalidArgumentException('No entity manager passed to Doctrine Populator.');
         }
@@ -99,6 +101,7 @@ class Populator
                     $insertedEntities,
                     $generateId
                 );
+
                 if (count($insertedEntities) % $this->batchSize === 0) {
                     $entityManager->flush();
                 }

--- a/src/Faker/ORM/Mandango/EntityPopulator.php
+++ b/src/Faker/ORM/Mandango/EntityPopulator.php
@@ -68,6 +68,7 @@ class EntityPopulator
 
                 continue;
             }
+
             if ($formatter = $columnTypeGuesser->guessFormat($field)) {
                 $formatters[$fieldName] = $formatter;
 

--- a/src/Faker/ORM/Mandango/Populator.php
+++ b/src/Faker/ORM/Mandango/Populator.php
@@ -37,6 +37,7 @@ class Populator
             $entity = new \Faker\ORM\Mandango\EntityPopulator($entity);
         }
         $entity->setColumnFormatters($entity->guessColumnFormatters($this->generator, $this->mandango));
+
         if ($customColumnFormatters) {
             $entity->mergeColumnFormattersWith($customColumnFormatters);
         }

--- a/src/Faker/ORM/Propel/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel/ColumnTypeGuesser.php
@@ -25,6 +25,7 @@ class ColumnTypeGuesser
     public function guessFormat(ColumnMap $column)
     {
         $generator = $this->generator;
+
         if ($column->isTemporal()) {
             if ($column->isEpochTemporal()) {
                 return function () use ($generator) {

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -67,6 +67,7 @@ class EntityPopulator
             if ($this->isColumnBehavior($columnMap)) {
                 continue;
             }
+
             if ($columnMap->isForeignKey()) {
                 $relatedClass = $columnMap->getRelation()->getForeignTable()->getClassname();
                 $formatters[$columnMap->getPhpName()] = function ($inserted) use ($relatedClass, $generator) {
@@ -75,14 +76,17 @@ class EntityPopulator
 
                 continue;
             }
+
             if ($columnMap->isPrimaryKey()) {
                 continue;
             }
+
             if ($formatter = $nameGuesser->guessFormat($columnMap->getPhpName(), $columnMap->getSize())) {
                 $formatters[$columnMap->getPhpName()] = $formatter;
 
                 continue;
             }
+
             if ($formatter = $columnTypeGuesser->guessFormat($columnMap)) {
                 $formatters[$columnMap->getPhpName()] = $formatter;
 
@@ -106,6 +110,7 @@ class EntityPopulator
             switch ($name) {
                 case 'nested_set':
                     $columnNames = [$params['left_column'], $params['right_column'], $params['level_column']];
+
                     if (in_array($columnName, $columnNames)) {
                         return true;
                     }
@@ -114,6 +119,7 @@ class EntityPopulator
 
                 case 'timestampable':
                     $columnNames = [$params['create_column'], $params['update_column']];
+
                     if (in_array($columnName, $columnNames)) {
                         return true;
                     }

--- a/src/Faker/ORM/Propel/Populator.php
+++ b/src/Faker/ORM/Propel/Populator.php
@@ -32,10 +32,12 @@ class Populator
             $entity = new \Faker\ORM\Propel\EntityPopulator($entity);
         }
         $entity->setColumnFormatters($entity->guessColumnFormatters($this->generator));
+
         if ($customColumnFormatters) {
             $entity->mergeColumnFormattersWith($customColumnFormatters);
         }
         $entity->setModifiers($entity->guessModifiers($this->generator));
+
         if ($customModifiers) {
             $entity->mergeModifiersWith($customModifiers);
         }
@@ -67,6 +69,7 @@ class Populator
             }
         }
         $con->commit();
+
         if ($isInstancePoolingEnabled) {
             \Propel::enableInstancePooling();
         }

--- a/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
@@ -25,6 +25,7 @@ class ColumnTypeGuesser
     public function guessFormat(ColumnMap $column)
     {
         $generator = $this->generator;
+
         if ($column->isTemporal()) {
             if ($column->getType() == PropelTypes::BU_DATE || $column->getType() == PropelTypes::BU_TIMESTAMP) {
                 return function () use ($generator) {

--- a/src/Faker/ORM/Propel2/EntityPopulator.php
+++ b/src/Faker/ORM/Propel2/EntityPopulator.php
@@ -67,6 +67,7 @@ class EntityPopulator
             if ($this->isColumnBehavior($columnMap)) {
                 continue;
             }
+
             if ($columnMap->isForeignKey()) {
                 $relatedClass = $columnMap->getRelation()->getForeignTable()->getClassname();
                 $formatters[$columnMap->getPhpName()] = function ($inserted) use ($relatedClass, $generator) {
@@ -77,14 +78,17 @@ class EntityPopulator
 
                 continue;
             }
+
             if ($columnMap->isPrimaryKey()) {
                 continue;
             }
+
             if ($formatter = $nameGuesser->guessFormat($columnMap->getPhpName(), $columnMap->getSize())) {
                 $formatters[$columnMap->getPhpName()] = $formatter;
 
                 continue;
             }
+
             if ($formatter = $columnTypeGuesser->guessFormat($columnMap)) {
                 $formatters[$columnMap->getPhpName()] = $formatter;
 
@@ -108,6 +112,7 @@ class EntityPopulator
             switch ($name) {
                 case 'nested_set':
                     $columnNames = [$params['left_column'], $params['right_column'], $params['level_column']];
+
                     if (in_array($columnName, $columnNames)) {
                         return true;
                     }
@@ -116,6 +121,7 @@ class EntityPopulator
 
                 case 'timestampable':
                     $columnNames = [$params['create_column'], $params['update_column']];
+
                     if (in_array($columnName, $columnNames)) {
                         return true;
                     }

--- a/src/Faker/ORM/Propel2/Populator.php
+++ b/src/Faker/ORM/Propel2/Populator.php
@@ -35,10 +35,12 @@ class Populator
             $entity = new \Faker\ORM\Propel2\EntityPopulator($entity);
         }
         $entity->setColumnFormatters($entity->guessColumnFormatters($this->generator));
+
         if ($customColumnFormatters) {
             $entity->mergeColumnFormattersWith($customColumnFormatters);
         }
         $entity->setModifiers($entity->guessModifiers($this->generator));
+
         if ($customModifiers) {
             $entity->mergeModifiersWith($customModifiers);
         }
@@ -70,6 +72,7 @@ class Populator
             }
         }
         $con->commit();
+
         if ($isInstancePoolingEnabled) {
             Propel::enableInstancePooling();
         }

--- a/src/Faker/ORM/Spot/EntityPopulator.php
+++ b/src/Faker/ORM/Spot/EntityPopulator.php
@@ -120,11 +120,13 @@ class EntityPopulator
             if ($field['primary'] === true) {
                 continue;
             }
+
             if ($formatter = $nameGuesser->guessFormat($fieldName)) {
                 $formatters[$fieldName] = $formatter;
 
                 continue;
             }
+
             if ($formatter = $columnTypeGuesser->guessFormat($field)) {
                 $formatters[$fieldName] = $formatter;
 
@@ -155,6 +157,7 @@ class EntityPopulator
                         // So let's find something existing in DB.
                         $mapper = $locator->mapper($entityName);
                         $records = $mapper->all()->limit(self::RELATED_FETCH_COUNT)->toArray();
+
                         if (empty($records)) {
                             return null;
                         }

--- a/src/Faker/ORM/Spot/Populator.php
+++ b/src/Faker/ORM/Spot/Populator.php
@@ -43,12 +43,14 @@ class Populator
         $useExistingData = false
     ) {
         $mapper = $this->locator->mapper($entityName);
+
         if (null === $mapper) {
             throw new \InvalidArgumentException('No mapper can be found for entity ' . $entityName);
         }
         $entity = new EntityPopulator($mapper, $this->locator, $useExistingData);
 
         $entity->setColumnFormatters($entity->guessColumnFormatters($this->generator));
+
         if ($customColumnFormatters) {
             $entity->mergeColumnFormattersWith($customColumnFormatters);
         }
@@ -70,6 +72,7 @@ class Populator
         if (null === $locator) {
             $locator = $this->locator;
         }
+
         if (null === $locator) {
             throw new \InvalidArgumentException('No entity manager passed to Spot Populator.');
         }

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -57,6 +57,7 @@ class Base
     public static function randomDigitNot($except)
     {
         $result = self::numberBetween(0, 8);
+
         if ($result >= $except) {
             ++$result;
         }
@@ -81,13 +82,16 @@ class Base
         if (!is_bool($strict)) {
             throw new \InvalidArgumentException('randomNumber() generates numbers of fixed width. To generate numbers between two boundaries, use numberBetween() instead.');
         }
+
         if (null === $nbDigits) {
             $nbDigits = static::randomDigitNotNull();
         }
         $max = 10 ** $nbDigits - 1;
+
         if ($max > mt_getrandmax()) {
             throw new \InvalidArgumentException('randomNumber() can only generate numbers up to mt_getrandmax()');
         }
+
         if ($strict) {
             return mt_rand(10 ** ($nbDigits - 1), $max);
         }
@@ -114,6 +118,7 @@ class Base
 
         if (null === $max) {
             $max = static::randomNumber();
+
             if ($min > $max) {
                 $max = $min;
             }
@@ -281,6 +286,7 @@ class Base
         if (is_array($arg)) {
             return static::shuffleArray($arg);
         }
+
         if (is_string($arg)) {
             return static::shuffleString($arg);
         }
@@ -316,6 +322,7 @@ class Base
             } else {
                 $j = mt_rand(0, $i);
             }
+
             if ($j == $i) {
                 $shuffledArray[]= $value;
             } else {
@@ -391,6 +398,7 @@ class Base
         // instead of using randomDigit() several times, which is slow,
         // count the number of hashes and generate once a large number
         $toReplace = [];
+
         if (($pos = strpos($string, '#')) !== false) {
             for ($i = $pos, $last = strrpos($string, '#', $pos) + 1; $i < $last; ++$i) {
                 if ($string[$i] === '#') {
@@ -398,6 +406,7 @@ class Base
                 }
             }
         }
+
         if ($nbReplacements = count($toReplace)) {
             $maxAtOnce = strlen((string) mt_getrandmax()) - 1;
             $numbers = '';

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -69,6 +69,7 @@ class HtmlLorem extends Base
     private function addRandomSubTree(\DOMElement $root, $maxDepth, $maxWidth)
     {
         --$maxDepth;
+
         if ($maxDepth <= 0) {
             return $root;
         }

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -47,12 +47,15 @@ class Image extends Base
         $size = sprintf('%dx%d.png', $width, $height);
 
         $imageParts = [];
+
         if ($category !== null) {
             $imageParts[] = $category;
         }
+
         if ($word !== null) {
             $imageParts[] = $word;
         }
+
         if ($randomize === true) {
             $imageParts[] = Lorem::word();
         }

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -181,6 +181,7 @@ class Internet extends Base
         if ($nbWords <= 0) {
             return '';
         }
+
         if ($variableNbWords) {
             $nbWords = (int) ($nbWords * self::numberBetween(60, 140) / 100) + 1;
         }
@@ -242,6 +243,7 @@ class Internet extends Base
         }
 
         $transId = 'Any-Latin; Latin-ASCII; NFD; [:Nonspacing Mark:] Remove; NFC;';
+
         if (class_exists('Transliterator', false) && $transliterator = \Transliterator::create($transId)) {
             $transString = $transliterator->transliterate($string);
         } else {

--- a/src/Faker/Provider/Lorem.php
+++ b/src/Faker/Provider/Lorem.php
@@ -91,6 +91,7 @@ class Lorem extends Base
         if ($nbWords <= 0) {
             return '';
         }
+
         if ($variableNbWords) {
             $nbWords = self::randomizeNbElements($nbWords);
         }
@@ -138,6 +139,7 @@ class Lorem extends Base
         if ($nbSentences <= 0) {
             return '';
         }
+
         if ($variableNbSentences) {
             $nbSentences = self::randomizeNbElements($nbSentences);
         }

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -242,6 +242,7 @@ class Payment extends Base
         $countryCode = is_null($countryCode) ? self::randomKey(self::$ibanFormats) : strtoupper($countryCode);
 
         $format = !isset(static::$ibanFormats[$countryCode]) ? null : static::$ibanFormats[$countryCode];
+
         if ($length === null) {
             if ($format === null) {
                 $length = 24;
@@ -254,6 +255,7 @@ class Payment extends Base
                 }
             }
         }
+
         if ($format === null) {
             $format = [['n', $length]];
         }

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -78,6 +78,7 @@ abstract class Text extends Base
 
         do {
             ++$iterations;
+
             if ($iterations >= 100) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a valid real text', $iterations));
             }
@@ -143,6 +144,7 @@ abstract class Text extends Base
 
             for ($i = 0, $count = count($parts); $i < $count; ++$i) {
                 $stringIndex = static::implode($index);
+
                 if (!isset($words[$stringIndex])) {
                     $words[$stringIndex] = [];
                 }
@@ -185,6 +187,7 @@ abstract class Text extends Base
     protected static function validStart($word)
     {
         $isValid = true;
+
         if (static::$textStartsWithUppercase) {
             $isValid = preg_match('/^\p{Lu}/u', $word);
         }

--- a/src/Faker/Provider/UserAgent.php
+++ b/src/Faker/Provider/UserAgent.php
@@ -103,6 +103,7 @@ class UserAgent extends Base
     public static function safari()
     {
         $saf = self::numberBetween(531, 535) . '.' . self::numberBetween(1, 50) . '.' . self::numberBetween(1, 7);
+
         if (Miscellaneous::boolean()) {
             $ver = self::numberBetween(4, 5) . '.' . self::numberBetween(0, 1);
         } else {

--- a/src/Faker/Provider/cs_CZ/Company.php
+++ b/src/Faker/Provider/cs_CZ/Company.php
@@ -111,6 +111,7 @@ class Company extends \Faker\Provider\Company
             $prod += $p * $split[$i];
         }
         $mod = $prod % 11;
+
         if ($mod === 0 || $mod === 10) {
             return "{$ico}1";
         } elseif ($mod === 1) {

--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -461,6 +461,7 @@ class Person extends \Faker\Provider\Person
         // from year 1954 birth number includes CRC
         if ($year >= 1954) {
             $crc = intval($birthNumber, 10) % 11;
+
             if ($crc == 10) {
                 $crc = 0;
             }

--- a/src/Faker/Provider/en_UG/Person.php
+++ b/src/Faker/Provider/en_UG/Person.php
@@ -113,6 +113,7 @@ class Person extends \Faker\Provider\Person
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
         }
+
         if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }

--- a/src/Faker/Provider/es_VE/Person.php
+++ b/src/Faker/Provider/es_VE/Person.php
@@ -166,6 +166,7 @@ class Person extends \Faker\Provider\Person
     public function nationalId($separator = '')
     {
         $id = static::randomElement(static::$nationalityId);
+
         if ($id == 'V') {
             return $id . $separator . $this->numberBetween(10000, 100000000);
         }

--- a/src/Faker/Provider/fi_FI/Person.php
+++ b/src/Faker/Provider/fi_FI/Person.php
@@ -126,6 +126,7 @@ class Person extends \Faker\Provider\Person
         }
 
         $randomDigits = self::numberBetween(0, 89);
+
         if ($gender && $gender == static::GENDER_MALE) {
             if ($randomDigits === 0) {
                 $randomDigits .= static::randomElement([3, 5, 7, 9]);

--- a/src/Faker/Provider/fr_FR/Company.php
+++ b/src/Faker/Provider/fr_FR/Company.php
@@ -117,6 +117,7 @@ class Company extends \Faker\Provider\Company
         $nicFormat = static::randomElement(static::$siretNicFormats);
         $siret .= $this->numerify($nicFormat);
         $siret .= Luhn::computeCheckDigit($siret);
+
         if ($formatted) {
             $siret = substr($siret, 0, 3) . ' ' . substr($siret, 3, 3) . ' ' . substr($siret, 6, 3) . ' ' . substr($siret, 9, 5);
         }
@@ -135,6 +136,7 @@ class Company extends \Faker\Provider\Company
     {
         $siren = self::numerify('%#######');
         $siren .= Luhn::computeCheckDigit($siren);
+
         if ($formatted) {
             $siren = substr($siren, 0, 3) . ' ' . substr($siren, 3, 3) . ' ' . substr($siren, 6, 3);
         }

--- a/src/Faker/Provider/fr_FR/Payment.php
+++ b/src/Faker/Provider/fr_FR/Payment.php
@@ -22,6 +22,7 @@ class Payment extends \Faker\Provider\Payment
         $siren = Company::siren(false);
         $key = (12 + 3 * ($siren % 97)) % 97;
         $pattern = "%s%'.02d%s";
+
         if ($spacedNationalPrefix) {
             $siren = trim(chunk_split($siren, 3, ' '));
             $pattern = "%s %'.02d %s";

--- a/src/Faker/Provider/id_ID/Person.php
+++ b/src/Faker/Provider/id_ID/Person.php
@@ -252,6 +252,7 @@ class Person extends \Faker\Provider\Person
         if ($gender === static::GENDER_MALE) {
             return static::lastNameMale();
         }
+
         if ($gender === static::GENDER_FEMALE) {
             return static::lastNameFemale();
         }

--- a/src/Faker/Provider/nl_BE/Person.php
+++ b/src/Faker/Provider/nl_BE/Person.php
@@ -88,6 +88,7 @@ class Person extends \Faker\Provider\Person
     public static function rrn($gender = null)
     {
         $middle = self::numberBetween(1, 997);
+
         if ($gender === static::GENDER_MALE) {
             $middle = $middle % 2 === 1 ? $middle : $middle + 1;
         } elseif ($gender === static::GENDER_FEMALE) {

--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -265,6 +265,7 @@ class Person extends \Faker\Provider\Person
     public function lastName()
     {
         $determinator = self::numberBetween(0, 25);
+
         if ($determinator === 0) {
             $lastName = static::randomElement(static::$longLastNames);
         } elseif ($determinator <= 10) {
@@ -329,12 +330,14 @@ class Person extends \Faker\Provider\Person
             $nr[] = static::randomDigit();
         }
         $nr[] = self::numberBetween(0, 6);
+
         if ($nr[7] == 0 && $nr[8] == 0) {
             $nr[7] = 0;
         }
 
         $bsn   = (9 * $nr[8]) + (8 * $nr[7]) + (7 * $nr[6]) + (6 * $nr[5]) + (5 * $nr[4]) + (4 * $nr[3]) + (3 * $nr[2]) + (2 * $nr[1]);
         $nr[0] = floor($bsn - floor($bsn / 11) * 11);
+
         if ($nr[0] > 9) {
             if ($nr[1] > 0) {
                 $nr[0] = 8;

--- a/src/Faker/Provider/pl_PL/Company.php
+++ b/src/Faker/Provider/pl_PL/Company.php
@@ -49,6 +49,7 @@ class Company extends \Faker\Provider\Company
             $checksum += $weights[$i] * $result[$i];
         }
         $checksum %= 11;
+
         if ($checksum == 10) {
             $checksum = 0;
         }
@@ -78,6 +79,7 @@ class Company extends \Faker\Provider\Company
             $checksum += $weights[$i] * $result[$i];
         }
         $checksum %= 11;
+
         if ($checksum == 10) {
             $checksum = 0;
         }

--- a/src/Faker/Provider/pl_PL/Person.php
+++ b/src/Faker/Provider/pl_PL/Person.php
@@ -165,6 +165,7 @@ class Person extends \Faker\Provider\Person
         }
 
         $result[$length - 1] |= 1;
+
         if ($sex == 'F') {
             $result[$length - 1] -= 1;
         }

--- a/src/Faker/Provider/pt_BR/check_digit.php
+++ b/src/Faker/Provider/pt_BR/check_digit.php
@@ -30,6 +30,7 @@ function check_digit($numbers)
     }
 
     $verifier = 11 - ($verifier % 11);
+
     if ($verifier >= 10) {
         $verifier = 0;
     }

--- a/src/Faker/Provider/pt_PT/Person.php
+++ b/src/Faker/Provider/pt_PT/Person.php
@@ -82,6 +82,7 @@ class Person extends \Faker\Provider\Person
             $numbers[$i] = substr($number, $i - 1, 1);
             $partial[$i] = $numbers[$i] * $factor;
             $sum += $partial[$i];
+
             if ($factor == $base) {
                 $factor = 1;
             }

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -118,6 +118,7 @@ class Person extends \Faker\Provider\Person
     public function cnp($gender = null, $dateOfBirth = null, $county = null, $isResident = true)
     {
         $genders = [Person::GENDER_MALE, Person::GENDER_FEMALE];
+
         if (empty($gender)) {
             $gender = static::randomElement($genders);
         } elseif (!in_array($gender, $genders)) {

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -52,6 +52,7 @@ class UniqueGenerator
         do {
             $res = call_user_func_array([$this->generator, $name], $arguments);
             ++$i;
+
             if ($i > $this->maxRetries) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a unique value', $this->maxRetries));
             }

--- a/src/Faker/ValidGenerator.php
+++ b/src/Faker/ValidGenerator.php
@@ -58,6 +58,7 @@ class ValidGenerator
         do {
             $res = call_user_func_array([$this->generator, $name], $arguments);
             ++$i;
+
             if ($i > $this->maxRetries) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a valid value', $this->maxRetries));
             }

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -11,12 +11,14 @@
 spl_autoload_register(function ($className) {
     $className = ltrim($className, '\\');
     $fileName = '';
+
     if ($lastNsPos = strripos($className, '\\')) {
         $namespace = substr($className, 0, $lastNsPos);
         $className = substr($className, $lastNsPos + 1);
         $fileName = str_replace('\\', DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
     }
     $fileName = __DIR__ . DIRECTORY_SEPARATOR . $fileName . $className . '.php';
+
     if (file_exists($fileName)) {
         require $fileName;
 

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -214,6 +214,7 @@ final class DateTimeTest extends TestCase
 
         $_interval = \DateInterval::createFromDateString($interval);
         $_start = new \DateTime($start);
+
         if ($isInFuture) {
             self::assertGreaterThanOrEqual($_start, $date);
             self::assertLessThanOrEqual($_start->add($_interval), $date);

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -99,6 +99,7 @@ final class ImageTest extends TestCase
 
         $file = Image::image(sys_get_temp_dir());
         self::assertFileExists($file);
+
         if (function_exists('getimagesize')) {
             list($width, $height, $type, $attr) = getimagesize($file);
             self::assertEquals(640, $width);
@@ -107,6 +108,7 @@ final class ImageTest extends TestCase
         } else {
             self::assertEquals('png', pathinfo($file, PATHINFO_EXTENSION));
         }
+
         if (file_exists($file)) {
             unlink($file);
         }

--- a/test/Faker/Provider/cs_CZ/PersonTest.php
+++ b/test/Faker/Provider/cs_CZ/PersonTest.php
@@ -26,6 +26,7 @@ final class PersonTest extends TestCase
             if ($month > 50) {
                 $month -= 50;
             }
+
             if ($year >= 2004 && $month > 20) {
                 $month -= 20;
             }
@@ -36,6 +37,7 @@ final class PersonTest extends TestCase
             if (strlen($birthNumber) == 10) {
                 $crc = (int) substr($birthNumber, -1);
                 $refCrc = (int) substr($birthNumber, 0, -1) % 11;
+
                 if ($refCrc == 10) {
                     $refCrc = 0;
                 }

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -37,9 +37,11 @@ final class PaymentTest extends TestCase
     {
         $isValid = false;
         $fixedString = strtoupper($givenString);
+
         if (is_int($fixedString[0])) {
             $fixedString = substr('000000000' . $givenString, -9);
         }
+
         if (preg_match($pattern, $fixedString)) {
             $isValid = true;
         }

--- a/test/Faker/Provider/fr_FR/PaymentTest.php
+++ b/test/Faker/Provider/fr_FR/PaymentTest.php
@@ -18,6 +18,7 @@ final class PaymentTest extends TestCase
         self::assertTrue(Luhn::isValid($siren));
 
         $key = (int) substr($siren, 2, 2);
+
         if ($key === 0) {
             self::assertEquals($key, (12 + 3 * ($siren % 97)) % 97);
         }
@@ -32,6 +33,7 @@ final class PaymentTest extends TestCase
         self::assertTrue(Luhn::isValid($siren));
 
         $key = (int) substr($siren, 2, 2);
+
         if ($key === 0) {
             self::assertEquals($key, (12 + 3 * ($siren % 97)) % 97);
         }

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -23,12 +23,14 @@ final class PersonTest extends TestCase
     private static function isValidTin($tin)
     {
         $regex = '(([1,2,3,5,6,8]{1}[0-9]{8})|((45)|(70)|(71)|(72)|(77)|(79)|(90|(98|(99))))[0-9]{7})';
+
         if (is_null($tin) || !is_numeric($tin) || !strlen($tin) == 9 || preg_match("/$regex/", $tin) !== 1) {
             return false;
         }
         $n = str_split($tin);
         // cd - Control Digit
         $cd = ($n[0] * 9 + $n[1] * 8 + $n[2] * 7 + $n[3] * 6 + $n[4] * 5 + $n[5] * 4 + $n[6] * 3 + $n[7] * 2) % 11;
+
         if ($cd === 0 || $cd === 1) {
             $cd = 0;
         } else {


### PR DESCRIPTION
This PR

* [x] configures the `blank_line_before_statement` fixer to add a blank line before an `if` statement
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/whitespace/blank_line_before_statement.rst.