### PR TITLE
Enhancement: Enable no_superfluous_phpdoc_tags fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -83,6 +83,7 @@ return $config
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_superfluous_elseif' => true,
+        'no_superfluous_phpdoc_tags' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -47,7 +47,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$class of method Faker\\\\ORM\\\\Doctrine\\\\ColumnTypeGuesser\\:\\:guessFormat\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
 
 		-
@@ -67,7 +67,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$class of method Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:__construct\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
 		-
@@ -157,7 +157,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$manager of method Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:execute\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
 		-
@@ -187,7 +187,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$manager of method Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:generateId\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
 		-
@@ -202,7 +202,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$manager of method Faker\\\\ORM\\\\Doctrine\\\\Populator\\:\\:__construct\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Doctrine/Populator.php
 
 		-
@@ -227,7 +227,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$mandango of method Faker\\\\ORM\\\\Mandango\\\\EntityPopulator\\:\\:guessColumnFormatters\\(\\) has invalid typehint type Mandango\\\\Mandango\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Mandango/EntityPopulator.php
 
 		-
@@ -237,7 +237,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$mandango of method Faker\\\\ORM\\\\Mandango\\\\EntityPopulator\\:\\:execute\\(\\) has invalid typehint type Mandango\\\\Mandango\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Mandango/EntityPopulator.php
 
 		-
@@ -252,12 +252,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\$mandango of method Faker\\\\ORM\\\\Mandango\\\\Populator\\:\\:__construct\\(\\) has invalid typehint type Mandango\\\\Mandango\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Mandango/Populator.php
 
 		-
 			message: "#^Parameter \\$column of method Faker\\\\ORM\\\\Propel\\\\ColumnTypeGuesser\\:\\:guessFormat\\(\\) has invalid typehint type ColumnMap\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Propel/ColumnTypeGuesser.php
 
 		-
@@ -402,7 +402,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$columnMap of method Faker\\\\ORM\\\\Propel\\\\EntityPopulator\\:\\:isColumnBehavior\\(\\) has invalid typehint type ColumnMap\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Propel/EntityPopulator.php
 
 		-
@@ -447,7 +447,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$column of method Faker\\\\ORM\\\\Propel2\\\\ColumnTypeGuesser\\:\\:guessFormat\\(\\) has invalid typehint type Propel\\\\Runtime\\\\Map\\\\ColumnMap\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Propel2/ColumnTypeGuesser.php
 
 		-
@@ -597,7 +597,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$columnMap of method Faker\\\\ORM\\\\Propel2\\\\EntityPopulator\\:\\:isColumnBehavior\\(\\) has invalid typehint type Propel\\\\Runtime\\\\Map\\\\ColumnMap\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Propel2/EntityPopulator.php
 
 		-
@@ -652,12 +652,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\$locator of method Faker\\\\ORM\\\\Spot\\\\EntityPopulator\\:\\:__construct\\(\\) has invalid typehint type Spot\\\\Locator\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Spot/EntityPopulator.php
 
 		-
 			message: "#^Parameter \\$mapper of method Faker\\\\ORM\\\\Spot\\\\EntityPopulator\\:\\:__construct\\(\\) has invalid typehint type Spot\\\\Mapper\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Spot/EntityPopulator.php
 
 		-
@@ -707,7 +707,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\$locator of method Faker\\\\ORM\\\\Spot\\\\Populator\\:\\:__construct\\(\\) has invalid typehint type Spot\\\\Locator\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/ORM/Spot/Populator.php
 
 		-

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -45,9 +45,7 @@
     </UndefinedDocblockClass>
   </file>
   <file src="src/Faker/ORM/Doctrine/Populator.php">
-    <UndefinedClass occurrences="1">
-      <code>ObjectManager|null</code>
-    </UndefinedClass>
+    <UndefinedClass occurrences="1"/>
     <UndefinedDocblockClass occurrences="3">
       <code>$this-&gt;manager</code>
       <code>ObjectManager|null</code>
@@ -145,7 +143,6 @@
   <file src="src/Faker/ORM/Spot/Populator.php">
     <UndefinedClass occurrences="2">
       <code>$this-&gt;locator</code>
