### PR TITLE
Enhancement: Enable strict_param fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -154,6 +154,7 @@ return $config
         'single_trait_insert_per_statement' => true,
         'standardize_not_equals' => true,
         'static_lambda' => true,
+        'strict_param' => true,
         'switch_case_space' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => true,

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -242,7 +242,7 @@ class EntityPopulator
 
         do {
             $id = mt_rand();
-        } while (in_array($id, $ids));
+        } while (in_array($id, $ids, true));
 
         return $id;
     }

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -242,7 +242,7 @@ class EntityPopulator
 
         do {
             $id = mt_rand();
-        } while (in_array($id, $ids, true));
+        } while (in_array($id, $ids, false));
 
         return $id;
     }

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -107,7 +107,7 @@ class EntityPopulator
                 case 'nested_set':
                     $columnNames = [$params['left_column'], $params['right_column'], $params['level_column']];
 
-                    if (in_array($columnName, $columnNames, true)) {
+                    if (in_array($columnName, $columnNames, false)) {
                         return true;
                     }
 
@@ -116,7 +116,7 @@ class EntityPopulator
                 case 'timestampable':
                     $columnNames = [$params['create_column'], $params['update_column']];
 
-                    if (in_array($columnName, $columnNames, true)) {
+                    if (in_array($columnName, $columnNames, false)) {
                         return true;
                     }
 

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -107,7 +107,7 @@ class EntityPopulator
                 case 'nested_set':
                     $columnNames = [$params['left_column'], $params['right_column'], $params['level_column']];
 
-                    if (in_array($columnName, $columnNames)) {
+                    if (in_array($columnName, $columnNames, true)) {
                         return true;
                     }
 
@@ -116,7 +116,7 @@ class EntityPopulator
                 case 'timestampable':
                     $columnNames = [$params['create_column'], $params['update_column']];
 
-                    if (in_array($columnName, $columnNames)) {
+                    if (in_array($columnName, $columnNames, true)) {
                         return true;
                     }
 

--- a/src/Faker/ORM/Propel2/EntityPopulator.php
+++ b/src/Faker/ORM/Propel2/EntityPopulator.php
@@ -109,7 +109,7 @@ class EntityPopulator
                 case 'nested_set':
                     $columnNames = [$params['left_column'], $params['right_column'], $params['level_column']];
 
-                    if (in_array($columnName, $columnNames, true)) {
+                    if (in_array($columnName, $columnNames, false)) {
                         return true;
                     }
 
@@ -118,7 +118,7 @@ class EntityPopulator
                 case 'timestampable':
                     $columnNames = [$params['create_column'], $params['update_column']];
 
-                    if (in_array($columnName, $columnNames, true)) {
+                    if (in_array($columnName, $columnNames, false)) {
                         return true;
                     }
 

--- a/src/Faker/ORM/Propel2/EntityPopulator.php
+++ b/src/Faker/ORM/Propel2/EntityPopulator.php
@@ -109,7 +109,7 @@ class EntityPopulator
                 case 'nested_set':
                     $columnNames = [$params['left_column'], $params['right_column'], $params['level_column']];
 
-                    if (in_array($columnName, $columnNames)) {
+                    if (in_array($columnName, $columnNames, true)) {
                         return true;
                     }
 
@@ -118,7 +118,7 @@ class EntityPopulator
                 case 'timestampable':
                     $columnNames = [$params['create_column'], $params['update_column']];
 
-                    if (in_array($columnName, $columnNames)) {
+                    if (in_array($columnName, $columnNames, true)) {
                         return true;
                     }
 

--- a/src/Faker/Provider/en_GB/Person.php
+++ b/src/Faker/Provider/en_GB/Person.php
@@ -103,7 +103,7 @@ class Person extends \Faker\Provider\Person
 
         do {
             $prefix = implode('', self::randomElements($prefixAllowList, 2, true));
-        } while (in_array($prefix, $prefixBanList) || $prefix[1] == 'O');
+        } while (in_array($prefix, $prefixBanList, true) || $prefix[1] == 'O');
 
         $digits = static::numerify('######');
         $suffix = static::randomElement(['A', 'B', 'C', 'D']);

--- a/src/Faker/Provider/en_GB/Person.php
+++ b/src/Faker/Provider/en_GB/Person.php
@@ -103,7 +103,7 @@ class Person extends \Faker\Provider\Person
 
         do {
             $prefix = implode('', self::randomElements($prefixAllowList, 2, true));
-        } while (in_array($prefix, $prefixBanList, true) || $prefix[1] == 'O');
+        } while (in_array($prefix, $prefixBanList, false) || $prefix[1] == 'O');
 
         $digits = static::numerify('######');
         $suffix = static::randomElement(['A', 'B', 'C', 'D']);

--- a/src/Faker/Provider/en_ZA/PhoneNumber.php
+++ b/src/Faker/Provider/en_ZA/PhoneNumber.php
@@ -45,13 +45,13 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
             case 2:
                 $number = self::numberBetween(1, 8);
-                $digits[] = in_array($number, [5, 6]) ? $number + 2 : $number;
+                $digits[] = in_array($number, [5, 6], true) ? $number + 2 : $number;
 
                 break;
 
             case 3:
                 $number = self::numberBetween(1, 8);
-                $digits[] = in_array($number, [7, 8]) ? $number - 2 : $number;
+                $digits[] = in_array($number, [7, 8], true) ? $number - 2 : $number;
 
                 break;
 
@@ -62,7 +62,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
             case 5:
                 $number = self::numberBetween(1, 8);
-                $digits[] = in_array($number, [2, 5]) ? $number + 2 : $number;
+                $digits[] = in_array($number, [2, 5], true) ? $number + 2 : $number;
 
                 break;
         }
@@ -82,7 +82,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
             case 7:
                 $number = self::numberBetween(1, 9);
-                $digits[] = in_array($number, [5, 7]) ? $number + 1 : $number;
+                $digits[] = in_array($number, [5, 7], true) ? $number + 1 : $number;
 
                 break;
 

--- a/src/Faker/Provider/en_ZA/PhoneNumber.php
+++ b/src/Faker/Provider/en_ZA/PhoneNumber.php
@@ -45,13 +45,13 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
             case 2:
                 $number = self::numberBetween(1, 8);
-                $digits[] = in_array($number, [5, 6], true) ? $number + 2 : $number;
+                $digits[] = in_array($number, [5, 6], false) ? $number + 2 : $number;
 
                 break;
 
             case 3:
                 $number = self::numberBetween(1, 8);
-                $digits[] = in_array($number, [7, 8], true) ? $number - 2 : $number;
+                $digits[] = in_array($number, [7, 8], false) ? $number - 2 : $number;
 
                 break;
 
@@ -62,7 +62,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
             case 5:
                 $number = self::numberBetween(1, 8);
-                $digits[] = in_array($number, [2, 5], true) ? $number + 2 : $number;
+                $digits[] = in_array($number, [2, 5], false) ? $number + 2 : $number;
 
                 break;
         }
@@ -82,7 +82,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
             case 7:
                 $number = self::numberBetween(1, 9);
-                $digits[] = in_array($number, [5, 7], true) ? $number + 1 : $number;
+                $digits[] = in_array($number, [5, 7], false) ? $number + 1 : $number;
 
                 break;
 

--- a/src/Faker/Provider/ja_JP/Text.php
+++ b/src/Faker/Provider/ja_JP/Text.php
@@ -616,7 +616,7 @@ EOT;
 
     protected static function validStart($word)
     {
-        return !in_array($word, static::$notBeginPunct, true);
+        return !in_array($word, static::$notBeginPunct, false);
     }
 
     protected static function appendEnd($text)
@@ -629,10 +629,10 @@ EOT;
             $last = end($chars);
         }
         // if the last char is a not-valid-end punctuation, remove it
-        if (in_array($last, static::$notEndPunct, true)) {
+        if (in_array($last, static::$notEndPunct, false)) {
             $text = preg_replace('/.$/u', '', $text);
         }
         // if the last char is not a valid punctuation, append a default one.
-        return in_array($last, static::$endPunct, true) ? $text : $text . '。';
+        return in_array($last, static::$endPunct, false) ? $text : $text . '。';
     }
 }

--- a/src/Faker/Provider/ja_JP/Text.php
+++ b/src/Faker/Provider/ja_JP/Text.php
@@ -616,7 +616,7 @@ EOT;
 
     protected static function validStart($word)
     {
-        return !in_array($word, static::$notBeginPunct);
+        return !in_array($word, static::$notBeginPunct, true);
     }
 
     protected static function appendEnd($text)
@@ -629,10 +629,10 @@ EOT;
             $last = end($chars);
         }
         // if the last char is a not-valid-end punctuation, remove it
-        if (in_array($last, static::$notEndPunct)) {
+        if (in_array($last, static::$notEndPunct, true)) {
             $text = preg_replace('/.$/u', '', $text);
         }
         // if the last char is not a valid punctuation, append a default one.
-        return in_array($last, static::$endPunct) ? $text : $text . '。';
+        return in_array($last, static::$endPunct, true) ? $text : $text . '。';
     }
 }

