### PR TITLE
[Core] Added color extension to core

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing
 
-If you've written a new formatter, added a new locale, or fixed a bug, your contribution is welcome!
+**At the moment we are not looking for pull requests that add new features.** We are planning for Faker 2.0's architecture.
+
+If you've <!-- written a new formatter, added a new locale, or --> fixed a bug, your contribution is welcome!
 
 Before proposing a pull request, please read these contribution guidelines.
 

--- a/src/Faker/Core/Barcode.php
+++ b/src/Faker/Core/Barcode.php
@@ -19,33 +19,16 @@ final class Barcode implements Extension\BarcodeExtension
         return sprintf('%s%s', $code, Calculator\Ean::checksum($code));
     }
 
-    /**
-     * Get a random EAN13 barcode.
-     *
-     * @example '4006381333931'
-     */
     public function ean13(): string
     {
         return $this->ean();
     }
 
-    /**
-     * Get a random EAN8 barcode.
-     *
-     * @example '73513537'
-     */
     public function ean8(): string
     {
         return $this->ean(8);
     }
 
-    /**
-     * Get a random ISBN-10 code
-     *
-     * @see http://en.wikipedia.org/wiki/International_Standard_Book_Number
-     *
-     * @example '4881416324'
-     */
     public function isbn10(): string
     {
         $code = Extension\Helper::numerify(str_repeat('#', 9));
@@ -53,13 +36,6 @@ final class Barcode implements Extension\BarcodeExtension
         return sprintf('%s%s', $code, Calculator\Isbn::checksum($code));
     }
 
-    /**
-     * Get a random ISBN-13 code
-     *
-     * @see http://en.wikipedia.org/wiki/International_Standard_Book_Number
-     *
-     * @example '9790404436093'
-     */
     public function isbn13(): string
     {
         $code = '97' . mt_rand(8, 9) . Extension\Helper::numerify(str_repeat('#', 9));

--- a/src/Faker/Core/Barcode.php
+++ b/src/Faker/Core/Barcode.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Faker\Core;
 
+use Faker\Calculator;
 use Faker\Extension;
 
 /**
@@ -15,7 +16,7 @@ final class Barcode implements Extension\BarcodeExtension
     {
         $code = Extension\Helper::numerify(str_repeat('#', $length - 1));
 
-        return sprintf('%s%s', $code, \Faker\Calculator\Ean::checksum($code));
+        return sprintf('%s%s', $code, Calculator\Ean::checksum($code));
     }
 
     /**
@@ -49,7 +50,7 @@ final class Barcode implements Extension\BarcodeExtension
     {
         $code = Extension\Helper::numerify(str_repeat('#', 9));
 
-        return sprintf('%s%s', $code, \Faker\Calculator\Isbn::checksum($code));
+        return sprintf('%s%s', $code, Calculator\Isbn::checksum($code));
     }
 
     /**
@@ -63,6 +64,6 @@ final class Barcode implements Extension\BarcodeExtension
     {
         $code = '97' . mt_rand(8, 9) . Extension\Helper::numerify(str_repeat('#', 9));
 
-        return sprintf('%s%s', $code, \Faker\Calculator\Ean::checksum($code));
+        return sprintf('%s%s', $code, Calculator\Ean::checksum($code));
     }
 }

--- a/src/Faker/Core/Color.php
+++ b/src/Faker/Core/Color.php
@@ -46,25 +46,16 @@ final class Color implements Extension\ColorExtension
         'gray', 'yellow', 'fuchsia', 'aqua', 'white',
     ];
 
-    /**
-     * @example 'NavajoWhite'
-     */
     public function colorName(): string
     {
         return Extension\Helper::randomElement($this->colorNames);
     }
 
-    /**
-     * @example '#fa3cc2'
-     */
     public function hexColor(): string
     {
         return '#' . str_pad(dechex(mt_rand(1, 16777215)), 6, '0', STR_PAD_LEFT);
     }
 
-    /**
-     * @example '340,50,20'
-     */
     public function hslColor(): string
     {
         return sprintf(
@@ -75,9 +66,6 @@ final class Color implements Extension\ColorExtension
         );
     }
 
-    /**
-     * @example array(340, 50, 20)
-     */
     public function hslColorAsArray(): array
     {
         return [
@@ -87,25 +75,16 @@ final class Color implements Extension\ColorExtension
         ];
     }
 
-    /**
-     * @example 'rgba(0,255,122,0.8)'
-     */
     public function rgbaCssColor(): string
     {
         return 'rgba(' . $this->rgbColor() . ',' . (mt_rand(0, 10) / 10) . ')';
     }
 
-    /**
-     * @example '0,255,122'
-     */
     public function rgbColor(): string
     {
         return implode(',', $this->rgbColorAsArray());
     }
 
-    /**
-     * @example '[0,255,122]'
-     */
     public function rgbColorAsArray(): array
     {
         $color = $this->hexColor();
@@ -117,17 +96,11 @@ final class Color implements Extension\ColorExtension
         ];
     }
 
-    /**
-     * @example 'rgb(0,255,122)'
-     */
     public function rgbCssColor(): string
     {
         return 'rgb(' . $this->rgbColor() . ')';
     }
 
-    /**
-     * @example '#ff0044'
-     */
     public function safeHexColor(): string
     {
         $color = str_pad(dechex(mt_rand(0, 255)), 3, '0', STR_PAD_LEFT);
@@ -135,9 +108,6 @@ final class Color implements Extension\ColorExtension
         return '#' . $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
     }
 