-      <code>Locator|null</code>
     </UndefinedClass>
     <UndefinedDocblockClass occurrences="1">
       <code>Locator</code>

--- a/src/Faker/Calculator/Isbn.php
+++ b/src/Faker/Calculator/Isbn.php
@@ -18,8 +18,6 @@ class Isbn
      * @param string $input ISBN without check-digit
      *
      * @throws \LengthException When wrong input length passed
-     *
-     * @return string
      */
     public static function checksum(string $input): string
     {
@@ -48,8 +46,6 @@ class Isbn
      * Checks whether the provided number is a valid ISBN-10 number
      *
      * @param string $isbn ISBN to check
-     *
-     * @return bool
      */
     public static function isValid(string $isbn): bool
     {

--- a/src/Faker/DefaultGenerator.php
+++ b/src/Faker/DefaultGenerator.php
@@ -17,8 +17,6 @@ class DefaultGenerator
 
     /**
      * @param string $attribute
-     *
-     * @return mixed
      */
     public function __get($attribute)
     {
@@ -28,8 +26,6 @@ class DefaultGenerator
     /**
      * @param string $method
      * @param array  $attributes
-     *
-     * @return mixed
      */
     public function __call($method, $attributes)
     {

--- a/src/Faker/Documentor.php
+++ b/src/Faker/Documentor.php
@@ -6,9 +6,6 @@ class Documentor
 {
     protected $generator;
 
-    /**
-     * @param Generator $generator
-     */
     public function __construct(Generator $generator)
     {
         $this->generator = $generator;

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -287,8 +287,6 @@ class Generator
 
     /**
      * @param string $attribute
-     *
-     * @return mixed
      */
     public function __get($attribute)
     {
@@ -298,8 +296,6 @@ class Generator
     /**
      * @param string $method
      * @param array  $attributes
-     *
-     * @return mixed
      */
     public function __call($method, $attributes)
     {

--- a/src/Faker/Guesser/Name.php
+++ b/src/Faker/Guesser/Name.php
@@ -8,9 +8,6 @@ class Name
 {
     protected $generator;
 
-    /**
-     * @param \Faker\Generator $generator
-     */
     public function __construct(\Faker\Generator $generator)
     {
         $this->generator = $generator;

--- a/src/Faker/ORM/CakePHP/Populator.php
+++ b/src/Faker/ORM/CakePHP/Populator.php
@@ -9,9 +9,6 @@ class Populator
     protected $quantities = [];
     protected $guessers = [];
 
-    /**
-     * @param \Faker\Generator $generator
-     */
     public function __construct(\Faker\Generator $generator)
     {
         $this->generator = $generator;

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -15,8 +15,6 @@ class ColumnTypeGuesser
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @return \Closure|null
      */
     public function guessFormat($fieldName, ClassMetadata $class)

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -23,9 +23,6 @@ class EntityPopulator
      */
     protected $modifiers = [];
 
-    /**
-     * @param ClassMetadata $class
-     */
     public function __construct(ClassMetadata $class)
     {
         $this->class = $class;
@@ -57,9 +54,6 @@ class EntityPopulator
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }
 
-    /**
-     * @param array $modifiers
-     */
     public function setModifiers(array $modifiers)
     {
         $this->modifiers = $modifiers;
@@ -73,17 +67,12 @@ class EntityPopulator
         return $this->modifiers;
     }
 
-    /**
-     * @param array $modifiers
-     */
     public function mergeModifiersWith(array $modifiers)
     {
         $this->modifiers = array_merge($this->modifiers, $modifiers);
     }
 
     /**
-     * @param \Faker\Generator $generator
-     *
      * @return array
      */
     public function guessColumnFormatters(\Faker\Generator $generator)
@@ -177,8 +166,7 @@ class EntityPopulator
     /**
      * Insert one new record using the Entity class.
      *
-     * @param ObjectManager $manager
-     * @param bool          $generateId
+     * @param bool $generateId
      *
      * @return EntityPopulator
      */
@@ -238,8 +226,6 @@ class EntityPopulator
     }
 
     /**
-     * @param ObjectManager $manager
-     *
      * @return int|null
      */
     private function generateId($obj, $column, ObjectManager $manager)

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -32,9 +32,7 @@ class Populator
     /**
      * Populator constructor.
      *
-     * @param Generator          $generator
-     * @param ObjectManager|null $manager
-     * @param int                $batchSize
+     * @param int $batchSize
      */
     public function __construct(Generator $generator, ObjectManager $manager = null, $batchSize = 1000)
     {

--- a/src/Faker/ORM/Mandango/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Mandango/ColumnTypeGuesser.php
@@ -11,9 +11,6 @@ class ColumnTypeGuesser
      */
     protected $generator;
 
-    /**
-     * @param Generator $generator
-     */
     public function __construct(Generator $generator)
     {
         $this->generator = $generator;

--- a/src/Faker/ORM/Mandango/EntityPopulator.php
+++ b/src/Faker/ORM/Mandango/EntityPopulator.php
@@ -48,9 +48,6 @@ class EntityPopulator
     }
 
     /**
-     * @param \Faker\Generator $generator
-     * @param Mandango         $mandango
-     *
      * @return array
      */
     public function guessColumnFormatters(\Faker\Generator $generator, Mandango $mandango)
@@ -97,8 +94,6 @@ class EntityPopulator
 
     /**
      * Insert one new record using the Entity class.
-     *
-     * @param Mandango $mandango
      */
     public function execute(Mandango $mandango, $insertedEntities)
     {

--- a/src/Faker/ORM/Mandango/Populator.php
+++ b/src/Faker/ORM/Mandango/Populator.php
@@ -15,10 +15,6 @@ class Populator
     protected $entities = [];
     protected $quantities = [];
 
-    /**
-     * @param \Faker\Generator $generator
-     * @param Mandango         $mandango
-     */
     public function __construct(\Faker\Generator $generator, Mandango $mandango)
     {
         $this->generator = $generator;

--- a/src/Faker/ORM/Propel/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel/ColumnTypeGuesser.php
@@ -9,17 +9,12 @@ class ColumnTypeGuesser
 {
     protected $generator;
 
-    /**
-     * @param \Faker\Generator $generator
-     */
     public function __construct(\Faker\Generator $generator)
     {
         $this->generator = $generator;
     }
 
     /**
-     * @param ColumnMap $column
-     *
      * @return \Closure|null
      */
     public function guessFormat(ColumnMap $column)

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -49,8 +49,6 @@ class EntityPopulator
     }
 
     /**
-     * @param \Faker\Generator $generator
-     *
      * @return array
      */
     public function guessColumnFormatters(\Faker\Generator $generator)
@@ -98,8 +96,6 @@ class EntityPopulator
     }
 
     /**
-     * @param ColumnMap $columnMap
-     *
      * @return bool
      */
     protected function isColumnBehavior(ColumnMap $columnMap)
@@ -150,8 +146,6 @@ class EntityPopulator
     }
 
     /**
-     * @param \Faker\Generator $generator
-     *
      * @return array
      */
     public function guessModifiers(\Faker\Generator $generator)

--- a/src/Faker/ORM/Propel/Populator.php
+++ b/src/Faker/ORM/Propel/Populator.php
@@ -12,9 +12,6 @@ class Populator
     protected $entities = [];
     protected $quantities = [];
 
-    /**
-     * @param \Faker\Generator $generator
-     */
     public function __construct(\Faker\Generator $generator)
     {
         $this->generator = $generator;

--- a/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel2/ColumnTypeGuesser.php
@@ -9,17 +9,12 @@ class ColumnTypeGuesser
 {
     protected $generator;
 
-    /**
-     * @param \Faker\Generator $generator
-     */
     public function __construct(\Faker\Generator $generator)
     {
         $this->generator = $generator;
     }
 
     /**
-     * @param ColumnMap $column
-     *
      * @return \Closure|null
      */
     public function guessFormat(ColumnMap $column)

--- a/src/Faker/ORM/Propel2/EntityPopulator.php
+++ b/src/Faker/ORM/Propel2/EntityPopulator.php
@@ -49,8 +49,6 @@ class EntityPopulator
     }
 
     /**
-     * @param \Faker\Generator $generator
-     *
      * @return array
      */
     public function guessColumnFormatters(\Faker\Generator $generator)
@@ -100,8 +98,6 @@ class EntityPopulator
     }
 
     /**
-     * @param ColumnMap $columnMap
-     *
      * @return bool
      */
     protected function isColumnBehavior(ColumnMap $columnMap)
@@ -152,8 +148,6 @@ class EntityPopulator
     }
 
     /**
-     * @param \Faker\Generator $generator
-     *
      * @return array
      */
     public function guessModifiers(\Faker\Generator $generator)

--- a/src/Faker/ORM/Propel2/Populator.php
+++ b/src/Faker/ORM/Propel2/Populator.php
@@ -15,9 +15,6 @@ class Populator
     protected $entities = [];
     protected $quantities = [];
 
-    /**
-     * @param \Faker\Generator $generator
-     */
     public function __construct(\Faker\Generator $generator)
     {
         $this->generator = $generator;

--- a/src/Faker/ORM/Spot/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Spot/ColumnTypeGuesser.php
@@ -10,8 +10,6 @@ class ColumnTypeGuesser
 
     /**
      * ColumnTypeGuesser constructor.
-     *
-     * @param Generator $generator
      */
     public function __construct(Generator $generator)
     {
@@ -19,8 +17,6 @@ class ColumnTypeGuesser
     }
 
     /**
-     * @param array $field
-     *
      * @return \Closure|null
      */
     public function guessFormat(array $field)

--- a/src/Faker/ORM/Spot/EntityPopulator.php
+++ b/src/Faker/ORM/Spot/EntityPopulator.php
@@ -43,9 +43,7 @@ class EntityPopulator
     protected $useExistingData = false;
 
     /**
-     * @param Mapper  $mapper
-     * @param Locator $locator
-     * @param bool    $useExistingData
+     * @param bool $useExistingData
      */
     public function __construct(Mapper $mapper, Locator $locator, $useExistingData = false)
     {
@@ -80,9 +78,6 @@ class EntityPopulator
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }
 
-    /**
-     * @param array $modifiers
-     */
     public function setModifiers(array $modifiers)
     {
         $this->modifiers = $modifiers;
@@ -96,17 +91,12 @@ class EntityPopulator
         return $this->modifiers;
     }
 
-    /**
-     * @param array $modifiers
-     */
     public function mergeModifiersWith(array $modifiers)
     {
         $this->modifiers = array_merge($this->modifiers, $modifiers);
     }
 
     /**
-     * @param Generator $generator
-     *
      * @return array
      */
     public function guessColumnFormatters(Generator $generator)

--- a/src/Faker/ORM/Spot/Populator.php
+++ b/src/Faker/ORM/Spot/Populator.php
@@ -16,9 +16,6 @@ class Populator
 
     /**
      * Populator constructor.
-     *
-     * @param \Faker\Generator $generator
-     * @param Locator|null     $locator
      */
     public function __construct(\Faker\Generator $generator, Locator $locator = null)
     {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -19,9 +19,6 @@ class Base
      */
     protected $unique;
 
-    /**
-     * @param \Faker\Generator $generator
-     */
     public function __construct(Generator $generator)
     {
         $this->generator = $generator;
@@ -153,10 +150,6 @@ class Base
 
     /**
      * Returns the passed value
-     *
-     * @param mixed $value
-     *
-     * @return mixed
      */
     public static function passthrough($value)
     {
@@ -236,8 +229,6 @@ class Base
      * Returns a random element from a passed array
      *
      * @param array $array
-     *
-     * @return mixed
      */
     public static function randomElement($array = ['a', 'b', 'c'])
     {

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -340,7 +340,6 @@ class DateTime extends Base
     /**
      * Internal method to set the time zone on a DateTime.
      *
-     * @param \DateTime   $dt
      * @param string|null $timezone
      *
      * @return \DateTime

--- a/src/Faker/Provider/de_AT/Person.php
+++ b/src/Faker/Provider/de_AT/Person.php
@@ -125,8 +125,6 @@ class Person extends \Faker\Provider\Person
      *
      * @link https://de.wikipedia.org/wiki/Sozialversicherungsnummer#.C3.96sterreich
      *
-     * @param \DateTime|null $birthdate
-     *
      * @return string
      */
     public static function ssn(\DateTime $birthdate = null)

--- a/src/Faker/Provider/hy_AM/PhoneNumber.php
+++ b/src/Faker/Provider/hy_AM/PhoneNumber.php
@@ -29,9 +29,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return static::randomElement(static::$codes);
     }
 
-    /**
-     * @return mixed
-     */
     public function numberFormat()
     {
         return static::randomElement(static::$numberFormats);

--- a/src/Faker/Provider/pl_PL/LicensePlate.php
+++ b/src/Faker/Provider/pl_PL/LicensePlate.php
@@ -507,8 +507,6 @@ class LicensePlate extends Base
      * @param bool       $special      whether special license plates should be included
      * @param array|null $voivodeships list of voivodeships license plate should be generated from
      * @param array|null $counties     list of counties license plate should be generated from
-     *
-     * @return string
      */
     public static function licensePlate(
         bool $special = false,
@@ -530,11 +528,6 @@ class LicensePlate extends Base
 
     /**
      * Selects random area from the list of available and requested.
-     *
-     * @param array      $available
-     * @param array|null $requested
-     *
-     * @return mixed
      */
     protected static function selectRandomArea(array $available, ?array $requested)
     {

--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -74,8 +74,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      * Randomizes between cellphone and landline numbers.
      *
      * @param bool $formatted [def: true] If it should return a formatted number or not.
-     *
-     * @return mixed
      */
     public static function phone($formatted = true)
     {
@@ -132,8 +130,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
     /**
      * Randomizes between complete cellphone and landline numbers.
-     *
-     * @return mixed
      */
     public function phoneNumber()
     {
@@ -144,8 +140,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
     /**
      * Randomizes between complete cellphone and landline numbers, cleared from formatting symbols.
-     *
-     * @return mixed
      */
     public static function phoneNumberCleared()
     {

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -193,9 +193,8 @@ class Person extends \Faker\Provider\Person
     /**
      * https://ro.wikipedia.org/wiki/Cod_numeric_personal#S
      *
-     * @param \DateTime $dateOfBirth
-     * @param bool      $isResident
-     * @param string    $gender
+     * @param bool   $isResident
+     * @param string $gender
      *
      * @return int
      */

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -13,8 +13,7 @@ class UniqueGenerator
     protected $uniques = [];
 
     /**
-     * @param Generator $generator
-     * @param int       $maxRetries
+     * @param int $maxRetries
      */
     public function __construct(Generator $generator, $maxRetries = 10000)
     {
@@ -26,8 +25,6 @@ class UniqueGenerator
      * Catch and proxy all generator calls but return only unique values
      *
      * @param string $attribute
-     *
-     * @return mixed
      */
     public function __get($attribute)
     {
@@ -39,8 +36,6 @@ class UniqueGenerator
      *
      * @param string $name
      * @param array  $arguments
-     *
-     * @return mixed
      */
     public function __call($name, $arguments)
     {

--- a/src/Faker/ValidGenerator.php
+++ b/src/Faker/ValidGenerator.php
@@ -13,7 +13,6 @@ class ValidGenerator
     protected $maxRetries;
 
     /**
-     * @param Generator     $generator
      * @param callable|null $validator
      * @param int           $maxRetries
      */
@@ -35,8 +34,6 @@ class ValidGenerator
      * Catch and proxy all generator calls but return only valid values
      *
      * @param string $attribute
-     *
-     * @return mixed
      */
     public function __get($attribute)
     {
@@ -48,8 +45,6 @@ class ValidGenerator
      *
      * @param string $name
      * @param array  $arguments
-     *
-     * @return mixed
      */
     public function __call($name, $arguments)
     {


### PR DESCRIPTION
This PR

* [x] enables the `no_superfluous_phpdoc_tags` fixer
* [x] runs `make cs`
* [x] runs `make baseline`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst.