### PR TITLE
Fix: Let phpstan report unmatched ignored errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -961,11 +961,6 @@ parameters:
 			path: src/Faker/Provider/zh_CN/Address.php
 
 		-
-			message: "#^Variable \\$chars might not be defined\\.$#"
-			count: 1
-			path: src/Faker/Provider/zh_TW/Text.php
-
-		-
 			message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, Closure\\(mixed\\)\\: mixed given\\.$#"
 			count: 1
 			path: src/autoload.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,6 @@ includes:
 
 parameters:
     level: 5
-    reportUnmatchedIgnoredErrors: false
     paths:
         - src
     tmpDir: .build/phpstan/


### PR DESCRIPTION
This PR

* [x] lets `phpstan` report unmatched ignored errors
* [x] runs `make baseline`

💁‍♂️ I think that this is a great feature of `phpstan/phpstan`, which prevents a developer from regenerating a baseline with changes unrelated to changes they made to source code.