-    /**
-     * @example 'blue'
-     */
     public function safeColorName(): string
     {
         return Extension\Helper::randomElement($this->safeColorNames);

--- a/src/Faker/Core/Color.php
+++ b/src/Faker/Core/Color.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Core;
+
+use Faker\Extension;
+
+/**
+ * @experimental This class is experimental and does not fall under our BC promise
+ */
+final class Color implements Extension\ColorExtension
+{
+    protected $allColorNames = [
+        'AliceBlue', 'AntiqueWhite', 'Aqua', 'Aquamarine',
+        'Azure', 'Beige', 'Bisque', 'Black', 'BlanchedAlmond',
+        'Blue', 'BlueViolet', 'Brown', 'BurlyWood', 'CadetBlue',
+        'Chartreuse', 'Chocolate', 'Coral', 'CornflowerBlue',
+        'Cornsilk', 'Crimson', 'Cyan', 'DarkBlue', 'DarkCyan',
+        'DarkGoldenRod', 'DarkGray', 'DarkGreen', 'DarkKhaki',
+        'DarkMagenta', 'DarkOliveGreen', 'Darkorange', 'DarkOrchid',
+        'DarkRed', 'DarkSalmon', 'DarkSeaGreen', 'DarkSlateBlue',
+        'DarkSlateGray', 'DarkTurquoise', 'DarkViolet', 'DeepPink',
+        'DeepSkyBlue', 'DimGray', 'DimGrey', 'DodgerBlue', 'FireBrick',
+        'FloralWhite', 'ForestGreen', 'Fuchsia', 'Gainsboro', 'GhostWhite',
+        'Gold', 'GoldenRod', 'Gray', 'Green', 'GreenYellow', 'HoneyDew',
+        'HotPink', 'IndianRed', 'Indigo', 'Ivory', 'Khaki', 'Lavender',
+        'LavenderBlush', 'LawnGreen', 'LemonChiffon', 'LightBlue', 'LightCoral',
+        'LightCyan', 'LightGoldenRodYellow', 'LightGray', 'LightGreen', 'LightPink',
+        'LightSalmon', 'LightSeaGreen', 'LightSkyBlue', 'LightSlateGray', 'LightSteelBlue',
+        'LightYellow', 'Lime', 'LimeGreen', 'Linen', 'Magenta', 'Maroon', 'MediumAquaMarine',
+        'MediumBlue', 'MediumOrchid', 'MediumPurple', 'MediumSeaGreen', 'MediumSlateBlue',
+        'MediumSpringGreen', 'MediumTurquoise', 'MediumVioletRed', 'MidnightBlue',
+        'MintCream', 'MistyRose', 'Moccasin', 'NavajoWhite', 'Navy', 'OldLace', 'Olive',
+        'OliveDrab', 'Orange', 'OrangeRed', 'Orchid', 'PaleGoldenRod', 'PaleGreen',
+        'PaleTurquoise', 'PaleVioletRed', 'PapayaWhip', 'PeachPuff', 'Peru', 'Pink', 'Plum',
+        'PowderBlue', 'Purple', 'Red', 'RosyBrown', 'RoyalBlue', 'SaddleBrown', 'Salmon',
+        'SandyBrown', 'SeaGreen', 'SeaShell', 'Sienna', 'Silver', 'SkyBlue', 'SlateBlue',
+        'SlateGray', 'Snow', 'SpringGreen', 'SteelBlue', 'Tan', 'Teal', 'Thistle', 'Tomato',
+        'Turquoise', 'Violet', 'Wheat', 'White', 'WhiteSmoke', 'Yellow', 'YellowGreen',
+    ];
+
+    protected $safeColorNames = [
+        'black', 'maroon', 'green', 'navy', 'olive',
+        'purple', 'teal', 'lime', 'blue', 'silver',
+        'gray', 'yellow', 'fuchsia', 'aqua', 'white',
+    ];
+
+    /**
+     * @example 'NavajoWhite'
+     */
+    public function colorName(): string
+    {
+        return Extension\Helper::randomElement($this->allColorNames);
+    }
+
+    /**
+     * @example '#fa3cc2'
+     */
+    public function hexColor(): string
+    {
+        return '#' . str_pad(dechex(mt_rand(1, 16777215)), 6, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * @example '340,50,20'
+     */
+    public function hslColor(): string
+    {
+        return sprintf(
+            '%s,%s,%s',
+            mt_rand(0, 360),
+            mt_rand(0, 100),
+            mt_rand(0, 100)
+        );
+    }
+
+    /**
+     * @example array(340, 50, 20)
+     */
+    public function hslColorAsArray(): array
+    {
+        return [
+            mt_rand(0, 360),
+            mt_rand(0, 100),
+            mt_rand(0, 100),
+        ];
+    }
+
+    /**
+     * @example 'rgba(0,255,122,0.8)'
+     */
+    public function rgbaCssColor(): string
+    {
+        return 'rgba(' . $this->rgbColor() . ',' . (mt_rand(0, 10) / 10) . ')';
+    }
+
+    /**
+     * @example '0,255,122'
+     */
+    public function rgbColor(): string
+    {
+        return implode(',', $this->rgbColorAsArray());
+    }
+
+    /**
+     * @example '[0,255,122]'
+     */
+    public function rgbColorAsArray(): array
+    {
+        $color = $this->hexColor();
+
+        return [
+            hexdec(substr($color, 1, 2)),
+            hexdec(substr($color, 3, 2)),
+            hexdec(substr($color, 5, 2)),
+        ];
+    }
+
+    /**
+     * @example 'rgb(0,255,122)'
+     */
+    public function rgbCssColor(): string
+    {
+        return 'rgb(' . $this->rgbColor() . ')';
+    }
+
+    /**
+     * @example '#ff0044'
+     */
+    public function safeHexColor(): string
+    {
+        $color = str_pad(dechex(mt_rand(0, 255)), 3, '0', STR_PAD_LEFT);
+
+        return '#' . $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
+    }
+
+    /**
+     * @example 'blue'
+     */
+    public function safeColorName(): string
+    {
+        return Extension\Helper::randomElement($this->safeColorNames);
+    }
+}

--- a/src/Faker/Core/Color.php
+++ b/src/Faker/Core/Color.php
@@ -11,7 +11,7 @@ use Faker\Extension;
  */
 final class Color implements Extension\ColorExtension
 {
-    protected $allColorNames = [
+    private $colorNames = [
         'AliceBlue', 'AntiqueWhite', 'Aqua', 'Aquamarine',
         'Azure', 'Beige', 'Bisque', 'Black', 'BlanchedAlmond',
         'Blue', 'BlueViolet', 'Brown', 'BurlyWood', 'CadetBlue',
@@ -40,7 +40,7 @@ final class Color implements Extension\ColorExtension
         'Turquoise', 'Violet', 'Wheat', 'White', 'WhiteSmoke', 'Yellow', 'YellowGreen',
     ];
 
-    protected $safeColorNames = [
+    private $safeColorNames = [
         'black', 'maroon', 'green', 'navy', 'olive',
         'purple', 'teal', 'lime', 'blue', 'silver',
         'gray', 'yellow', 'fuchsia', 'aqua', 'white',
@@ -51,7 +51,7 @@ final class Color implements Extension\ColorExtension
      */
     public function colorName(): string
     {
-        return Extension\Helper::randomElement($this->allColorNames);
+        return Extension\Helper::randomElement($this->colorNames);
     }
 
     /**

--- a/src/Faker/Core/File.php
+++ b/src/Faker/Core/File.php
@@ -545,21 +545,11 @@ final class File implements Extension\FileExtension
         'video/x-sgi-movie' => 'movie',
     ];
 
-    /**
-     * Get a random MIME type
-     *
-     * @example 'video/avi'
-     */
     public function mimeType(): string
     {
         return array_rand($this->mimeTypes, 1);
     }
 
-    /**
-     * Get a random file extension (without a dot)
-     *
-     * @example avi
-     */
     public function extension(): string
     {
         $extension = $this->mimeTypes[array_rand($this->mimeTypes, 1)];
@@ -567,9 +557,6 @@ final class File implements Extension\FileExtension
         return is_array($extension) ? $extension[array_rand($extension, 1)] : $extension;
     }
 
-    /**
-     * Get a full path to a new real file on the system.
-     */
     public function filePath(): string
     {
         return tempnam(sys_get_temp_dir(), 'faker');

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Core;
+
+use Faker\Extension;
+
+/**
+ * @experimental This class is experimental and does not fall under our BC promise
+ */
+final class Number implements Extension\NumberExtension
+{
+    public function numberBetween(int $min = 0, int $max = 2147483647): int
+    {
+        $int1 = $min < $max ? $min : $max;
+        $int2 = $min < $max ? $max : $min;
+
+        return mt_rand($int1, $int2);
+    }
+
+    public function randomDigit(): int
+    {
+        return mt_rand(0, 9);
+    }
+
+    public function randomDigitNot(int $except): int
+    {
+        $result = self::numberBetween(0, 8);
+
+        if ($result >= $except) {
+            ++$result;
+        }
+
+        return $result;
+    }
+
+    public function randomDigitNotZero(): int
+    {
+        return mt_rand(1, 9);
+    }
+
+    public function randomFloat(int $nbMaxDecimals = null, float $min = 0, float $max = null): float
+    {
+        if (null === $nbMaxDecimals) {
+            $nbMaxDecimals = $this->randomDigit();
+        }
+
+        if (null === $max) {
+            $max = $this->randomNumber();
+
+            if ($min > $max) {
+                $max = $min;
+            }
+        }
+
+        if ($min > $max) {
+            $tmp = $min;
+            $min = $max;
+            $max = $tmp;
+        }
+
+        return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
+    }
+
+    public function randomNumber(int $nbDigits = null, bool $strict = false): int
+    {
+        if (null === $nbDigits) {
+            $nbDigits = $this->randomDigitNotZero();
+        }
+        $max = 10 ** $nbDigits - 1;
+
+        if ($max > mt_getrandmax()) {
+            throw new \InvalidArgumentException('randomNumber() can only generate numbers up to mt_getrandmax()');
+        }
+
+        if ($strict) {
+            return mt_rand(10 ** ($nbDigits - 1), $max);
+        }
+
+        return mt_rand(0, $max);
+    }
+}

--- a/src/Faker/Extension/ColorExtension.php
+++ b/src/Faker/Extension/ColorExtension.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Faker\Extension;
+
+/**
+ * @experimental This interface is experimental and does not fall under our BC promise
+ */
+interface ColorExtension extends Extension
+{
+    /**
+     * @example 'NavajoWhite'
+     */
+    public function colorName(): string;
+
+    /**
+     * @example '#fa3cc2'
+     */
+    public function hexColor(): string;
+
+    /**
+     * @example '340,50,20'
+     */
+    public function hslColor(): string;
+
+    /**
+     * @example array(340, 50, 20)
+     */
+    public function hslColorAsArray(): array;
+
+    /**
+     * @example 'rgba(0,255,122,0.8)'
+     */
+    public function rgbaCssColor(): string;
+
+    /**
+     * @example '0,255,122'
+     */
+    public function rgbColor(): string;
+
+    /**
+     * @example '[0,255,122]'
+     */
+    public function rgbColorAsArray(): array;
+
+    /**
+     * @example 'rgb(0,255,122)'
+     */
+    public function rgbCssColor(): string;
+
+    /**
+     * @example '#ff0044'
+     */
+    public function safeHexColor(): string;
+
+    /**
+     * @example 'blue'
+     */
+    public function safeColorName(): string;
+}

--- a/src/Faker/Extension/ContainerBuilder.php
+++ b/src/Faker/Extension/ContainerBuilder.php
@@ -64,6 +64,7 @@ final class ContainerBuilder
             BarcodeExtension::class => Core\Barcode::class,
             BloodExtension::class => Core\Blood::class,
             FileExtension::class => Core\File::class,
+            NumberExtension::class => Core\Number::class,
         ];
     }
 

--- a/src/Faker/Extension/ContainerBuilder.php
+++ b/src/Faker/Extension/ContainerBuilder.php
@@ -63,6 +63,7 @@ final class ContainerBuilder
         return [
             BarcodeExtension::class => Core\Barcode::class,
             BloodExtension::class => Core\Blood::class,
+            ColorExtension::class => Core\Color::class,
             FileExtension::class => Core\File::class,
             NumberExtension::class => Core\Number::class,
         ];

--- a/src/Faker/Extension/NumberExtension.php
+++ b/src/Faker/Extension/NumberExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Faker\Extension;
+
+/**
+ * @experimental This interface is experimental and does not fall under our BC promise
+ */
+interface NumberExtension extends Extension
+{
+    /**
+     * Returns a random number between $int1 and $int2 (any order)
+     *
+     * @param int $min default to 0
+     * @param int $max defaults to 32 bit max integer, ie 2147483647
+     *
+     * @example 79907610
+     */
+    public function numberBetween(int $min, int $max): int;
+
+    /**
+     * Returns a random number between 0 and 9
+     */
+    public function randomDigit(): int;
+
+    /**
+     * Generates a random digit, which cannot be $except
+     */
+    public function randomDigitNot(int $except): int;
+
+    /**
+     * Returns a random number between 1 and 9
+     */
+    public function randomDigitNotZero(): int;
+
+    /**
+     * Return a random float number
+     *
+     * @example 48.8932
+     */
+    public function randomFloat(?int $nbMaxDecimals, float $min, float $max): float;
+
+    /**
+     * Returns a random integer with 0 to $nbDigits digits.
+     *
+     * The maximum value returned is mt_getrandmax()
+     *
+     * @param int|null $nbDigits Defaults to a random number between 1 and 9
+     * @param bool     $strict   Whether the returned number should have exactly $nbDigits
+     *
+     * @example 79907610
+     */
+    public function randomNumber(?int $nbDigits, bool $strict): int;
+}

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -473,51 +473,81 @@ class Generator
         return $this->ext(Extension\NumberExtension::class)->randomNumber((int) $nbDigits, (bool) $strict);
     }
 
+    /**
+     * @example 'NavajoWhite'
+     */
     public function colorName(): string
     {
         return $this->ext(Extension\ColorExtension::class)->colorName();
     }
 
+    /**
+     * @example '#fa3cc2'
+     */
     public function hexColor(): string
     {
         return $this->ext(Extension\ColorExtension::class)->hexColor();
     }
 
+    /**
+     * @example '340,50,20'
+     */
     public function hslColor(): string
     {
         return $this->ext(Extension\ColorExtension::class)->hslColor();
     }
 
+    /**
+     * @example array(340, 50, 20)
+     */
     public function hslColorAsArray(): array
     {
         return $this->ext(Extension\ColorExtension::class)->hslColorAsArray();
     }
 
+    /**
+     * @example 'rgba(0,255,122,0.8)'
+     */
     public function rgbaCssColor(): string
     {
         return $this->ext(Extension\ColorExtension::class)->rgbaCssColor();
     }
 
+    /**
+     * @example '0,255,122'
+     */
     public function rgbColor(): string
     {
         return $this->ext(Extension\ColorExtension::class)->rgbColor();
     }
 
+    /**
+     * @example '[0,255,122]'
+     */
     public function rgbColorAsArray(): array
     {
         return $this->ext(Extension\ColorExtension::class)->rgbColorAsArray();
     }
 
+    /**
+     * @example 'rgb(0,255,122)'
+     */
     public function rgbCssColor(): string
     {
         return $this->ext(Extension\ColorExtension::class)->rgbCssColor();
     }
 
+    /**
+     * @example '#ff0044'
+     */
     public function safeHexColor(): string
     {
         return $this->ext(Extension\ColorExtension::class)->safeHexColor();
     }
 
+    /**
+     * @example 'blue'
+     */
     public function safeColorName(): string
     {
         return $this->ext(Extension\ColorExtension::class)->safeColorName();

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -473,6 +473,56 @@ class Generator
         return $this->ext(Extension\NumberExtension::class)->randomNumber((int) $nbDigits, (bool) $strict);
     }
 
+    public function colorName(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->colorName();
+    }
+
+    public function hexColor(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->hexColor();
+    }
+
+    public function hslColor(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->hslColor();
+    }
+
+    public function hslColorAsArray(): array
+    {
+        return $this->ext(Extension\ColorExtension::class)->hslColorAsArray();
+    }
+
+    public function rgbaCssColor(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->rgbaCssColor();
+    }
+
+    public function rgbColor(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->rgbColor();
+    }
+
+    public function rgbColorAsArray(): array
+    {
+        return $this->ext(Extension\ColorExtension::class)->rgbColorAsArray();
+    }
+
+    public function rgbCssColor(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->rgbCssColor();
+    }
+
+    public function safeHexColor(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->safeHexColor();
+    }
+
+    public function safeColorName(): string
+    {
+        return $this->ext(Extension\ColorExtension::class)->safeColorName();
+    }
+
     protected function callFormatWithMatches($matches)
     {
         return $this->format($matches[1]);

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -312,51 +312,103 @@ class Generator
         return preg_replace_callback('/\{\{\s?(\w+)\s?\}\}/u', [$this, 'callFormatWithMatches'], $string);
     }
 
+    /**
+     * Get a random MIME type
+     *
+     * @example 'video/avi'
+     */
     public function mimeType()
     {
         return $this->ext(Extension\FileExtension::class)->mimeType();
     }
 
+    /**
+     * Get a random file extension (without a dot)
+     *
+     * @example avi
+     */
     public function fileExtension()
     {
         return $this->ext(Extension\FileExtension::class)->extension();
     }
 
+    /**
+     * Get a full path to a new real file on the system.
+     */
     public function filePath()
     {
         return $this->ext(Extension\FileExtension::class)->filePath();
     }
 
+    /**
+     * Get an actual blood type
+     *
+     * @example 'AB'
+     */
     public function bloodType(): string
     {
         return $this->ext(Extension\BloodExtension::class)->bloodType();
     }
 
+    /**
+     * Get a random resis value
+     *
+     * @example '+'
+     */
     public function bloodRh(): string
     {
         return $this->ext(Extension\BloodExtension::class)->bloodRh();
     }
 
+    /**
+     * Get a full blood group
+     *
+     * @example 'AB+'
+     */
     public function bloodGroup(): string
     {
         return $this->ext(Extension\BloodExtension::class)->bloodGroup();
     }
 
+    /**
+     * Get a random EAN13 barcode.
+     *
+     * @example '4006381333931'
+     */
     public function ean13(): string
     {
         return $this->ext(Extension\BarcodeExtension::class)->ean13();
     }
 
+    /**
+     * Get a random EAN8 barcode.
+     *
+     * @example '73513537'
+     */
     public function ean8(): string
     {
         return $this->ext(Extension\BarcodeExtension::class)->ean8();
     }
 
+    /**
+     * Get a random ISBN-10 code
+     *
+     * @see http://en.wikipedia.org/wiki/International_Standard_Book_Number
+     *
+     * @example '4881416324'
+     */
     public function isbn10(): string
     {
         return $this->ext(Extension\BarcodeExtension::class)->isbn10();
     }
 
+    /**
+     * Get a random ISBN-13 code
+     *
+     * @see http://en.wikipedia.org/wiki/International_Standard_Book_Number
+     *
+     * @example '9790404436093'
+     */
     public function isbn13(): string
     {
         return $this->ext(Extension\BarcodeExtension::class)->isbn13();

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -166,10 +166,7 @@ use Psr\Container\ContainerInterface;
  * @property string $randomLetter
  * @property string $randomAscii
  *
- * @method int randomNumber($nbDigits = null, $strict = false)
  * @method int|string|null randomKey(array $array = array())
- * @method int numberBetween($min = 0, $max = 2147483647)
- * @method float randomFloat($nbMaxDecimals = null, $min = 0, $max = null)
  * @method mixed randomElement(array $array = array('a', 'b', 'c'))
  * @method array randomElements(array $array = array('a', 'b', 'c'), $count = 1, $allowDuplicates = false)
  * @method array|string shuffle($arg = '')
@@ -363,6 +360,65 @@ class Generator
     public function isbn13(): string
     {
         return $this->ext(Extension\BarcodeExtension::class)->isbn13();
+    }
+
+    /**
+     * Returns a random number between $int1 and $int2 (any order)
+     *
+     * @example 79907610
+     */
+    public function numberBetween($int1 = 0, $int2 = 2147483647): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->numberBetween((int) $int1, (int) $int2);
+    }
+
+    /**
+     * Returns a random number between 0 and 9
+     */
+    public function randomDigit(): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomDigit();
+    }
+
+    /**
+     * Generates a random digit, which cannot be $except
+     */
+    public function randomDigitNot($except): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomDigitNot((int) $except);
+    }
+
+    /**
+     * Returns a random number between 1 and 9
+     */
+    public function randomDigitNotZero(): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomDigitNotZero();
+    }
+
+    /**
+     * Return a random float number
+     *
+     * @example 48.8932
+     */
+    public function randomFloat($nbMaxDecimals = null, $min = 0, $max = null): float
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomFloat((int) $nbMaxDecimals, (float) $min, (float) $max);
+    }
+
+    /**
+     * Returns a random integer with 0 to $nbDigits digits.
+     *
+     * The maximum value returned is mt_getrandmax()
+     *
+     * @param int|null $nbDigits Defaults to a random number between 1 and 9
+     * @param bool     $strict   Whether the returned number should have exactly $nbDigits
+     *
+     * @example 79907610
+     */
+    public function randomNumber($nbDigits = null, $strict = false): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomNumber((int) $nbDigits, (bool) $strict);
     }
 
     protected function callFormatWithMatches($matches)

