### PR TITLE
Enhancement: Enable phpdoc_line_span fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -111,6 +111,7 @@ return $config
         'phpdoc_align' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag_normalizer' => true,
+        'phpdoc_line_span' => true,
         'phpdoc_no_alias_tag' => [
             'replacements' => [
                 'type' => 'var',

--- a/src/Faker/Calculator/Ean.php
+++ b/src/Faker/Calculator/Ean.php
@@ -7,7 +7,9 @@ namespace Faker\Calculator;
  */
 class Ean
 {
-    /** @var string EAN validation pattern */
+    /**
+     * @var string EAN validation pattern
+     */
     public const PATTERN = '/^(?:\d{8}|\d{13})$/';
 
     /**

--- a/src/Faker/Calculator/Isbn.php
+++ b/src/Faker/Calculator/Isbn.php
@@ -7,7 +7,9 @@ namespace Faker\Calculator;
  */
 class Isbn
 {
-    /** @var string ISBN-10 validation pattern */
+    /**
+     * @var string ISBN-10 validation pattern
+     */
     public const PATTERN = '/^\d{9}[0-9X]$/';
 
     /**

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -11,22 +11,34 @@ use Faker\Generator;
  */
 class Populator
 {
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $batchSize;
 
-    /** @var Generator */
+    /**
+     * @var Generator
+     */
     protected $generator;
 
-    /** @var ObjectManager|null */
+    /**
+     * @var ObjectManager|null
+     */
     protected $manager;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $entities = [];
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $quantities = [];
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $generateId = [];
 
     /**

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -7,7 +7,9 @@ namespace Faker\Provider;
  */
 class Image extends Base
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     public const BASE_URL = 'https://via.placeholder.com';
 
     /**

--- a/src/Faker/Provider/pt_PT/Address.php
+++ b/src/Faker/Provider/pt_PT/Address.php
@@ -20,12 +20,16 @@ class Address extends \Faker\Provider\Address
         '{{streetName}}, {{buildingNumber}}, {{secondaryAddress}}',
     ];
 
-    /** @link http://www.univ-ab.pt/PINTAC/carta_normas.htm address example in letters **/
+    /**
+     * @link http://www.univ-ab.pt/PINTAC/carta_normas.htm address example in letters *
+     */
     protected static $addressFormats = [
         '{{streetAddress}} {{postcode}} {{city}}',
     ];
 
-    /** @link http://www.mapadeportugal.net/indicecidades.asp **/
+    /**
+     * @link http://www.mapadeportugal.net/indicecidades.asp *
+     */
     private static $cities = [
         'Abrantes', 'Agualva-Cacém', 'Águeda', 'Albufeira', 'Alcácer do Sal', 'Alcobaça', 'Almada', 'Almeirim', 'Alverca do Ribatejo', 'Amadora', 'Amarante', 'Amora', 'Anadia', 'Angra do Heroísmo', 'Aveiro', 'Barcelos', 'Barreiro',
         'Beja', 'Braga', 'Bragança', 'Caldas da Rainha', 'Camara de Lobos', 'Cantanhede', 'Cartaxo', 'Castelo Branco', 'Chaves', 'Coimbra', 'Covilhã', 'Elvas', 'Entroncamento', 'Ermesinde', 'Esmoriz', 'Espinho', 'Esposende', 'Estarreja',
@@ -62,7 +66,9 @@ class Address extends \Faker\Provider\Address
         return static::numerify(static::randomElement(static::$secondaryAddressFormats));
     }
 
-    /** @link http://www.indexmundi.com/pt/ **/
+    /**
+     * @link http://www.indexmundi.com/pt/ *
+     */
     protected static $country = [
         'Afeganistão', 'África do Sul', 'Albânia', 'Alemanha', 'Andorra',
         'Angola', 'Antigua e Barbuda', 'Arabia Saudita', 'Argélia',

--- a/src/Faker/Provider/pt_PT/Person.php
+++ b/src/Faker/Provider/pt_PT/Person.php
@@ -26,7 +26,9 @@ class Person extends \Faker\Provider\Person
         '{{firstNameFemale}} {{firstNameFemale}} {{lastName}} {{lastName}} {{lastName}}',
     ];
 
-    /** @link http://goo.gl/v6bScG document with all pt abreviations **/
+    /**
+     * @link http://goo.gl/v6bScG document with all pt abreviations *
+     */
     protected static $titleMale = ['Sr.', 'Dr.', 'Exmo.', 'Eng.', 'Eng.º', 'Ex.', 'Exº'];
     protected static $titleFemale = ['Sra.', 'Dra.', 'Exma', 'Eng.ª', 'Exª'];
 


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_line_span` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/phpdoc_line_span.rst.