### PR TITLE
[Core] Added number extension

### DIFF
--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -11,12 +11,12 @@ use Faker\Extension;
  */
 final class Number implements Extension\NumberExtension
 {
-    public function numberBetween(int $int1 = 0, int $int2 = 2147483647): int
+    public function numberBetween(int $min = 0, int $max = 2147483647): int
     {
-        $min = $int1 < $int2 ? $int1 : $int2;
-        $max = $int1 < $int2 ? $int2 : $int1;
+        $int1 = $min < $max ? $min : $max;
+        $int2 = $min < $max ? $max : $min;
 
-        return mt_rand($min, $max);
+        return mt_rand($int1, $int2);
     }
 
     public function randomDigit(): int

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -11,14 +11,6 @@ use Faker\Extension;
  */
 final class Number implements Extension\NumberExtension
 {
-    /**
-     * Returns a random number between $int1 and $int2 (any order)
-     *
-     * @param int $int1 default to 0
-     * @param int $int2 defaults to 32 bit max integer, ie 2147483647
-     *
-     * @example 79907610
-     */
     public function numberBetween(int $int1 = 0, int $int2 = 2147483647): int
     {
         $min = $int1 < $int2 ? $int1 : $int2;
@@ -27,19 +19,11 @@ final class Number implements Extension\NumberExtension
         return mt_rand($min, $max);
     }
 
-    /**
-     * Returns a random number between 0 and 9
-     */
     public function randomDigit(): int
     {
         return mt_rand(0, 9);
     }
 
-    /**
-     * Generates a random digit, which cannot be $except
-     *
-     * @param int $except
-     */
     public function randomDigitNot(int $except): int
     {
         $result = self::numberBetween(0, 8);
@@ -51,23 +35,11 @@ final class Number implements Extension\NumberExtension
         return $result;
     }
 
-    /**
-     * Returns a random number between 1 and 9
-     */
     public function randomDigitNotNull(): int
     {
         return mt_rand(1, 9);
     }
 
-    /**
-     * Return a random float number
-     *
-     * @param int|null  $nbMaxDecimals
-     * @param float|int $min
-     * @param float|int $max
-     *
-     * @example 48.8932
-     */
     public function randomFloat(int $nbMaxDecimals = null, float $min = 0, float $max = null): float
     {
         if (null === $nbMaxDecimals) {
@@ -91,16 +63,6 @@ final class Number implements Extension\NumberExtension
         return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
     }
 
-    /**
-     * Returns a random integer with 0 to $nbDigits digits.
-     *
-     * The maximum value returned is mt_getrandmax()
-     *
-     * @param int|null $nbDigits Defaults to a random number between 1 and 9
-     * @param bool     $strict   Whether the returned number should have exactly $nbDigits
-     *
-     * @example 79907610
-     */
     public function randomNumber(int $nbDigits = null, bool $strict = false): int
     {
         if (!is_bool($strict)) {

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -19,7 +19,7 @@ final class Number implements Extension\NumberExtension
      *
      * @example 79907610
      */
-    public function numberBetween($int1 = 0, $int2 = 2147483647): int
+    public function numberBetween(int $int1 = 0, int $int2 = 2147483647): int
     {
         $min = $int1 < $int2 ? $int1 : $int2;
         $max = $int1 < $int2 ? $int2 : $int1;
@@ -40,7 +40,7 @@ final class Number implements Extension\NumberExtension
      *
      * @param int $except
      */
-    public function randomDigitNot($except): int
+    public function randomDigitNot(int $except): int
     {
         $result = self::numberBetween(0, 8);
 
@@ -68,7 +68,7 @@ final class Number implements Extension\NumberExtension
      *
      * @example 48.8932
      */
-    public function randomFloat($nbMaxDecimals = null, $min = 0, $max = null): float
+    public function randomFloat(int $nbMaxDecimals = null, float $min = 0, float $max = null): float
     {
         if (null === $nbMaxDecimals) {
             $nbMaxDecimals = $this->randomDigit();
@@ -101,7 +101,7 @@ final class Number implements Extension\NumberExtension
      *
      * @example 79907610
      */
-    public function randomNumber($nbDigits = null, $strict = false): int
+    public function randomNumber(int $nbDigits = null, bool $strict = false): int
     {
         if (!is_bool($strict)) {
             throw new \InvalidArgumentException('randomNumber() generates numbers of fixed width. To generate numbers between two boundaries, use numberBetween() instead.');

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Core;
+
+use Faker\Extension;
+
+/**
+ * @experimental This class is experimental and does not fall under our BC promise
+ */
+final class Number implements Extension\NumberExtension
+{
+    /**
+     * Returns a random number between $int1 and $int2 (any order)
+     *
+     * @param int $int1 default to 0
+     * @param int $int2 defaults to 32 bit max integer, ie 2147483647
+     *
+     * @example 79907610
+     */
+    public function numberBetween($int1 = 0, $int2 = 2147483647): int
+    {
+        $min = $int1 < $int2 ? $int1 : $int2;
+        $max = $int1 < $int2 ? $int2 : $int1;
+
+        return mt_rand($min, $max);
+    }
+
+    /**
+     * Returns a random number between 0 and 9
+     */
+    public function randomDigit(): int
+    {
+        return mt_rand(0, 9);
+    }
+
+    /**
+     * Generates a random digit, which cannot be $except
+     *
+     * @param int $except
+     */
+    public function randomDigitNot($except): int
+    {
+        $result = self::numberBetween(0, 8);
+
+        if ($result >= $except) {
+            ++$result;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns a random number between 1 and 9
+     */
+    public function randomDigitNotNull(): int
+    {
+        return mt_rand(1, 9);
+    }
+
+    /**
+     * Return a random float number
+     *
+     * @param int|null  $nbMaxDecimals
+     * @param float|int $min
+     * @param float|int $max
+     *
+     * @example 48.8932
+     */
+    public function randomFloat($nbMaxDecimals = null, $min = 0, $max = null): float
+    {
+        if (null === $nbMaxDecimals) {
+            $nbMaxDecimals = $this->randomDigit();
+        }
+
+        if (null === $max) {
+            $max = $this->randomNumber();
+
+            if ($min > $max) {
+                $max = $min;
+            }
+        }
+
+        if ($min > $max) {
+            $tmp = $min;
+            $min = $max;
+            $max = $tmp;
+        }
+
+        return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
+    }
+
+    /**
+     * Returns a random integer with 0 to $nbDigits digits.
+     *
+     * The maximum value returned is mt_getrandmax()
+     *
+     * @param int|null $nbDigits Defaults to a random number between 1 and 9
+     * @param bool     $strict   Whether the returned number should have exactly $nbDigits
+     *
+     * @example 79907610
+     */
+    public function randomNumber($nbDigits = null, $strict = false): int
+    {
+        if (!is_bool($strict)) {
+            throw new \InvalidArgumentException('randomNumber() generates numbers of fixed width. To generate numbers between two boundaries, use numberBetween() instead.');
+        }
+
+        if (null === $nbDigits) {
+            $nbDigits = $this->randomDigitNotNull();
+        }
+        $max = 10 ** $nbDigits - 1;
+
+        if ($max > mt_getrandmax()) {
+            throw new \InvalidArgumentException('randomNumber() can only generate numbers up to mt_getrandmax()');
+        }
+
+        if ($strict) {
+            return mt_rand(10 ** ($nbDigits - 1), $max);
+        }
+
+        return mt_rand(0, $max);
+    }
+}

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -35,7 +35,7 @@ final class Number implements Extension\NumberExtension
         return $result;
     }
 
-    public function randomDigitNotNull(): int
+    public function randomDigitNotZero(): int
     {
         return mt_rand(1, 9);
     }
@@ -66,7 +66,7 @@ final class Number implements Extension\NumberExtension
     public function randomNumber(int $nbDigits = null, bool $strict = false): int
     {
         if (null === $nbDigits) {
-            $nbDigits = $this->randomDigitNotNull();
+            $nbDigits = $this->randomDigitNotZero();
         }
         $max = 10 ** $nbDigits - 1;
 

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -65,10 +65,6 @@ final class Number implements Extension\NumberExtension
 
     public function randomNumber(int $nbDigits = null, bool $strict = false): int
     {
-        if (!is_bool($strict)) {
-            throw new \InvalidArgumentException('randomNumber() generates numbers of fixed width. To generate numbers between two boundaries, use numberBetween() instead.');
-        }
-
         if (null === $nbDigits) {
             $nbDigits = $this->randomDigitNotNull();
         }

--- a/src/Faker/Extension/ContainerBuilder.php
+++ b/src/Faker/Extension/ContainerBuilder.php
@@ -64,6 +64,7 @@ final class ContainerBuilder
             BarcodeExtension::class => Core\Barcode::class,
             BloodExtension::class => Core\Blood::class,
             FileExtension::class => Core\File::class,
+            NumberExtension::class => Core\Number::class,
         ];
     }
 

--- a/src/Faker/Extension/NumberExtension.php
+++ b/src/Faker/Extension/NumberExtension.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Faker\Extension;
+
+/**
+ * @experimental This interface is experimental and does not fall under our BC promise
+ */
+interface NumberExtension extends Extension
+{
+    /**
+     * Returns a random number between $int1 and $int2 (any order)
+     *
+     * @param int $int1 default to 0
+     * @param int $int2 defaults to 32 bit max integer, ie 2147483647
+     *
+     * @example 79907610
+     */
+    public function numberBetween($int1, $int2): int;
+
+    /**
+     * Returns a random number between 0 and 9
+     */
+    public function randomDigit(): int;
+
+    /**
+     * Generates a random digit, which cannot be $except
+     *
+     * @param int $except
+     */
+    public function randomDigitNot($except): int;
+
+    /**
+     * Returns a random number between 1 and 9
+     */
+    public function randomDigitNotNull(): int;
+
+    /**
+     * Return a random float number
+     *
+     * @param int|null  $nbMaxDecimals
+     * @param float|int $min
+     * @param float|int $max
+     *
+     * @example 48.8932
+     */
+    public function randomFloat($nbMaxDecimals, $min, $max): float;
+
+    /**
+     * Returns a random integer with 0 to $nbDigits digits.
+     *
+     * The maximum value returned is mt_getrandmax()
+     *
+     * @param int|null $nbDigits Defaults to a random number between 1 and 9
+     * @param bool     $strict   Whether the returned number should have exactly $nbDigits
+     *
+     * @example 79907610
+     */
+    public function randomNumber($nbDigits, $strict): int;
+}

--- a/src/Faker/Extension/NumberExtension.php
+++ b/src/Faker/Extension/NumberExtension.php
@@ -10,12 +10,12 @@ interface NumberExtension extends Extension
     /**
      * Returns a random number between $int1 and $int2 (any order)
      *
-     * @param int $int1 default to 0
-     * @param int $int2 defaults to 32 bit max integer, ie 2147483647
+     * @param int $min default to 0
+     * @param int $max defaults to 32 bit max integer, ie 2147483647
      *
      * @example 79907610
      */
-    public function numberBetween(int $int1, int $int2): int;
+    public function numberBetween(int $min, int $max): int;
 
     /**
      * Returns a random number between 0 and 9
@@ -24,8 +24,6 @@ interface NumberExtension extends Extension
 
     /**
      * Generates a random digit, which cannot be $except
-     *
-     * @param int $except
      */
     public function randomDigitNot(int $except): int;
 
@@ -37,13 +35,9 @@ interface NumberExtension extends Extension
     /**
      * Return a random float number
      *
-     * @param int|null  $nbMaxDecimals
-     * @param float $min
-     * @param float $max
-     *
      * @example 48.8932
      */
-    public function randomFloat(int $nbMaxDecimals, float $min, float $max): float;
+    public function randomFloat(?int $nbMaxDecimals, float $min, float $max): float;
 
     /**
      * Returns a random integer with 0 to $nbDigits digits.
@@ -55,5 +49,5 @@ interface NumberExtension extends Extension
      *
      * @example 79907610
      */
-    public function randomNumber(int $nbDigits, bool $strict): int;
+    public function randomNumber(?int $nbDigits, bool $strict): int;
 }

--- a/src/Faker/Extension/NumberExtension.php
+++ b/src/Faker/Extension/NumberExtension.php
@@ -15,7 +15,7 @@ interface NumberExtension extends Extension
      *
      * @example 79907610
      */
-    public function numberBetween($int1, $int2): int;
+    public function numberBetween(int $int1, int $int2): int;
 
     /**
      * Returns a random number between 0 and 9
@@ -27,7 +27,7 @@ interface NumberExtension extends Extension
      *
      * @param int $except
      */
-    public function randomDigitNot($except): int;
+    public function randomDigitNot(int $except): int;
 
     /**
      * Returns a random number between 1 and 9
@@ -43,7 +43,7 @@ interface NumberExtension extends Extension
      *
      * @example 48.8932
      */
-    public function randomFloat($nbMaxDecimals, $min, $max): float;
+    public function randomFloat(int $nbMaxDecimals, float $min, float $max): float;
 
     /**
      * Returns a random integer with 0 to $nbDigits digits.

--- a/src/Faker/Extension/NumberExtension.php
+++ b/src/Faker/Extension/NumberExtension.php
@@ -30,7 +30,7 @@ interface NumberExtension extends Extension
     /**
      * Returns a random number between 1 and 9
      */
-    public function randomDigitNotNull(): int;
+    public function randomDigitNotZero(): int;
 
     /**
      * Return a random float number

--- a/src/Faker/Extension/NumberExtension.php
+++ b/src/Faker/Extension/NumberExtension.php
@@ -38,8 +38,8 @@ interface NumberExtension extends Extension
      * Return a random float number
      *
      * @param int|null  $nbMaxDecimals
-     * @param float|int $min
-     * @param float|int $max
+     * @param float $min
+     * @param float $max
      *
      * @example 48.8932
      */
@@ -55,5 +55,5 @@ interface NumberExtension extends Extension
      *
      * @example 79907610
      */
-    public function randomNumber($nbDigits, $strict): int;
+    public function randomNumber(int $nbDigits, bool $strict): int;
 }

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -362,31 +362,60 @@ class Generator
         return $this->ext(Extension\BarcodeExtension::class)->isbn13();
     }
 
+    /**
+     * Returns a random number between $int1 and $int2 (any order)
+     *
+     * @example 79907610
+     */
     public function numberBetween($int1 = 0, $int2 = 2147483647): int
     {
         return $this->ext(Extension\NumberExtension::class)->numberBetween((int) $int1, (int) $int2);
     }
 
+    /**
+     * Returns a random number between 0 and 9
+     */
     public function randomDigit(): int
     {
         return $this->ext(Extension\NumberExtension::class)->randomDigit();
     }
 
+    /**
+     * Generates a random digit, which cannot be $except
+     */
     public function randomDigitNot($except): int
     {
         return $this->ext(Extension\NumberExtension::class)->randomDigitNot((int) $except);
     }
 
+    /**
+     * Returns a random number between 1 and 9
+     */
     public function randomDigitNotNull(): int
     {
         return $this->ext(Extension\NumberExtension::class)->randomDigitNotNull();
     }
 
+    /**
+     * Return a random float number
+     *
+     * @example 48.8932
+     */
     public function randomFloat($nbMaxDecimals = null, $min = 0, $max = null): float
     {
         return $this->ext(Extension\NumberExtension::class)->randomFloat((int) $nbMaxDecimals, (float) $min, (float) $max);
     }
 
+    /**
+     * Returns a random integer with 0 to $nbDigits digits.
+     *
+     * The maximum value returned is mt_getrandmax()
+     *
+     * @param int|null $nbDigits Defaults to a random number between 1 and 9
+     * @param bool     $strict   Whether the returned number should have exactly $nbDigits
+     *
+     * @example 79907610
+     */
     public function randomNumber($nbDigits = null, $strict = false): int
     {
         return $this->ext(Extension\NumberExtension::class)->randomNumber((int) $nbDigits, (bool) $strict);

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -364,7 +364,7 @@ class Generator
 
     public function numberBetween($int1 = 0, $int2 = 2147483647): int
     {
-        return $this->ext(Extension\NumberExtension::class)->numberBetween($int1, $int2);
+        return $this->ext(Extension\NumberExtension::class)->numberBetween((int) $int1, (int) $int2);
     }
 
     public function randomDigit(): int
@@ -374,7 +374,7 @@ class Generator
 
     public function randomDigitNot($except): int
     {
-        return $this->ext(Extension\NumberExtension::class)->randomDigitNot($except);
+        return $this->ext(Extension\NumberExtension::class)->randomDigitNot((int) $except);
     }
 
     public function randomDigitNotNull(): int
@@ -384,12 +384,12 @@ class Generator
 
     public function randomFloat($nbMaxDecimals = null, $min = 0, $max = null): float
     {
-        return $this->ext(Extension\NumberExtension::class)->randomFloat($nbMaxDecimals, $min, $max);
+        return $this->ext(Extension\NumberExtension::class)->randomFloat((int) $nbMaxDecimals, (float) $min, (float) $max);
     }
 
     public function randomNumber($nbDigits = null, $strict = false): int
     {
-        return $this->ext(Extension\NumberExtension::class)->randomNumber($nbDigits, $strict);
+        return $this->ext(Extension\NumberExtension::class)->randomNumber((int) $nbDigits, (bool) $strict);
     }
 
     protected function callFormatWithMatches($matches)

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -391,9 +391,9 @@ class Generator
     /**
      * Returns a random number between 1 and 9
      */
-    public function randomDigitNotNull(): int
+    public function randomDigitNotZero(): int
     {
-        return $this->ext(Extension\NumberExtension::class)->randomDigitNotNull();
+        return $this->ext(Extension\NumberExtension::class)->randomDigitNotZero();
     }
 
     /**

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -166,10 +166,7 @@ use Psr\Container\ContainerInterface;
  * @property string $randomLetter
  * @property string $randomAscii
  *
- * @method int randomNumber($nbDigits = null, $strict = false)
  * @method int|string|null randomKey(array $array = array())
- * @method int numberBetween($min = 0, $max = 2147483647)
- * @method float randomFloat($nbMaxDecimals = null, $min = 0, $max = null)
  * @method mixed randomElement(array $array = array('a', 'b', 'c'))
  * @method array randomElements(array $array = array('a', 'b', 'c'), $count = 1, $allowDuplicates = false)
  * @method array|string shuffle($arg = '')
@@ -363,6 +360,36 @@ class Generator
     public function isbn13(): string
     {
         return $this->ext(Extension\BarcodeExtension::class)->isbn13();
+    }
+
+    public function numberBetween($int1 = 0, $int2 = 2147483647): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->numberBetween($int1, $int2);
+    }
+
+    public function randomDigit(): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomDigit();
+    }
+
+    public function randomDigitNot($except): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomDigitNot($except);
+    }
+
+    public function randomDigitNotNull(): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomDigitNotNull();
+    }
+
+    public function randomFloat($nbMaxDecimals = null, $min = 0, $max = null): float
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomFloat($nbMaxDecimals, $min, $max);
+    }
+
+    public function randomNumber($nbDigits = null, $strict = false): int
+    {
+        return $this->ext(Extension\NumberExtension::class)->randomNumber($nbDigits, $strict);
     }
 
     protected function callFormatWithMatches($matches)

--- a/test/Faker/Core/NumberTest.php
+++ b/test/Faker/Core/NumberTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\Core;
+
+use Faker\Test\TestCase;
+
+final class NumberTest extends TestCase
+{
+    public function testRandomDigitReturnsInteger()
+    {
+        self::assertIsInt($this->faker->randomDigit());
+    }
+
+    public function testRandomDigitReturnsDigit()
+    {
+        self::assertGreaterThanOrEqual(0, $this->faker->randomDigit());
+        self::assertLessThan(10, $this->faker->randomDigit());
+    }
+
+    public function testRandomDigitNotNullReturnsNotNullDigit()
+    {
+        self::assertGreaterThan(0, $this->faker->randomDigitNotNull());
+        self::assertLessThan(10, $this->faker->randomDigitNotNull());
+    }
+
+    public function testRandomDigitNotReturnsValidDigit()
+    {
+        for ($i = 0; $i <= 9; ++$i) {
+            self::assertGreaterThanOrEqual(0, $this->faker->randomDigitNot($i));
+            self::assertLessThan(10, $this->faker->randomDigitNot($i));
+            self::assertNotSame($this->faker->randomDigitNot($i), $i);
+        }
+    }
+
+    public function testRandomNumberThrowsExceptionWhenCalledWithAMax()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->faker->randomNumber(5, 200);
+    }
+
+    public function testRandomNumberThrowsExceptionWhenCalledWithATooHighNumberOfDigits()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->faker->randomNumber(10);
+    }
+
+    public function testRandomNumberReturnsInteger()
+    {
+        self::assertIsInt($this->faker->randomNumber());
+        self::assertIsInt($this->faker->randomNumber(5, false));
+    }
+
+    public function testRandomNumberReturnsDigit()
+    {
+        self::assertGreaterThanOrEqual(0, $this->faker->randomNumber(3));
+        self::assertLessThan(1000, $this->faker->randomNumber(3));
+    }
+
+    public function testRandomNumberAcceptsStrictParamToEnforceNumberSize()
+    {
+        self::assertEquals(5, strlen((string) $this->faker->randomNumber(5, true)));
+    }
+
+    public function testNumberBetween()
+    {
+        $min = 5;
+        $max = 6;
+
+        self::assertGreaterThanOrEqual($min, $this->faker->numberBetween($min, $max));
+        self::assertGreaterThanOrEqual($this->faker->numberBetween($min, $max), $max);
+    }
+
+    public function testNumberBetweenAcceptsZeroAsMax()
+    {
+        self::assertEquals(0, $this->faker->numberBetween(0, 0));
+    }
+
+    public function testRandomFloat()
+    {
+        $min = 4;
+        $max = 10;
+        $nbMaxDecimals = 8;
+
+        $result = $this->faker->randomFloat($nbMaxDecimals, $min, $max);
+
+        $parts = explode('.', (string) $result);
+
+        self::assertIsFloat($result);
+        self::assertGreaterThanOrEqual($min, $result);
+        self::assertLessThanOrEqual($max, $result);
+        self::assertLessThanOrEqual($nbMaxDecimals, strlen($parts[1]));
+    }
+}

--- a/test/Faker/Core/NumberTest.php
+++ b/test/Faker/Core/NumberTest.php
@@ -21,8 +21,8 @@ final class NumberTest extends TestCase
 
     public function testRandomDigitNotNullReturnsNotNullDigit()
     {
-        self::assertGreaterThan(0, $this->faker->randomDigitNotNull());
-        self::assertLessThan(10, $this->faker->randomDigitNotNull());
+        self::assertGreaterThan(0, $this->faker->randomDigitNotZero());
+        self::assertLessThan(10, $this->faker->randomDigitNotZero());
     }
 
     public function testRandomDigitNotReturnsValidDigit()

--- a/test/Faker/Core/NumberTest.php
+++ b/test/Faker/Core/NumberTest.php
@@ -34,12 +34,6 @@ final class NumberTest extends TestCase
         }
     }
 
-    public function testRandomNumberThrowsExceptionWhenCalledWithAMax()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->faker->randomNumber(5, 200);
-    }
-
     public function testRandomNumberThrowsExceptionWhenCalledWithATooHighNumberOfDigits()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
### What is the reason for this PR?

Number extension is not yet in core.

- [x] A new feature

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Added the number extension to the core.

Should we move the number methods to a helper class (as static methods), so it's easier to use them in other (internal) methods, such as for #256?

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