--- a/src/Faker/Provider/en_GB/Company.php
+++ b/src/Faker/Provider/en_GB/Company.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Faker\Provider\en_GB;
+
+class Company extends \Faker\Provider\Company
+{
+    public const VAT_PREFIX = 'GB';
+    public const VAT_TYPE_DEFAULT = 'vat';
+    public const VAT_TYPE_BRANCH = 'branch';
+    public const VAT_TYPE_GOVERNMENT = 'gov';
+    public const VAT_TYPE_HEALTH_AUTHORITY = 'health';
+
+    /**
+     * UK VAT number
+     *
+     * This method produces numbers that are _reasonably_ representative
+     * of those issued by government
+     *
+     * @see https://en.wikipedia.org/wiki/VAT_identification_number#VAT_numbers_by_country
+     */
+    public static function vat(string $type = null): string
+    {
+        switch ($type) {
+
+            case static::VAT_TYPE_BRANCH:
+                return static::generateBranchTraderVatNumber();
+
+            case static::VAT_TYPE_GOVERNMENT:
+                return static::generateGovernmentVatNumber();
+
+            case static::VAT_TYPE_HEALTH_AUTHORITY:
+                return static::generateHealthAuthorityVatNumber();
+
+            default:
+                return static::generateStandardVatNumber();
+
+        }
+    }
+
+    /**
+     * Standard
+     * 9 digits (block of 3, block of 4, block of 2)
+     *
+     * This uses the format introduced November 2009 onward where the first
+     * block starts from 100 and the final two digits are generated via a the
+     * modulus 9755 algorithm
+     */
+    private static function generateStandardVatNumber(): string
+    {
+        $firstBlock = static::numberBetween(100, 999);
+        $secondBlock = static::randomNumber(4, true);
+
+        return sprintf(
+            '%s%d %d %d',
+            static::VAT_PREFIX,
+            $firstBlock,
+            $secondBlock,
+            static::calculateModulus97($firstBlock . $secondBlock)
+        );
+    }
+
+    /**
+     * Health authorities
+     * the letters HA then 3 digits from 500 to 999 (e.g. GBHA599)
+     */
+    private static function generateHealthAuthorityVatNumber(): string
+    {
+        return sprintf(
+            '%sHA%d',
+            static::VAT_PREFIX,
+            static::numberBetween(500, 999)
+        );
+    }
+
+    /**
+     * Branch traders
+     * 12 digits (as for 9 digits, followed by a block of 3 digits)
+     */
+    private static function generateBranchTraderVatNumber(): string
+    {
+        return sprintf(
+            '%s %d',
+            static::generateStandardVatNumber(),
+            static::randomNumber(3, true)
+        );
+    }
+
+    /**
+     * Government departments
+     * the letters GD then 3 digits from 000 to 499 (e.g. GBGD001)
+     */
+    private static function generateGovernmentVatNumber(): string
+    {
+        return sprintf(
+            '%sGD%s',
+            static::VAT_PREFIX,
+            str_pad((string) static::numberBetween(0, 499), 3, '0', STR_PAD_LEFT)
+        );
+    }
+
+    /**
+     * Apply a Modulus97 algorithm to an input
+     *
+     * @see https://library.croneri.co.uk/cch_uk/bvr/43-600
+     */
+    public static function calculateModulus97(string $input, bool $use9755 = true): string
+    {
+        $digits = str_split($input);
+
+        if (count($digits) !== 7) {
+            throw new \InvalidArgumentException();
+        }
+        $multiplier = 8;
+        $sum = 0;
+
+        foreach ($digits as $digit) {
+            $sum += (int) $digit * $multiplier;
+            --$multiplier ;
+        }
+
+        if ($use9755) {
+            $sum = $sum + 55;
+        }
+
+        while ($sum > 0) {
+            $sum -= 97;
+        }
+        $sum = $sum * -1;
+
+        return str_pad((string) $sum, 2, '0', STR_PAD_LEFT);
+    }
+}

