### PR TITLE
Shorten the stale period to 14 days instead of the original 30

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,4 @@
-daysUntilStale: 30
+daysUntilStale: 14
 daysUntilClose: 7
 exemptLabels:
   - pinned


### PR DESCRIPTION
### What is the reason for this PR?

Stale PRs stay open too long. Therefor the threshold has been put back to 14 instead of 30 days. 14 days without a single comment is pretty not active imo. If needed we can always pin them to keep open.

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Stale 30 > 14 days

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
