### PR TITLE
Enhancement: Configure braces fixer to allow empty single-line anonymous classes

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -48,6 +48,9 @@ return $config
                 'yield',
             ],
         ],
+        'braces' => [
+            'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [


### PR DESCRIPTION
This PR

* [x] configures the `braces` fixer to allow empty single-line anonymous classes

Follows #157.
Related to #228.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/basic/braces.rst.