### PR TITLE
Enhancement: Configure cache directory for phpstan/phpstan and vimeo/psalm

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,3 +6,4 @@ parameters:
     reportUnmatchedIgnoredErrors: false
     paths:
         - src
+    tmpDir: .build/phpstan/

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    cacheDirectory=".build/psalm/"
     errorBaseline="psalm.baseline.xml"
     errorLevel="5"
     resolveFromConfigFile="true"


### PR DESCRIPTION
This PR

* [x] configures the cache directories for `phpstan/phpstan` and `vimeo/psalm`

💁‍♂️ Configuring the cache directories explicitly allows a developer to remove the cache without looking it up in location that is otherwise used as a default.