### PR TITLE
Enhancement: Enable and configure operator_linebreak fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -94,6 +94,10 @@ return $config
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_imports' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,

--- a/src/Faker/ORM/Mandango/EntityPopulator.php
+++ b/src/Faker/ORM/Mandango/EntityPopulator.php
@@ -105,8 +105,8 @@ class EntityPopulator
             if (null !== $format) {
                 $value =  is_callable($format) ? $format($insertedEntities, $obj) : $format;
 
-                if (isset($metadata['fields'][$column]) ||
-                    isset($metadata['referencesOne'][$column])) {
+                if (isset($metadata['fields'][$column])
+                    || isset($metadata['referencesOne'][$column])) {
                     $obj->set($column, $value);
                 }
 

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -29,8 +29,7 @@ final class PaymentTest extends TestCase
     public function isValidCIFFormat($docNumber)
     {
         return $this->respectsDocPattern($docNumber, '/^[PQSNWR][0-9][0-9][0-9][0-9][0-9][0-9][0-9][A-Z0-9]/')
-                ||
-               $this->respectsDocPattern($docNumber, '/^[ABCDEFGHJUV][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/');
+               || $this->respectsDocPattern($docNumber, '/^[ABCDEFGHJUV][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/');
     }
 
     public function respectsDocPattern($givenString, $pattern)

--- a/test/Faker/Provider/es_ES/PersonTest.php
+++ b/test/Faker/Provider/es_ES/PersonTest.php
@@ -15,8 +15,8 @@ final class PersonTest extends TestCase
     // validation taken from http://kiwwito.com/php-function-for-spanish-dni-nie-validation/
     public function isValidDNI($string)
     {
-        if (strlen($string) != 9 ||
-            preg_match('/^[XYZ]?([0-9]{7,8})([A-Z])$/i', $string, $matches) !== 1) {
+        if (strlen($string) != 9
+            || preg_match('/^[XYZ]?([0-9]{7,8})([A-Z])$/i', $string, $matches) !== 1) {
             return false;
         }
 


### PR DESCRIPTION
This PR

* [x] enables and configures the `operator_linebreak` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/operator/operator_linebreak.rst.