### PR TITLE
Enhancement: Enable no_trailing_comma_in_singleline_array fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -87,6 +87,7 @@ return $config
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => true,
+        'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,

--- a/src/Faker/Provider/ar_JO/Address.php
+++ b/src/Faker/Provider/ar_JO/Address.php
@@ -6,7 +6,7 @@ class Address extends \Faker\Provider\Address
 {
     protected static $streetPrefix = ['شارع'];
 
-    protected static $cityPrefix = ['شمال', 'شرق', 'غرب', 'جنوب', 'وسط', ];
+    protected static $cityPrefix = ['شمال', 'شرق', 'غرب', 'جنوب', 'وسط'];
 
     /**
      * @see http://ar.wikipedia.org/wiki/%D9%85%D9%84%D8%AD%D9%82:%D9%82%D8%A7%D8%A6%D9%85%D8%A9_%D9%85%D8%AF%D9%86_%D8%A7%D9%84%D8%A3%D8%B1%D8%AF%D9%86


### PR DESCRIPTION
This PR

* [x] enables the `no_trailing_comma_in_singleline_array` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/array_notation/no_trailing_comma_in_singleline_array.rst.