### PR TITLE
Enhancement: Enable and configure list_syntax fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -69,6 +69,9 @@ return $config
         'increment_style' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
+        'list_syntax' => [
+            'syntax' => 'short',
+        ],
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -250,7 +250,7 @@ class Payment extends Base
                 $length = 0;
 
                 foreach ($format as $part) {
-                    list($class, $groupCount) = $part;
+                    [$class, $groupCount] = $part;
                     $length += $groupCount;
                 }
             }
@@ -263,7 +263,7 @@ class Payment extends Base
         $expandedFormat = '';
 
         foreach ($format as $item) {
-            list($class, $length) = $item;
+            [$class, $length] = $item;
             $expandedFormat .= str_repeat($class, $length);
         }
 

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -101,7 +101,7 @@ final class ImageTest extends TestCase
         self::assertFileExists($file);
 
         if (function_exists('getimagesize')) {
-            list($width, $height, $type, $attr) = getimagesize($file);
+            [$width, $height, $type, $attr] = getimagesize($file);
             self::assertEquals(640, $width);
             self::assertEquals(480, $height);
             self::assertEquals(constant('IMAGETYPE_PNG'), $type);


### PR DESCRIPTION
This PR

* [x] enables and configures the `list_syntax` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/list_notation/list_syntax.rst.