### PR TITLE
Extract fixtures into separate classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Faker\\Test\\": "test/Faker/"
+            "Faker\\Test\\": "test/Faker/",
+            "Faker\\Test\\Fixture\\": "test/Fixture/"
         }
     },
     "conflict": {

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -56,29 +56,29 @@ final class GeneratorTest extends TestCase
 
     public function testAddProviderGivesPriorityToNewlyAddedProvider()
     {
-        $this->faker->addProvider(new FooProvider());
-        $this->faker->addProvider(new BarProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\BarProvider());
         self::assertEquals('barfoo', $this->faker->format('fooFormatter'));
     }
 
     public function testGetProvidersReturnsCorrectProviders()
     {
-        $this->faker->addProvider(new FooProvider());
-        $this->faker->addProvider(new BarProvider());
-        self::assertInstanceOf(FooProvider::class, $this->faker->getProviders()[1]);
-        self::assertInstanceOf(BarProvider::class, $this->faker->getProviders()[0]);
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\BarProvider());
+        self::assertInstanceOf(Fixture\Provider\FooProvider::class, $this->faker->getProviders()[1]);
+        self::assertInstanceOf(Fixture\Provider\BarProvider::class, $this->faker->getProviders()[0]);
         self::assertCount(2, $this->faker->getProviders());
     }
 
     public function testGetFormatterReturnsCallable()
     {
-        $this->faker->addProvider(new FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
         self::assertIsCallable($this->faker->getFormatter('fooFormatter'));
     }
 
     public function testGetFormatterReturnsCorrectFormatter()
     {
-        $provider = new FooProvider();
+        $provider = new Fixture\Provider\FooProvider();
         $this->faker->addProvider($provider);
         $expected = [$provider, 'fooFormatter'];
         self::assertEquals($expected, $this->faker->getFormatter('fooFormatter'));
@@ -93,20 +93,20 @@ final class GeneratorTest extends TestCase
     public function testGetFormatterThrowsExceptionOnIncorrectFormatter()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->faker->addProvider(new FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
         $this->faker->getFormatter('barFormatter');
     }
 
     public function testFormatCallsFormatterOnProvider()
     {
-        $this->faker->addProvider(new FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
         self::assertEquals('foobar', $this->faker->format('fooFormatter'));
     }
 
     public function testFormatTransfersArgumentsToFormatter()
     {
         $this->faker = new Generator();
-        $provider = new FooProvider();
+        $provider = new Fixture\Provider\FooProvider();
         $this->faker->addProvider($provider);
         self::assertEquals('bazfoo', $this->faker->format('fooFormatterWithArguments', ['foo']));
     }
@@ -118,7 +118,7 @@ final class GeneratorTest extends TestCase
 
     public function testParseReturnsStringWithTokensReplacedByFormatters()
     {
-        $this->faker->addProvider(new FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
         self::assertEquals('This is foobar a text with foobar', $this->faker->parse('This is {{fooFormatter}} a text with {{ fooFormatter }}'));
     }
 
@@ -127,19 +127,19 @@ final class GeneratorTest extends TestCase
      */
     public function testMagicGetCallsFormat()
     {
-        $this->faker->addProvider(new FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
         self::assertEquals('foobar', $this->faker->fooFormatter);
     }
 
     public function testMagicCallCallsFormat()
     {
-        $this->faker->addProvider(new FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
         self::assertEquals('foobar', $this->faker->fooFormatter());
     }
 
     public function testMagicCallCallsFormatWithArguments()
     {
-        $this->faker->addProvider(new FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
         self::assertEquals('bazfoo', $this->faker->fooFormatterWithArguments('foo'));
     }
 
@@ -283,26 +283,5 @@ final class GeneratorTest extends TestCase
         ));
 
         $uniqueGenerator->word();
-    }
-}
-
-final class FooProvider
-{
-    public function fooFormatter()
-    {
-        return 'foobar';
-    }
-
-    public function fooFormatterWithArguments($value = '')
-    {
-        return 'baz' . $value;
-    }
-}
-
-final class BarProvider
-{
-    public function fooFormatter()
-    {
-        return 'barfoo';
     }
 }

--- a/test/Fixture/Provider/BarProvider.php
+++ b/test/Fixture/Provider/BarProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Faker\Test\Fixture\Provider;
+
+final class BarProvider
+{
+    public function fooFormatter()
+    {
+        return 'barfoo';
+    }
+}

--- a/test/Fixture/Provider/FooProvider.php
+++ b/test/Fixture/Provider/FooProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Faker\Test\Fixture\Provider;
+
+final class FooProvider
+{
+    public function fooFormatter()
+    {
+        return 'foobar';
+    }
+
+    public function fooFormatterWithArguments($value = '')
+    {
+        return 'baz' . $value;
+    }
+}


### PR DESCRIPTION
This PR

* [x] extracts fixtures into separate classes and introduces a new PSR-4 class mapping

💁‍♂️ There is a range of test classes in `tests/Faker`. Some of the files declare additional classes in the containing files.

The first impulse would be to move them into separate files, declaring a single class in each file. The question that arises then is: where to put these classes?

We use `Faker\Test` as namespace for tests. We could 

- declare test doubles in `Faker\Test\Double` 
- declare fixtures in `Faker\Test\Fixture`
- declare integration tests in `Faker\Test\Integration`
- declare unit tests in `Faker\Test\Unit`

This could nicely map to the following directory structure:

```
test
├── Double
├── Fixture
├── Integration
└── Unit
```

However, we currently autoload classes from the `Faker\Test` namespace using a PSR-4 autoloader with PSR-0 class mapping with the following directory structure:

```
test
└── Faker
```
We could move classes into the following structure:

```
test
└── Faker
    ├── Double
    ├── Fixture
    ├── Integration
    └── Unit
```
but then these classes would mix with existing classes.

We could move existing classes from `test/Faker/` to `test/`, effectively flattening the directory structure. People often complain that this will make history hard to understand or follow (I don't care much). Since a lot of classes will be removed or extracted into separate packages, these tests will disappear sooner or later, too.

That's why I propose to keep the old tests and add new tests in a separate structure:

```
test
├── Double
├── Faker
├── Fixture
├── Integration
└── Unit
```

We could then easily differentiate between kinds of tests, in particular, tests that demonstrate the behaviour from the outside  as expected from users (also see #233), and others, that test specifics of extensions and similar.

Eventually, we could remove the directory `test/Faker`.

What do you think?