### PR TITLE
Enhancement: Enable no_blank_lines_after_phpdoc fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -78,6 +78,7 @@ return $config
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_blank_lines_after_class_opening' => true,
+        'no_blank_lines_after_phpdoc' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,

--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -5,7 +5,6 @@ namespace Faker\Provider\en_CA;
 /**
  * Extend US class since most fields share the same format
  */
-
 class Address extends \Faker\Provider\en_US\Address
 {
     protected static $postcode = ['?#? #?#', '?#?-#?#', '?#?#?#'];

--- a/src/Faker/Provider/id_ID/Color.php
+++ b/src/Faker/Provider/id_ID/Color.php
@@ -9,7 +9,6 @@ class Color extends \Faker\Provider\Color
      * @see https://id.wikipedia.org/wiki/Kategori:Warna
      * @see https://id.wikipedia.org/wiki/Warna_tersier
      */
-
     protected static $safeColorNames = ['abu-abu', 'biru', 'biru dongker', 'biru laut', 'cokelat',
         'emas', 'hijau', 'hitam', 'jingga', 'krem', 'kuning', 'magenta', 'mawar', 'merah', 'merah jambu',
         'merah marun', 'nila', 'perak', 'putih', 'sepia', 'teal', 'toska', 'ungu', 'violet', 'zaitun',

--- a/src/Faker/Provider/ko_KR/Person.php
+++ b/src/Faker/Provider/ko_KR/Person.php
@@ -7,7 +7,6 @@ class Person extends \Faker\Provider\Person
     /**
      * This provider uses wikipedia's top Korean last names. These cover more than 90% of Korean population.
      */
-
     protected static $maleNameFormats = [
         '{{lastName}}{{firstNameMale}}',
     ];

--- a/src/Faker/Provider/pt_PT/Person.php
+++ b/src/Faker/Provider/pt_PT/Person.php
@@ -104,7 +104,6 @@ class Person extends \Faker\Provider\Person
     /**
      * @see http://nomesportugueses.blogspot.pt/2012/01/lista-dos-cem-nomes-mais-usados-em.html
      */
-
     protected static $firstNameMale = [
         'Rodrigo', 'João', 'Martim', 'Afonso', 'Tomás', 'Gonçalo', 'Francisco', 'Tiago',
         'Diogo', 'Guilherme', 'Pedro', 'Miguel', 'Rafael', 'Gabriel', 'Santiago', 'Dinis',


### PR DESCRIPTION
This PR

* [x] enables the `no_blank_lines_after_phpdoc` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/no_blank_lines_after_phpdoc.rst.