### PR TITLE
Enhancement: Enable no_unneeded_control_parentheses fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -85,6 +85,7 @@ return $config
         'no_leading_namespace_whitespace' => true,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => true,
+        'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -376,6 +376,6 @@ class DateTime extends Base
      */
     private static function resolveTimezone($timezone)
     {
-        return ((null === $timezone) ? ((null === static::$defaultTimezone) ? date_default_timezone_get() : static::$defaultTimezone) : $timezone);
+        return (null === $timezone) ? ((null === static::$defaultTimezone) ? date_default_timezone_get() : static::$defaultTimezone) : $timezone;
     }
 }


### PR DESCRIPTION
This PR

* [x] enables the `no_unneeded_control_parentheses` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/control_structure/no_unneeded_control_parentheses.rst.