--- a/src/Faker/Provider/en_US/PhoneNumber.php
+++ b/src/Faker/Provider/en_US/PhoneNumber.php
@@ -5,6 +5,20 @@ namespace Faker\Provider\en_US;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     /**
+     * @var array<int, string>
+     */
+    protected static $areaCodeRegexes = [
+        2 => '(0[1-35-9]|1[02-9]|2[03-589]|3[149]|4[08]|5[1-46]|6[0279]|7[0269]|8[13])',
+        3 => '(0[1-57-9]|1[02-9]|2[0135]|3[0-24679]|4[167]|5[12]|6[014]|8[056])',
+        4 => '(0[124-9]|1[02-579]|2[3-5]|3[0245]|4[0235]|58|6[39]|7[0589]|8[04])',
+        5 => '(0[1-57-9]|1[0235-8]|20|3[0149]|4[01]|5[19]|6[1-47]|7[013-5]|8[056])',
+        6 => '(0[1-35-9]|1[024-9]|2[03689]|[34][016]|5[017]|6[0-279]|78|8[0-29])',
+        7 => '(0[1-46-8]|1[2-9]|2[04-7]|3[1247]|4[037]|5[47]|6[02359]|7[02-59]|8[156])',
+        8 => '(0[1-68]|1[02-8]|2[08]|3[0-28]|4[3578]|5[046-9]|6[02-5]|7[028])',
+        9 => '(0[1346-9]|1[02-9]|2[0589]|3[0146-8]|4[0179]|5[12469]|7[0-389]|8[04-69])',
+    ];
+
+    /**
      * @see https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#United_States.2C_Canada.2C_and_other_NANP_countries
      */
     protected static $formats = [
@@ -89,11 +103,9 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      */
     public static function areaCode()
     {
-        $digits[] = self::numberBetween(2, 9);
-        $digits[] = self::randomDigit();
-        $digits[] = self::randomDigitNot($digits[1]);
+        $firstDigit = self::numberBetween(2, 9);
 
-        return implode('', $digits);
+        return $firstDigit . self::regexify(self::$areaCodeRegexes[$firstDigit]);
     }
 
     /**

--- a/src/Faker/Provider/ne_NP/Address.php
+++ b/src/Faker/Provider/ne_NP/Address.php
@@ -19,6 +19,7 @@ class Address extends \Faker\Provider\Address
         'Baglung', 'Baitadi', 'Bajhang', 'Bajura', 'Banke', 'Bara', 'Bardiya', 'Bhaktapur', 'Bhojpur',
         'Chitwan',
         'Dadeldhura', 'Dailekh', 'Dang Deukhuri', 'Darchula', 'Dhading', 'Dhankuta', 'Dhanusa', 'Dolakha', 'Dolpa', 'Doti',
+        'Eastern Rukum',
         'Gorkha', 'Gulmi',
         'Humla',
         'Ilam',
@@ -26,13 +27,14 @@ class Address extends \Faker\Provider\Address
         'Kailali', 'Kalikot', 'Kanchanpur', 'Kapilvastu', 'Kaski', 'Kathmandu', 'Kavrepalanchok', 'Khotang',
         'Lalitpur', 'Lamjung',
         'Mahottari', 'Makwanpur', 'Manang', 'Morang', 'Mugu', 'Mustang', 'Myagdi',
-        'Nawalparasi', 'Nuwakot',
+        'Nawalpur', 'Nuwakot',
         'Okhaldhunga',
-        'Palpa', 'Panchthar', 'Parbat', 'Parsa', 'Pyuthan',
-        'Ramechhap', 'Rasuwa', 'Rautahat', 'Rolpa', 'Rukum', 'Rupandehi',
+        'Palpa', 'Panchthar', 'Parasi', 'Parbat', 'Parsa', 'Pyuthan',
+        'Ramechhap', 'Rasuwa', 'Rautahat', 'Rolpa', 'Rupandehi',
         'Salyan', 'Sankhuwasabha', 'Saptari', 'Sarlahi', 'Sindhuli', 'Sindhupalchok', 'Siraha', 'Solukhumbu', 'Sunsari', 'Surkhet', 'Syangja',
         'Tanahu', 'Taplejung', 'Terhathum',
         'Udayapur',
+        'Western Rukum',
     ];
 
     /**

--- a/test/Faker/Core/ColorTest.php
+++ b/test/Faker/Core/ColorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\Core;
+
+use Faker\Test\TestCase;
+
+final class ColorTest extends TestCase
+{
+    public function testHexColor()
+    {
+        self::assertMatchesRegularExpression('/^#[a-f0-9]{6}$/i', $this->faker->hexColor());
+    }
+
+    public function testSafeHexColor()
+    {
+        self::assertMatchesRegularExpression('/^#[a-f0-9]{6}$/i', $this->faker->safeHexColor());
+    }
+
+    public function testRgbColorAsArray()
+    {
+        self::assertCount(3, $this->faker->rgbColorAsArray());
+    }
+
+    public function testRgbColor()
+    {
+        $regexp = '([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])';
+        self::assertMatchesRegularExpression('/^' . $regexp . ',' . $regexp . ',' . $regexp . '$/i', $this->faker->rgbColor());
+    }
+
+    public function testRgbCssColor()
+    {
+        $regexp = '([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])';
+        self::assertMatchesRegularExpression('/^rgb\(' . $regexp . ',' . $regexp . ',' . $regexp . '\)$/i', $this->faker->rgbCssColor());
+    }
+
+    public function testRgbaCssColor()
+    {
+        $regexp = '([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])';
+        $regexpAlpha = '([01]?(\.\d+)?)';
+        self::assertMatchesRegularExpression('/^rgba\(' . $regexp . ',' . $regexp . ',' . $regexp . ',' . $regexpAlpha . '\)$/i', $this->faker->rgbaCssColor());
+    }
+
+    public function testSafeColorName()
+    {
+        self::assertMatchesRegularExpression('/^[\w]+$/', $this->faker->safeColorName());
+    }
+
+    public function testColorName()
+    {
+        self::assertMatchesRegularExpression('/^[\w]+$/', $this->faker->colorName());
+    }
+
+    public function testHslColor()
+    {
+        $regexp360 = '(?:36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])';
+        $regexp100 = '(?:100|[1-9]?[0-9])';
+        self::assertMatchesRegularExpression('/^' . $regexp360 . ',' . $regexp100 . ',' . $regexp100 . '$/', $this->faker->hslColor());
+    }
+
+    public function testHslColorArray()
+    {
+        self::assertCount(3, $this->faker->hslColorAsArray());
+    }
+}

--- a/test/Faker/Core/NumberTest.php
+++ b/test/Faker/Core/NumberTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\Core;
+
+use Faker\Test\TestCase;
+
+final class NumberTest extends TestCase
+{
+    public function testRandomDigitReturnsInteger()
+    {
+        self::assertIsInt($this->faker->randomDigit());
+    }
+
+    public function testRandomDigitReturnsDigit()
+    {
+        self::assertGreaterThanOrEqual(0, $this->faker->randomDigit());
+        self::assertLessThan(10, $this->faker->randomDigit());
+    }
+
+    public function testRandomDigitNotNullReturnsNotNullDigit()
+    {
+        self::assertGreaterThan(0, $this->faker->randomDigitNotZero());
+        self::assertLessThan(10, $this->faker->randomDigitNotZero());
+    }
+
+    public function testRandomDigitNotReturnsValidDigit()
+    {
+        for ($i = 0; $i <= 9; ++$i) {
+            self::assertGreaterThanOrEqual(0, $this->faker->randomDigitNot($i));
+            self::assertLessThan(10, $this->faker->randomDigitNot($i));
+            self::assertNotSame($this->faker->randomDigitNot($i), $i);
+        }
+    }
+
+    public function testRandomNumberThrowsExceptionWhenCalledWithATooHighNumberOfDigits()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->faker->randomNumber(10);
+    }
+
+    public function testRandomNumberReturnsInteger()
+    {
+        self::assertIsInt($this->faker->randomNumber());
+        self::assertIsInt($this->faker->randomNumber(5, false));
+    }
+
+    public function testRandomNumberReturnsDigit()
+    {
+        self::assertGreaterThanOrEqual(0, $this->faker->randomNumber(3));
+        self::assertLessThan(1000, $this->faker->randomNumber(3));
+    }
+
+    public function testRandomNumberAcceptsStrictParamToEnforceNumberSize()
+    {
+        self::assertEquals(5, strlen((string) $this->faker->randomNumber(5, true)));
+    }
+
+    public function testNumberBetween()
+    {
+        $min = 5;
+        $max = 6;
+
+        self::assertGreaterThanOrEqual($min, $this->faker->numberBetween($min, $max));
+        self::assertGreaterThanOrEqual($this->faker->numberBetween($min, $max), $max);
+    }
+
+    public function testNumberBetweenAcceptsZeroAsMax()
+    {
+        self::assertEquals(0, $this->faker->numberBetween(0, 0));
+    }
+
+    public function testRandomFloat()
+    {
+        $min = 4;
+        $max = 10;
+        $nbMaxDecimals = 8;
+
+        $result = $this->faker->randomFloat($nbMaxDecimals, $min, $max);
+
+        $parts = explode('.', (string) $result);
+
+        self::assertIsFloat($result);
+        self::assertGreaterThanOrEqual($min, $result);
+        self::assertLessThanOrEqual($max, $result);
+        self::assertLessThanOrEqual($nbMaxDecimals, strlen($parts[1]));
+    }
+}

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -64,6 +64,7 @@ final class PaymentTest extends TestCase
         'AD' => '/^AD\d{2}\d{4}\d{4}[A-Z0-9]{12}$/',
         'AE' => '/^AE\d{2}\d{3}\d{16}$/',
         'AL' => '/^AL\d{2}\d{8}[A-Z0-9]{16}$/',
+        'AR' => '/^AR\d{2}\d{4}\d{4}\d{1}\d{1}\d{14}$/',
         'AT' => '/^AT\d{2}\d{5}\d{11}$/',
         'AZ' => '/^AZ\d{2}[A-Z]{4}[A-Z0-9]{20}$/',
         'BA' => '/^BA\d{2}\d{3}\d{3}\d{8}\d{2}$/',
@@ -109,6 +110,7 @@ final class PaymentTest extends TestCase
         'MU' => '/^MU\d{2}[A-Z]{4}\d{2}\d{2}\d{12}\d{3}[A-Z]{3}$/',
         'NL' => '/^NL\d{2}[A-Z]{4}\d{10}$/',
         'NO' => '/^NO\d{2}\d{4}\d{6}\d{1}$/',
+        'PE' => '/^PE\d{2}\d{4}\d{4}\d{1}\d{1}\d{14}$/',
         'PK' => '/^PK\d{2}[A-Z]{4}[A-Z0-9]{16}$/',
         'PL' => '/^PL\d{2}\d{8}\d{16}$/',
         'PS' => '/^PS\d{2}[A-Z]{4}[A-Z0-9]{21}$/',
@@ -122,6 +124,7 @@ final class PaymentTest extends TestCase
         'SM' => '/^SM\d{2}[A-Z]{1}\d{5}\d{5}[A-Z0-9]{12}$/',
         'TN' => '/^TN\d{2}\d{2}\d{3}\d{13}\d{2}$/',
         'TR' => '/^TR\d{2}\d{5}\d{1}[A-Z0-9]{16}$/',
+        'VE' => '/^VE\d{2}\d{4}\d{4}\d{1}\d{1}\d{14}$/',
         'VG' => '/^VG\d{2}[A-Z]{4}\d{16}$/',
     ];
 

--- a/test/Faker/Provider/en_GB/CompanyTest.php
+++ b/test/Faker/Provider/en_GB/CompanyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Faker\Test\Provider\en_GB;
+
+use Faker\Provider\en_GB\Company;
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class CompanyTest extends TestCase
+{
+    public function testModulus97Algorithm()
+    {
+        // 9755 format
+        self::assertSame('27', $this->faker->calculateModulus97(1234567));
+        // Pre November 2009 format
+        self::assertSame('82', $this->faker->calculateModulus97(1234567, false));
+        // The following value expects a leading zero
+        self::assertSame('06', $this->faker->calculateModulus97(1271786));
+    }
+
+    public function testModulus97AlgorithmWithInvalidArgument()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->faker->calculateModulus97(123);
+    }
+
+    public function testVat()
+    {
+        $this->assertDefaultVatFormat($this->faker->vat());
+        $this->assertDefaultVatFormat($this->faker->vat(Company::VAT_TYPE_DEFAULT));
+    }
+
+    private function assertDefaultVatFormat($number)
+    {
+        self::assertEquals(1, preg_match('/^GB[\d]{3} [\d]{4} [\d]{2}$/', $number));
+    }
+
+    public function testVatBranchType()
+    {
+        $number = $this->faker->vat(Company::VAT_TYPE_BRANCH);
+        self::assertEquals(1, preg_match('/^GB[\d]{3} [\d]{4} [\d]{2} [\d]{3}$/', $number));
+    }
+
+    public function testVatGovernmentType()
+    {
+        $number = $this->faker->vat(Company::VAT_TYPE_GOVERNMENT);
+        $match = preg_match('/^GBGD([\d]{3})$/', $number, $matches);
+        self::assertEquals(1, $match);
+        self::assertTrue($matches[1] < 499);
+    }
+
+    public function testVatHealthAuthorityType()
+    {
+        $number = $this->faker->vat(Company::VAT_TYPE_HEALTH_AUTHORITY);
+        $match = preg_match('/^GBHA([\d]{3})$/', $number, $matches);
+        self::assertEquals(1, $match);
+        self::assertTrue($matches[1] > 499);
+        self::assertTrue($matches[1] < 1000);
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Company($this->faker);
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

Color extension is not yet in core.

- [x] A new feature

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Added the color extension to the core.

A couple of things I am unsure of:
- I had to replace a `static::randomFloat()` from the Color provider with a core php function. Is this fine or should we use a (to-be-created) Number extension for that?
- Despite being localized in English (the color names), I've added `Color` now to `\Faker\Core`. Would it be better to place these classes in some other location (for example Faker/Extension/English/us/Color.php)?

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
