### PR TITLE
Enhancement: Enable phpdoc_no_empty_return fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -119,6 +119,7 @@ return $config
                 'type' => 'var',
             ],
         ],
+        'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_order' => true,
         'phpdoc_return_self_reference' => true,

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -353,8 +353,6 @@ class DateTime extends Base
      * Sets default time zone.
      *
      * @param string $timezone
-     *
-     * @return void
      */
     public static function setDefaultTimezone($timezone = null)
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_no_empty_return` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/phpdoc_no_empty_return.rst.