### PR TITLE
Fix: Force execution of vendor target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,32 @@
 .PHONY: build
 build: cs static test ## Runs cs, static, and test targets
 
+# https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
+always:
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: cs
-cs: vendor/autoload.php ## Fixes coding standard issues with php-cs-fixer
+cs: vendor ## Fixes coding standard issues with php-cs-fixer
 	vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --verbose
 
 .PHONY: coverage
-coverage: vendor/autoload.php ## Collects coverage with phpunit
+coverage: vendor ## Collects coverage with phpunit
 	vendor/bin/simple-phpunit --coverage-text --coverage-clover=.build/logs/clover.xml
 
 .PHONY: test
-test: vendor/autoload.php ## Runs tests with phpunit
+test: vendor ## Runs tests with phpunit
 	vendor/bin/simple-phpunit
 
 .PHONY: static
-static: vendor/autoload.php ## Runs static analyzers
+static: vendor ## Runs static analyzers
 	vendor/bin/phpstan analyze
 	vendor/bin/psalm
 
 .PHONY: baseline
-baseline: vendor/autoload.php ## Generate baseline files
+baseline: vendor ## Generate baseline files
 	vendor/bin/phpstan analyze --generate-baseline
 	vendor/bin/psalm --update-baseline
 
@@ -31,7 +34,7 @@ baseline: vendor/autoload.php ## Generate baseline files
 clean:   ## Cleans up build and vendor files
 	rm -rf vendor composer.lock .build
 
-vendor/autoload.php:
+vendor: always
 	composer update --no-interaction
 	composer bin all install --no-interaction
 	vendor/bin/simple-phpunit install


### PR DESCRIPTION
This PR

* [x] forces the execution of the `vendor` target

💁‍♂️ This ensures that dependencies are installed at all times. At the moment it would be possible to do the following after checkout

```
$ composer install
$ make
```

This would then fail because dependencies are not installed for that `coding-standards` and `static` targets.