### PR TITLE
[Core] Fix Helper::numerify

### DIFF
--- a/src/Faker/Extension/Helper.php
+++ b/src/Faker/Extension/Helper.php
@@ -48,7 +48,7 @@ final class Helper
 
             while ($i < $nbReplacements) {
                 $size = min($nbReplacements - $i, $maxAtOnce);
-                $numbers .= str_pad((string) mt_rand(0, $size), $size, '0', STR_PAD_LEFT);
+                $numbers .= str_pad((string) mt_rand(0, 10 ** $size - 1), $size, '0', STR_PAD_LEFT);
                 $i += $size;
             }
 

--- a/test/Faker/Extension/HelperTest.php
+++ b/test/Faker/Extension/HelperTest.php
@@ -50,6 +50,12 @@ final class HelperTest extends TestCase
         self::assertEquals(20, strlen(Helper::numerify($largePattern)));
     }
 
+    public function testNumerifyReturnsLargeNumber()
+    {
+        $result = Helper::numerify(str_repeat('#', 10));
+        self::assertGreaterThan(100, (int) $result);
+    }
+
     public function testLexifyReturnsSameStringWhenItContainsNoQuestionMark()
     {
         self::assertEquals('fooBar#', Helper::lexify('fooBar#'));


### PR DESCRIPTION
### What is the reason for this PR?

There's a bug in `Helper::numerify` caused by a - compared to `Base::numerify` - changed use of mt_rand: 
`Base::numerify` uses `randomNumber($size)`, where the argument `$size` is the **number of digits** while `Helper::numerify` uses `mt_rand(0, $size)`, where `$size` is the **highest possible value** to be returned.

Thus executing `Helper::numerify(str_repeat('#', 10))` always returns strings like `0000000050`:
```php
Factory::create()->seed(1);
echo Helper::numerify(str_repeat('#', 10)); // "0000000050"
echo BaseProvider::numerify(str_repeat('#', 10)); // "7203244899"
```

- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR fixes the issue and adds a test to verify functionality. The test is based on a very high probability that `Helper::numerify(str_repeat('#', 10))` should return large numbers.

Since `mt_rand(0, 10 ** $size - 1)` is not as easy to read as `static::randomNumber($size)` (at least for me), I'd be in favor of replacing the change done with this PR once the number extension is implemented, but this is out of scope for this bugfix PR.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