--- a/src/Faker/Provider/ms_MY/Person.php
+++ b/src/Faker/Provider/ms_MY/Person.php
@@ -784,7 +784,7 @@ class Person extends \Faker\Provider\Person
         $dd = DateTime::dayOfMonth();
 
         // place of birth (1-59 except 17-20)
-        while (in_array($pb = self::numberBetween(1, 59), [17, 18, 19, 20])) {
+        while (in_array($pb = self::numberBetween(1, 59), [17, 18, 19, 20], true)) {
         }
 
         // random number

--- a/src/Faker/Provider/ms_MY/Person.php
+++ b/src/Faker/Provider/ms_MY/Person.php
@@ -784,7 +784,7 @@ class Person extends \Faker\Provider\Person
         $dd = DateTime::dayOfMonth();
 
         // place of birth (1-59 except 17-20)
-        while (in_array($pb = self::numberBetween(1, 59), [17, 18, 19, 20], true)) {
+        while (in_array($pb = self::numberBetween(1, 59), [17, 18, 19, 20], false)) {
         }
 
         // random number

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -121,7 +121,7 @@ class Person extends \Faker\Provider\Person
 
         if (empty($gender)) {
             $gender = static::randomElement($genders);
-        } elseif (!in_array($gender, $genders)) {
+        } elseif (!in_array($gender, $genders, true)) {
             throw new \InvalidArgumentException("Gender must be '{Person::GENDER_MALE}' or '{Person::GENDER_FEMALE}'");
         }
 

--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -121,7 +121,7 @@ class Person extends \Faker\Provider\Person
 
         if (empty($gender)) {
             $gender = static::randomElement($genders);
-        } elseif (!in_array($gender, $genders, true)) {
+        } elseif (!in_array($gender, $genders, false)) {
             throw new \InvalidArgumentException("Gender must be '{Person::GENDER_MALE}' or '{Person::GENDER_FEMALE}'");
         }
 

--- a/src/Faker/Provider/zh_TW/Text.php
+++ b/src/Faker/Provider/zh_TW/Text.php
@@ -824,7 +824,7 @@ EOT;
 
     protected static function validStart($word)
     {
-        return !in_array($word, static::$notBeginPunct);
+        return !in_array($word, static::$notBeginPunct, true);
     }
 
     protected static function appendEnd($text)
@@ -842,7 +842,7 @@ EOT;
         }
 
         // if the last char is a not-valid-end punctuation, remove it
-        if (in_array($last, static::$notEndPunct)) {
+        if (in_array($last, static::$notEndPunct, true)) {
             if ($mbAvailable) {
                 $text = mb_substr($text, 0, mb_strlen($text, static::$encoding) - 1, static::$encoding);
             } else {
@@ -852,7 +852,7 @@ EOT;
         }
 
         // if the last char is not a valid punctuation, append a default one.
-        return in_array($last, static::$endPunct) ? $text : $text . '。';
+        return in_array($last, static::$endPunct, true) ? $text : $text . '。';
     }
 
     /**

--- a/src/Faker/Provider/zh_TW/Text.php
+++ b/src/Faker/Provider/zh_TW/Text.php
@@ -824,7 +824,7 @@ EOT;
 
     protected static function validStart($word)
     {
-        return !in_array($word, static::$notBeginPunct, true);
+        return !in_array($word, static::$notBeginPunct, false);
     }
 
     protected static function appendEnd($text)
@@ -842,7 +842,7 @@ EOT;
         }
 
         // if the last char is a not-valid-end punctuation, remove it
-        if (in_array($last, static::$notEndPunct, true)) {
+        if (in_array($last, static::$notEndPunct, false)) {
             if ($mbAvailable) {
                 $text = mb_substr($text, 0, mb_strlen($text, static::$encoding) - 1, static::$encoding);
             } else {
@@ -852,7 +852,7 @@ EOT;
         }
 
         // if the last char is not a valid punctuation, append a default one.
-        return in_array($last, static::$endPunct, true) ? $text : $text . '。';
+        return in_array($last, static::$endPunct, false) ? $text : $text . '。';
     }
 
     /**

--- a/test/Faker/Provider/en_SG/PersonTest.php
+++ b/test/Faker/Provider/en_SG/PersonTest.php
@@ -62,7 +62,7 @@ final class PersonTest extends TestCase
             $checksum += (int) $id[$key + 1] * $weight;
         }
 
-        $checksumArr = in_array($prefix, ['F', 'G'])
+        $checksumArr = in_array($prefix, ['F', 'G'], true)
             ? ['X', 'W', 'U', 'T', 'R', 'Q', 'P', 'N', 'M', 'L', 'K']
             : ['J', 'Z', 'I', 'H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
 

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -191,12 +191,12 @@ final class PersonTest extends TestCase
 
     protected function isValidFemaleCnp($value)
     {
-        return $this->isValidCnp($value) && in_array($value[0], [2, 4, 6, 8, 9], true);
+        return $this->isValidCnp($value) && in_array($value[0], [2, 4, 6, 8, 9], false);
     }
 
     protected function isValidMaleCnp($value)
     {
-        return $this->isValidCnp($value) && in_array($value[0], [1, 3, 5, 7, 9], true);
+        return $this->isValidCnp($value) && in_array($value[0], [1, 3, 5, 7, 9], false);
     }
 
     protected function isValidCnp($cnp)

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -191,12 +191,12 @@ final class PersonTest extends TestCase
 
     protected function isValidFemaleCnp($value)
     {
-        return $this->isValidCnp($value) && in_array($value[0], [2, 4, 6, 8, 9]);
+        return $this->isValidCnp($value) && in_array($value[0], [2, 4, 6, 8, 9], true);
     }
 
     protected function isValidMaleCnp($value)
     {
-        return $this->isValidCnp($value) && in_array($value[0], [1, 3, 5, 7, 9]);
+        return $this->isValidCnp($value) && in_array($value[0], [1, 3, 5, 7, 9], true);
     }
 
     protected function isValidCnp($cnp)


### PR DESCRIPTION
This PR

* [x] enables the `strict_param` fixer
* [x] runs `make cs`
* [x] sets the parameter to `false` to retain current behaviour

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/strict/strict_param.rst.