### PR TITLE
Fix: Add missing tests for ContainerBuilder

### DIFF
--- a/test/Faker/Extension/ContainerBuilderTest.php
+++ b/test/Faker/Extension/ContainerBuilderTest.php
@@ -6,6 +6,7 @@ namespace Faker\Test\Extension;
 
 use Faker\Core\File;
 use Faker\Extension\ContainerBuilder;
+use Faker\Extension\Extension;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -14,6 +15,90 @@ use Psr\Container\ContainerInterface;
  */
 final class ContainerBuilderTest extends TestCase
 {
+    /**
+     * @dataProvider provideInvalidValue
+     *
+     * @param array|bool|float|int|resource|null $value
+     */
+    public function testAddRejectsInvalidValue($value): void
+    {
+        $containerBuilder = new ContainerBuilder();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'First argument to "%s::add()" must be a string, callable or object.',
+            ContainerBuilder::class
+        ));
+
+        $containerBuilder->add($value);
+    }
+
+    /**
+     * @return \Generator<string, array{0: array|bool|float|int|null|resource}>
+     */
+    public function provideInvalidValue(): \Generator
+    {
+        $values = [
+            'array' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+            'bool-false' => false,
+            'bool-true' => true,
+            'float' => 3.14,
+            'int' => 9001,
+            'null' => true,
+            'resource' => fopen(__FILE__, 'rb'),
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    public function testAddRejectsNameWhenValueIsCallableAndNameIsNull(): void
+    {
+        $value = [
+            new class() {
+                public static function create(): Extension
+                {
+                    return new class() implements Extension {
+                    };
+                }
+            },
+            'create',
+        ];
+
+        $containerBuilder = new ContainerBuilder();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Second argument to "%s::add()" is required not passing a string or object as first argument',
+            ContainerBuilder::class
+        ));
+
+        $containerBuilder->add($value);
+    }
+
+    public function testAddAcceptsValueWhenItIsAnObjectAndNameIsNull(): void
+    {
+        $value = new class() implements Extension {};
+
+        $name = get_class($value);
+
+        $containerBuilder = new ContainerBuilder();
+
+        $containerBuilder->add($value);
+
+        $container = $containerBuilder->build();
+
+        self::assertTrue($container->has($name));
+        self::assertSame($value, $container->get($name));
+    }
+
     public function testBuildEmpty(): void
     {
         $builder = new ContainerBuilder();


### PR DESCRIPTION
This PR

* [x] add missing tests for the previously introduced `ContainerBuilder`

Follows #154.