### PR TITLE
class_exists consistently called with ::class

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -244,7 +244,7 @@ class Internet extends Base
 
         $transId = 'Any-Latin; Latin-ASCII; NFD; [:Nonspacing Mark:] Remove; NFC;';
 
-        if (class_exists('Transliterator', false) && $transliterator = \Transliterator::create($transId)) {
+        if (class_exists(\Transliterator::class, false) && $transliterator = \Transliterator::create($transId)) {
             $transString = $transliterator->transliterate($string);
         } else {
             $transString = static::toAscii($string);

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -70,10 +70,6 @@ final class ProviderOverrideTest extends TestCase
      */
     public function testInternet($locale = null)
     {
-        if ($locale && $locale !== 'en_US' && !class_exists('Transliterator')) {
-            self::markTestSkipped('Transliterator class not available (intl extension)');
-        }
-
         $faker = Faker\Factory::create($locale);
 
         self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->userName);


### PR DESCRIPTION
### What is the reason for this PR?

In https://github.com/FakerPHP/Faker/pull/120#discussion_r546782102 the string class_exists parameter was replaced with a ::class call. 

### Summary of changes

This PR replaces the other occurrence of the class_exists paramter to ::class call.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
