### PR TITLE
Enhancement: Enable semicolon_after_instruction fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -139,6 +139,7 @@ return $config
         'random_api_migration' => true,
         'return_assignment' => true,
         'return_type_declaration' => true,
+        'semicolon_after_instruction' => true,
         'short_scalar_cast' => true,
         'single_blank_line_before_namespace' => true,
         'single_quote' => true,

--- a/test/documentor.php
+++ b/test/documentor.php
@@ -7,10 +7,10 @@ $documentor = new Faker\Documentor($generator);
 ?>
 <?php foreach ($documentor->getFormatters() as $provider => $formatters): ?>
 
-### `<?php echo $provider ?>`
+### `<?php echo $provider; ?>`
 
 <?php foreach ($formatters as $formatter => $example): ?>
-    <?php echo str_pad($formatter, 23) ?><?php if ($example): ?> // <?php echo $example ?> <?php endif; ?>
+    <?php echo str_pad($formatter, 23); ?><?php if ($example): ?> // <?php echo $example; ?> <?php endif; ?>
 
 <?php endforeach; ?>
 <?php endforeach;

--- a/test/test.php
+++ b/test/test.php
@@ -7,29 +7,29 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 ?>
 <contacts>
 <?php for ($i=0; $i < 10; ++$i): ?>
-  <contact firstName="<?php echo $faker->firstName ?>" lastName="<?php echo $faker->lastName ?>" email="<?php echo $faker->email ?>" >
-    <phone number="<?php echo $faker->phoneNumber ?>"/>
+  <contact firstName="<?php echo $faker->firstName; ?>" lastName="<?php echo $faker->lastName; ?>" email="<?php echo $faker->email; ?>" >
+    <phone number="<?php echo $faker->phoneNumber; ?>"/>
 <?php if ($faker->boolean(25)): ?>
-    <birth date="<?php echo $faker->dateTimeThisCentury->format('Y-m-d') ?>" place="<?php echo $faker->city ?>"/>
+    <birth date="<?php echo $faker->dateTimeThisCentury->format('Y-m-d'); ?>" place="<?php echo $faker->city; ?>"/>
 <?php endif; ?>
     <address>
-      <street><?php echo $faker->streetAddress ?></street>
-      <city><?php echo $faker->city ?></city>
-      <postcode><?php echo $faker->postcode ?></postcode>
-      <state><?php echo $faker->state ?></state>
+      <street><?php echo $faker->streetAddress; ?></street>
+      <city><?php echo $faker->city; ?></city>
+      <postcode><?php echo $faker->postcode; ?></postcode>
+      <state><?php echo $faker->state; ?></state>
     </address>
-    <company name="<?php echo $faker->company ?>" catchPhrase="<?php echo $faker->catchPhrase ?>">
+    <company name="<?php echo $faker->company; ?>" catchPhrase="<?php echo $faker->catchPhrase; ?>">
 <?php if ($faker->boolean(33)): ?>
-      <offer><?php echo $faker->bs ?></offer>
+      <offer><?php echo $faker->bs; ?></offer>
 <?php endif; ?>
 <?php if ($faker->boolean(33)): ?>
-      <director name="<?php echo $faker->name ?>" />
+      <director name="<?php echo $faker->name; ?>" />
 <?php endif; ?>
     </company>
 <?php if ($faker->boolean(15)): ?>
     <details>
 <![CDATA[
-<?php echo $faker->text(400) ?>
+<?php echo $faker->text(400); ?>
 ]]>
     </details>
 <?php endif; ?>


### PR DESCRIPTION
This PR

* [x] enables the `semicolon_after_instruction ` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/semicolon/semicolon_after_instruction.rst.