### PR TITLE
[Core] Improve checks in blood tests

### DIFF
--- a/test/Faker/Core/BloodTest.php
+++ b/test/Faker/Core/BloodTest.php
@@ -5,49 +5,69 @@ declare(strict_types=1);
 namespace Faker\Test\Core;
 
 use Faker\Test\TestCase;
+use Faker\UniqueGenerator;
 
 final class BloodTest extends TestCase
 {
     public function testBloodType(): void
     {
-        $resultSet = [];
+        $expected = [
+            'A',
+            'AB',
+            'B',
+            'O',
+        ];
 
-        for ($i = 0; $i < 17; ++$i) {
-            $resultSet[] = $this->faker->bloodType();
+        $faker = new UniqueGenerator($this->faker);
+
+        $generated = [];
+        for ($i = 0; $i < count($expected); ++$i) {
+            $generated[] = $faker->bloodType();
         }
 
-        self::assertContains('A', $resultSet);
-        self::assertContains('AB', $resultSet);
-        self::assertContains('B', $resultSet);
-        self::assertContains('O', $resultSet);
+        self::assertEqualsCanonicalizing($expected, $generated);
     }
 
     public function testBloodRh(): void
     {
-        $resultSet = [];
+        $expected = [
+            '+',
+            '-',
+        ];
 
-        for ($i = 0; $i < 3; ++$i) {
-            $resultSet[] = $this->faker->bloodRh();
+        $faker = new UniqueGenerator($this->faker);
+
+        $generated = [];
+        for ($i = 0; $i < count($expected); ++$i) {
+            $generated[] = $faker->bloodRh();
         }
-        self::assertContains('+', $resultSet);
-        self::assertContains('-', $resultSet);
+
+        self::assertEqualsCanonicalizing($expected, $generated);
+
     }
 
     public function testBloodGroup(): void
     {
-        $resultSet = [];
 
-        for ($i = 0; $i < 10; ++$i) {
-            $resultSet[] = $this->faker->bloodGroup();
+        $expected = [
+            'A+',
+            'A-',
+            'AB+',
+            'AB-',
+            'B+',
+            'B-',
+            'O+',
+            'O-',
+        ];
+
+        $faker = new UniqueGenerator($this->faker);
+
+        $generated = [];
+        for ($i = 0; $i < count($expected); ++$i) {
+            $generated[] = $faker->bloodGroup();
         }
 
-        self::assertContains('A+', $resultSet);
-        self::assertContains('A-', $resultSet);
-        self::assertContains('AB+', $resultSet);
-        self::assertContains('AB-', $resultSet);
-        self::assertContains('B+', $resultSet);
-        self::assertContains('B-', $resultSet);
-        self::assertContains('O+', $resultSet);
-        self::assertContains('O-', $resultSet);
+        self::assertEqualsCanonicalizing($expected, $generated);
+
     }
 }

--- a/test/Faker/Core/BloodTest.php
+++ b/test/Faker/Core/BloodTest.php
@@ -10,16 +10,41 @@ final class BloodTest extends TestCase
 {
     public function testBloodType(): void
     {
-        self::assertContains($this->faker->bloodType(), ['A', 'AB', 'B', 'O']);
+        $resultSet = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $resultSet[] = $this->faker->bloodType();
+        }
+
+        self::assertContains('A', $resultSet);
+        self::assertContains('AB', $resultSet);
+        self::assertContains('B', $resultSet);
+        self::assertContains('O', $resultSet);
     }
 
     public function testBloodRh(): void
     {
-        self::assertContains($this->faker->bloodRh(), ['+', '-']);
+        $resultSet = [];
+        for ($i = 0; $i < 100; ++$i){
+            $resultSet[] = $this->faker->bloodRh();
+        }
+        self::assertContains('+', $resultSet);
+        self::assertContains('-', $resultSet);
     }
 
     public function testBloodGroup(): void
     {
-        self::assertContains($this->faker->bloodGroup(), ['A+', 'A-', 'AB+', 'AB-', 'B+', 'B-', 'O+', 'O-']);
+        $resultSet = [];
+        for ($i = 0; $i < 100; ++$i){
+            $resultSet[] = $this->faker->bloodGroup();
+        }
+
+        self::assertContains('A+', $resultSet);
+        self::assertContains('A-', $resultSet);
+        self::assertContains('AB+', $resultSet);
+        self::assertContains('AB-', $resultSet);
+        self::assertContains('B+', $resultSet);
+        self::assertContains('B-', $resultSet);
+        self::assertContains('O+', $resultSet);
+        self::assertContains('O-', $resultSet);
     }
 }

--- a/test/Faker/Core/BloodTest.php
+++ b/test/Faker/Core/BloodTest.php
@@ -21,6 +21,7 @@ final class BloodTest extends TestCase
         $faker = new UniqueGenerator($this->faker);
 
         $generated = [];
+
         for ($i = 0; $i < count($expected); ++$i) {
             $generated[] = $faker->bloodType();
         }
@@ -38,17 +39,16 @@ final class BloodTest extends TestCase
         $faker = new UniqueGenerator($this->faker);
 
         $generated = [];
+
         for ($i = 0; $i < count($expected); ++$i) {
             $generated[] = $faker->bloodRh();
         }
 
         self::assertEqualsCanonicalizing($expected, $generated);
-
     }
 
     public function testBloodGroup(): void
     {
-
         $expected = [
             'A+',
             'A-',
@@ -63,11 +63,11 @@ final class BloodTest extends TestCase
         $faker = new UniqueGenerator($this->faker);
 
         $generated = [];
+
         for ($i = 0; $i < count($expected); ++$i) {
             $generated[] = $faker->bloodGroup();
         }
 
         self::assertEqualsCanonicalizing($expected, $generated);
-
     }
 }

--- a/test/Faker/Core/BloodTest.php
+++ b/test/Faker/Core/BloodTest.php
@@ -12,7 +12,7 @@ final class BloodTest extends TestCase
     {
         $resultSet = [];
 
-        for ($i = 0; $i < 100; ++$i) {
+        for ($i = 0; $i < 17; ++$i) {
             $resultSet[] = $this->faker->bloodType();
         }
 
@@ -26,7 +26,7 @@ final class BloodTest extends TestCase
     {
         $resultSet = [];
 
-        for ($i = 0; $i < 100; ++$i) {
+        for ($i = 0; $i < 3; ++$i) {
             $resultSet[] = $this->faker->bloodRh();
         }
         self::assertContains('+', $resultSet);
@@ -37,7 +37,7 @@ final class BloodTest extends TestCase
     {
         $resultSet = [];
 
-        for ($i = 0; $i < 100; ++$i) {
+        for ($i = 0; $i < 10; ++$i) {
             $resultSet[] = $this->faker->bloodGroup();
         }
 

--- a/test/Faker/Core/BloodTest.php
+++ b/test/Faker/Core/BloodTest.php
@@ -11,6 +11,7 @@ final class BloodTest extends TestCase
     public function testBloodType(): void
     {
         $resultSet = [];
+
         for ($i = 0; $i < 100; ++$i) {
             $resultSet[] = $this->faker->bloodType();
         }
@@ -24,7 +25,8 @@ final class BloodTest extends TestCase
     public function testBloodRh(): void
     {
         $resultSet = [];
-        for ($i = 0; $i < 100; ++$i){
+
+        for ($i = 0; $i < 100; ++$i) {
             $resultSet[] = $this->faker->bloodRh();
         }
         self::assertContains('+', $resultSet);
@@ -34,7 +36,8 @@ final class BloodTest extends TestCase
     public function testBloodGroup(): void
     {
         $resultSet = [];
-        for ($i = 0; $i < 100; ++$i){
+
+        for ($i = 0; $i < 100; ++$i) {
             $resultSet[] = $this->faker->bloodGroup();
         }
 


### PR DESCRIPTION
### What is the reason for this PR?

To improve the test suite around blood tests so it fails should any blood type, or RH, not be present. Previously it would pass if *any* blood type and RH were present. Now all must exist.

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

I've updated the Blood Test suite inline with how tests are handled in `en_US/PersonTest` regarding randomized data. I don't believe this is a perfect solution, but it does correct the potential issue where breaking changes in the Blood class did not break the tests.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
