### PR TITLE
Fix: Mark factory as final

### DIFF
--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -2,7 +2,7 @@
 
 namespace Faker;
 
-class Factory
+final class Factory
 {
     public const DEFAULT_LOCALE = 'en_US';
 


### PR DESCRIPTION
This PR

* [x] marks `Faker\Factory` as `final`

💁‍♂️ There is probably no need to extend it. In any case, this is a backwards-incompatible change, as far as I am concerned.