### PR TITLE
Enhancement: Enable comments from codecov.io

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 /.gitattributes           export-ignore
 /.gitignore               export-ignore
 /.php_cs.dist             export-ignore
-/codecov.yml              export-ignore
 /Makefile                 export-ignore
 /phpstan-baseline.neon    export-ignore
 /phpstan.neon.dist        export-ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,0 @@
-comment: false


### PR DESCRIPTION
This PR

* [x] enables comments from [codecov.io](https://about.codecov.io)

Follows #178.

@bramceulemans [indicated that he does not like the comments](https://github.com/FakerPHP/Faker/pull/178#issuecomment-748676221), but at the end of the day we want to improve this project and not cater to whether maintainers or contributors like something. 

While the [status checks](https://docs.codecov.io/docs/commit-status#branches) show the effect, they are collapsed when all checks have completed:

![CleanShot 2020-12-22 at 15 32 46](https://user-images.githubusercontent.com/605483/102899300-fefabf00-446a-11eb-83dd-930ea6352591.png)

and need to be expanded

![CleanShot 2020-12-22 at 15 34 07](https://user-images.githubusercontent.com/605483/102899461-32d5e480-446b-11eb-9a89-7a165f4ede0c.png)

and then a reviewer needs to scroll

![CleanShot 2020-12-22 at 15 34 54](https://user-images.githubusercontent.com/605483/102899502-4a14d200-446b-11eb-8276-98c0986b880d.png)

before they can see the effect.


The comments help to show the effect of adding and removing production code, adding and removing test code and help reviewers understand the effects of proposed changes.

 

In my opinion, code coverage alone is a useless metric, but it's useful to see in which direction we are going. 

Also see https://localheinz.com/blog/2018/02/01/test-coverage-is-meaningless/.