### PR TITLE
Fix: Let dependabot update dependencies in vendor-bin/php-cs-fixer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
   - commit-message:
       include: "scope"
       prefix: "composer"
+    directory: "/vendor-bin/php-cs-fixer"
+    labels:
+      - "dependency"
+    open-pull-requests-limit: 10
+    package-ecosystem: "composer"
+    schedule:
+      interval: "monthly"
+    versioning-strategy: "increase"
+
+  - commit-message:
+      include: "scope"
+      prefix: "composer"
     directory: "/vendor-bin/phpstan"
     labels:
       - "dependency"


### PR DESCRIPTION
This PR

* [x] lets Dependabot update dependencies in `vendor-bin/php-cs-fixer`

Follows #157.