### PR TITLE
Enhancement: Enable phpdoc_no_access fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -121,6 +121,7 @@ return $config
         'phpdoc_indent' => true,
         'phpdoc_inline_tag_normalizer' => true,
         'phpdoc_line_span' => true,
+        'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => [
             'replacements' => [
                 'link' => 'see',

--- a/src/Faker/Provider/en_IN/Person.php
+++ b/src/Faker/Provider/en_IN/Person.php
@@ -116,8 +116,6 @@ class Person extends \Faker\Provider\Person
      *
      * @example 'Kumar'
      *
-     * @access public
-     *
      * @return string Middle name
      */
     public function middleNameMale()

--- a/src/Faker/Provider/id_ID/Person.php
+++ b/src/Faker/Provider/id_ID/Person.php
@@ -264,8 +264,6 @@ class Person extends \Faker\Provider\Person
     /**
      * Return last name for male
      *
-     * @access public
-     *
      * @return string last name
      */
     public static function lastNameMale()
@@ -276,8 +274,6 @@ class Person extends \Faker\Provider\Person
     /**
      * Return last name for female
      *
-     * @access public
-     *
      * @return string last name
      */
     public static function lastNameFemale()
@@ -287,8 +283,6 @@ class Person extends \Faker\Provider\Person
 
     /**
      * For academic title
-     *
-     * @access public
      *
      * @return string suffix
      */

--- a/src/Faker/Provider/ru_RU/Person.php
+++ b/src/Faker/Provider/ru_RU/Person.php
@@ -112,8 +112,6 @@ class Person extends \Faker\Provider\Person
      *
      * @example 'Иванович'
      *
-     * @access public
-     *
      * @return string Middle name
      */
     public function middleNameMale()
@@ -126,8 +124,6 @@ class Person extends \Faker\Provider\Person
      *
      * @example 'Ивановна'
      *
-     * @access public
-     *
      * @return string Middle name
      */
     public function middleNameFemale()
@@ -137,8 +133,6 @@ class Person extends \Faker\Provider\Person
 
     /**
      * Return middle name for the specified gender.
-     *
-     * @access public
      *
      * @param string|null $gender A gender the middle name should be generated
      *                            for. If the argument is skipped a random gender will be used.

--- a/src/Faker/Provider/uk_UA/Person.php
+++ b/src/Faker/Provider/uk_UA/Person.php
@@ -55,7 +55,6 @@ class Person extends \Faker\Provider\Person
      * Return male middle name
      *
      * @example 'Іванович'
-     * @access public
      *
      * @return string Middle name
      */
@@ -68,7 +67,6 @@ class Person extends \Faker\Provider\Person
      * Return female middle name
      *
      * @example 'Івановна'
-     * @access public
      *
      * @return string Middle name
      */
@@ -79,8 +77,6 @@ class Person extends \Faker\Provider\Person
 
     /**
      * Return middle name for the specified gender.
-     *
-     * @access public
      *
      * @param string|null $gender A gender the middle name should be generated
      *                            for. If the argument is skipped a random gender will be used.


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_no_access` fixer
* [x] runs `make cs`

Follows #157.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/phpdoc/phpdoc_no_access.rst.