### PR TITLE
Enhancement: Enable phpdoc_trim_consecutive_blank_line_separation fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -127,6 +127,7 @@ return $config
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_last',

--- a/src/Faker/Provider/fr_CA/Text.php
+++ b/src/Faker/Provider/fr_CA/Text.php
@@ -98,9 +98,6 @@ class Text extends \Faker\Provider\Text
      *
      * H.B.
      *
-     *
-     *
-     *
      * @see http://www.gutenberg.org/cache/epub/16210/pg16210.txt
      *
      * @var string


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_trim_consecutive_blank_line_separation` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/phpdoc_trim_consecutive_blank_line_separation.rst.