### PR TITLE
Enhancement: Enable phpdoc_tag_type fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -158,6 +158,7 @@ return $config
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_tag_type' => true,
         'phpdoc_trim' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,

--- a/src/Faker/Calculator/Inn.php
+++ b/src/Faker/Calculator/Inn.php
@@ -3,7 +3,7 @@
 namespace Faker\Calculator;
 
 /**
- * @deprecated moved to ru_RU\Company, use {@link \Faker\Provider\ru_RU\Company}.
+ * @deprecated moved to ru_RU\Company, use {@link \Faker\Provider\ru_RU\Company.
  * @see \Faker\Provider\ru_RU\Company
  */
 class Inn
@@ -17,7 +17,7 @@ class Inn
      *
      * @return string Checksum (one digit)
      *
-     * @deprecated use {@link \Faker\Provider\ru_RU\Company::inn10Checksum()} instead
+     * @deprecated use {@link \Faker\Provider\ru_RU\Company::inn10Checksum() instead
      * @see \Faker\Provider\ru_RU\Company::inn10Checksum()
      */
     public static function checksum($inn)
@@ -32,7 +32,7 @@ class Inn
      *
      * @return bool
      *
-     * @deprecated use {@link \Faker\Provider\ru_RU\Company::inn10IsValid()} instead
+     * @deprecated use {@link \Faker\Provider\ru_RU\Company::inn10IsValid() instead
      * @see \Faker\Provider\ru_RU\Company::inn10IsValid()
      */
     public static function isValid($inn)

--- a/src/Faker/Calculator/TCNo.php
+++ b/src/Faker/Calculator/TCNo.php
@@ -3,7 +3,7 @@
 namespace Faker\Calculator;
 
 /**
- * @deprecated moved to tr_TR\Person, use {@link \Faker\Provider\tr_TR\Person}.
+ * @deprecated moved to tr_TR\Person, use {@link \Faker\Provider\tr_TR\Person.
  * @see \Faker\Provider\tr_TR\Person
  */
 class TCNo
@@ -18,7 +18,7 @@ class TCNo
      *
      * @return string Checksum (two digit)
      *
-     * @deprecated use {@link \Faker\Provider\tr_TR\Person::tcNoChecksum()} instead
+     * @deprecated use {@link \Faker\Provider\tr_TR\Person::tcNoChecksum() instead
      * @see \Faker\Provider\tr_TR\Person::tcNoChecksum()
      */
     public static function checksum($identityPrefix)
@@ -33,7 +33,7 @@ class TCNo
      *
      * @return bool
      *
-     * @deprecated use {@link \Faker\Provider\tr_TR\Person::tcNoIsValid()} instead
+     * @deprecated use {@link \Faker\Provider\tr_TR\Person::tcNoIsValid() instead
      * @see \Faker\Provider\tr_TR\Person::tcNoIsValid()
      */
     public static function isValid($tcNo)

--- a/src/Faker/Provider/at_AT/Payment.php
+++ b/src/Faker/Provider/at_AT/Payment.php
@@ -3,7 +3,7 @@
 namespace Faker\Provider\at_AT;
 
 /**
- * @deprecated at_AT is not an existing locale, use {@link \Faker\Provider\de_AT\Payment}.
+ * @deprecated at_AT is not an existing locale, use {@link \Faker\Provider\de_AT\Payment.
  * @see \Faker\Provider\de_AT\Payment
  */
 class Payment extends \Faker\Provider\de_AT\Payment

--- a/src/Faker/Provider/ru_RU/Company.php
+++ b/src/Faker/Provider/ru_RU/Company.php
@@ -104,7 +104,7 @@ class Company extends \Faker\Provider\Company
      *
      * @return string
      *
-     * @deprecated use {@link \Faker\Provider\ru_RU\Company::inn10()} instead
+     * @deprecated use {@link \Faker\Provider\ru_RU\Company::inn10() instead
      * @see \Faker\Provider\ru_RU\Company::inn10()
      */
     public static function inn($area_code = '')

--- a/src/Faker/Provider/zh_TW/Internet.php
+++ b/src/Faker/Provider/zh_TW/Internet.php
@@ -3,13 +3,13 @@
 namespace Faker\Provider\zh_TW;
 
 /**
- * @deprecated Use {@link \Faker\Provider\Internet} instead
+ * @deprecated Use {@link \Faker\Provider\Internet instead
  * @see \Faker\Provider\Internet
  */
 class Internet extends \Faker\Provider\Internet
 {
     /**
-     * @deprecated Use {@link \Faker\Provider\Internet::userName()} instead
+     * @deprecated Use {@link \Faker\Provider\Internet::userName() instead
      * @see \Faker\Provider\Internet::userName()
      */
     public function userName()
@@ -18,7 +18,7 @@ class Internet extends \Faker\Provider\Internet
     }
 
     /**
-     * @deprecated Use {@link \Faker\Provider\Internet::domainWord()} instead
+     * @deprecated Use {@link \Faker\Provider\Internet::domainWord() instead
      * @see \Faker\Provider\Internet::domainWord()
      */
     public function domainWord()

--- a/src/Faker/Provider/zh_TW/Payment.php
+++ b/src/Faker/Provider/zh_TW/Payment.php
@@ -3,7 +3,7 @@
 namespace Faker\Provider\zh_TW;
 
 /**
- * @deprecated Use {@link \Faker\Provider\Payment} instead
+ * @deprecated Use {@link \Faker\Provider\Payment instead
  * @see \Faker\Provider\Payment
  */
 class Payment extends \Faker\Provider\Payment
@@ -11,7 +11,7 @@ class Payment extends \Faker\Provider\Payment
     /**
      * @return array
      *
-     * @deprecated Use {@link \Faker\Provider\Payment::creditCardDetails()} instead
+     * @deprecated Use {@link \Faker\Provider\Payment::creditCardDetails() instead
      * @see \Faker\Provider\Payment::creditCardDetails()
      */
     public function creditCardDetails($valid = true)

--- a/test/Faker/Extension/ContainerBuilderTest.php
+++ b/test/Faker/Extension/ContainerBuilderTest.php
@@ -34,7 +34,7 @@ final class ContainerBuilderTest extends TestCase
     }
 
     /**
-     * @return \Generator<string, array{0: array|bool|float|int|null|resource}>
+     * @return \Generator<string, array{0: array|bool|float|int|null|resource>
      */
     public function provideInvalidValue(): \Generator
     {

--- a/test/Faker/Extension/ContainerTest.php
+++ b/test/Faker/Extension/ContainerTest.php
@@ -65,7 +65,7 @@ final class ContainerTest extends TestCase
     }
 
     /**
-     * @return \Generator<string, array{0: callable|object|string}>
+     * @return \Generator<string, array{0: callable|object|string>
      */
     public function provideDefinitionThatDoesNotResolveToExtension(): \Generator
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_tag_type` fixer
* [x] runs `make cs`
* [ ] fixes annotations manually

Follows #157.

❗ Blocked by https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5395.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.3/doc/rules/phpdoc/phpdoc_tag_type.rst.