### PR TITLE
Enhancement: Enable and configure global_namespace_import fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -66,6 +66,11 @@ return $config
                 'author',
             ],
         ],
+        'global_namespace_import' => [
+            'import_classes' => false,
+            'import_constants' => false,
+            'import_functions' => false,
+        ],
         'implode_call' => true,
         'increment_style' => true,
         'is_null' => true,

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -69,9 +69,7 @@
     </UndefinedClass>
   </file>
   <file src="src/Faker/ORM/Propel/ColumnTypeGuesser.php">
-    <UndefinedClass occurrences="1">
-      <code>ColumnMap</code>
-    </UndefinedClass>
+    <UndefinedClass occurrences="1"/>
   </file>
   <file src="src/Faker/ORM/Propel/EntityPopulator.php">
     <UndefinedClass occurrences="9">
@@ -83,7 +81,6 @@
       <code>$columnMap</code>
       <code>$columnMap</code>
       <code>$columnMap</code>
-      <code>ColumnMap</code>
     </UndefinedClass>
   </file>
   <file src="src/Faker/ORM/Propel/Populator.php">

--- a/src/Faker/Calculator/Luhn.php
+++ b/src/Faker/Calculator/Luhn.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Calculator;
 
-use InvalidArgumentException;
-
 /**
  * Utility class for generating and validating Luhn numbers.
  *
@@ -74,7 +72,7 @@ class Luhn
     public static function generateLuhnNumber($partialValue)
     {
         if (!preg_match('/^\d+$/', $partialValue)) {
-            throw new InvalidArgumentException('Argument should be an integer.');
+            throw new \InvalidArgumentException('Argument should be an integer.');
         }
 
         return $partialValue . Luhn::computeCheckDigit($partialValue);

--- a/src/Faker/ORM/Propel/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel/ColumnTypeGuesser.php
@@ -2,9 +2,6 @@
 
 namespace Faker\ORM\Propel;
 
-use ColumnMap;
-use PropelColumnTypes;
-
 class ColumnTypeGuesser
 {
     protected $generator;
@@ -17,7 +14,7 @@ class ColumnTypeGuesser
     /**
      * @return \Closure|null
      */
-    public function guessFormat(ColumnMap $column)
+    public function guessFormat(\ColumnMap $column)
     {
         $generator = $this->generator;
 
@@ -35,75 +32,75 @@ class ColumnTypeGuesser
         $type = $column->getType();
 
         switch ($type) {
-            case PropelColumnTypes::BOOLEAN:
-            case PropelColumnTypes::BOOLEAN_EMU:
+            case \PropelColumnTypes::BOOLEAN:
+            case \PropelColumnTypes::BOOLEAN_EMU:
                 return static function () use ($generator) {
                     return $generator->boolean;
                 };
 
-            case PropelColumnTypes::NUMERIC:
-            case PropelColumnTypes::DECIMAL:
+            case \PropelColumnTypes::NUMERIC:
+            case \PropelColumnTypes::DECIMAL:
                 $size = $column->getSize();
 
                 return static function () use ($generator, $size) {
                     return $generator->randomNumber($size + 2) / 100;
                 };
 
-            case PropelColumnTypes::TINYINT:
+            case \PropelColumnTypes::TINYINT:
                 return static function () use ($generator) {
                     return $generator->numberBetween(0, 127);
                 };
 
-            case PropelColumnTypes::SMALLINT:
+            case \PropelColumnTypes::SMALLINT:
                 return static function () use ($generator) {
                     return $generator->numberBetween(0, 32767);
                 };
 
-            case PropelColumnTypes::INTEGER:
+            case \PropelColumnTypes::INTEGER:
                 return static function () use ($generator) {
                     return $generator->numberBetween(0, 2147483647);
                 };
 
-            case PropelColumnTypes::BIGINT:
+            case \PropelColumnTypes::BIGINT:
                 return static function () use ($generator) {
                     return $generator->numberBetween(0, PHP_INT_MAX);
                 };
 
-            case PropelColumnTypes::FLOAT:
-            case PropelColumnTypes::DOUBLE:
-            case PropelColumnTypes::REAL:
+            case \PropelColumnTypes::FLOAT:
+            case \PropelColumnTypes::DOUBLE:
+            case \PropelColumnTypes::REAL:
             return static function () use ($generator) {
                 return $generator->randomFloat();
             };
 
-            case PropelColumnTypes::CHAR:
-            case PropelColumnTypes::VARCHAR:
-            case PropelColumnTypes::BINARY:
-            case PropelColumnTypes::VARBINARY:
+            case \PropelColumnTypes::CHAR:
+            case \PropelColumnTypes::VARCHAR:
+            case \PropelColumnTypes::BINARY:
+            case \PropelColumnTypes::VARBINARY:
                 $size = $column->getSize();
 
                 return static function () use ($generator, $size) {
                     return $generator->text($size);
                 };
 
-            case PropelColumnTypes::LONGVARCHAR:
-            case PropelColumnTypes::LONGVARBINARY:
-            case PropelColumnTypes::CLOB:
-            case PropelColumnTypes::CLOB_EMU:
-            case PropelColumnTypes::BLOB:
+            case \PropelColumnTypes::LONGVARCHAR:
+            case \PropelColumnTypes::LONGVARBINARY:
+            case \PropelColumnTypes::CLOB:
+            case \PropelColumnTypes::CLOB_EMU:
+            case \PropelColumnTypes::BLOB:
                 return static function () use ($generator) {
                     return $generator->text;
                 };
 
-            case PropelColumnTypes::ENUM:
+            case \PropelColumnTypes::ENUM:
                 $valueSet = $column->getValueSet();
 
                 return static function () use ($generator, $valueSet) {
                     return $generator->randomElement($valueSet);
                 };
 
-            case PropelColumnTypes::OBJECT:
-            case PropelColumnTypes::PHP_ARRAY:
+            case \PropelColumnTypes::OBJECT:
+            case \PropelColumnTypes::PHP_ARRAY:
             default:
             // no smart way to guess what the user expects here
                 return null;

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -2,7 +2,6 @@
 
 namespace Faker\ORM\Propel;
 
-use ColumnMap;
 use Faker\Provider\Base;
 
 /**
@@ -98,7 +97,7 @@ class EntityPopulator
     /**
      * @return bool
      */
-    protected function isColumnBehavior(ColumnMap $columnMap)
+    protected function isColumnBehavior(\ColumnMap $columnMap)
     {
         foreach ($columnMap->getTable()->getBehaviors() as $name => $params) {
             $columnName = Base::toLower($columnMap->getName());

--- a/src/Faker/Provider/tr_TR/Person.php
+++ b/src/Faker/Provider/tr_TR/Person.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\tr_TR;
 
-use InvalidArgumentException;
-
 class Person extends \Faker\Provider\Person
 {
     /**
@@ -125,7 +123,7 @@ class Person extends \Faker\Provider\Person
     public static function tcNoChecksum($identityPrefix)
     {
         if (strlen((string) $identityPrefix) !== 9) {
-            throw new InvalidArgumentException('Argument should be an integer and should be 9 digits.');
+            throw new \InvalidArgumentException('Argument should be an integer and should be 9 digits.');
         }
 
         $oddSum = 0;

--- a/test/Faker/Calculator/IsbnTest.php
+++ b/test/Faker/Calculator/IsbnTest.php
@@ -4,7 +4,6 @@ namespace Faker\Test\Calculator;
 
 use Faker\Calculator\Isbn;
 use Faker\Test\TestCase;
-use LengthException;
 
 final class IsbnTest extends TestCase
 {
@@ -44,7 +43,7 @@ final class IsbnTest extends TestCase
 
     public function testInvalidChecksumIsbn(): void
     {
-        $this->expectException(LengthException::class);
+        $this->expectException(\LengthException::class);
         Isbn::checksum('9971502100');
     }
 

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -2,7 +2,6 @@
 
 namespace Faker\Test\Provider\pl_PL;
 
-use DateTime;
 use Faker\Provider\pl_PL\Person;
 use Faker\Test\TestCase;
 
@@ -17,7 +16,7 @@ final class PersonTest extends TestCase
 
     public function testPeselDate()
     {
-        $date = new DateTime('1990-01-01');
+        $date = new \DateTime('1990-01-01');
         $pesel = $this->faker->pesel($date);
 
         self::assertEquals('90', substr($pesel, 0, 2));
@@ -27,7 +26,7 @@ final class PersonTest extends TestCase
 
     public function testPeselDateWithYearAfter2000()
     {
-        $date = new DateTime('2001-01-01');
+        $date = new \DateTime('2001-01-01');
         $pesel = $this->faker->pesel($date);
 
         self::assertEquals('01', substr($pesel, 0, 2));
@@ -37,7 +36,7 @@ final class PersonTest extends TestCase
 
     public function testPeselDateWithYearAfter2100()
     {
-        $date = new DateTime('2101-01-01');
+        $date = new \DateTime('2101-01-01');
         $pesel = $this->faker->pesel($date);
 
         self::assertEquals('01', substr($pesel, 0, 2));
@@ -47,7 +46,7 @@ final class PersonTest extends TestCase
 
     public function testPeselDateWithYearAfter2200()
     {
-        $date = new DateTime('2201-01-01');
+        $date = new \DateTime('2201-01-01');
         $pesel = $this->faker->pesel($date);
 
         self::assertEquals('01', substr($pesel, 0, 2));
@@ -57,7 +56,7 @@ final class PersonTest extends TestCase
 
     public function testPeselDateWithYearBefore1900()
     {
-        $date = new DateTime('1801-01-01');
+        $date = new \DateTime('1801-01-01');
         $pesel = $this->faker->pesel($date);
 
         self::assertEquals('01', substr($pesel, 0, 2));


### PR DESCRIPTION
This PR

* [x] enables and configures the `global_namespace_import` fixer
* [x] runs `make cs`
* [x] runs `make baseline`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/import/global_namespace_import.rst.