### PR TITLE
Fix U.S. Area Code Generation

### DIFF
--- a/src/Faker/Provider/en_US/PhoneNumber.php
+++ b/src/Faker/Provider/en_US/PhoneNumber.php
@@ -5,6 +5,20 @@ namespace Faker\Provider\en_US;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     /**
+     * @var array<int, string>
+     */
+    protected static $areaCodeRegexes = [
+        2 => '(0[1-35-9]|1[02-9]|2[03-589]|3[149]|4[08]|5[1-46]|6[0279]|7[0269]|8[13])',
+        3 => '(0[1-57-9]|1[02-9]|2[0135]|3[0-24679]|4[167]|5[12]|6[014]|8[056])',
+        4 => '(0[124-9]|1[02-579]|2[3-5]|3[0245]|4[0235]|58|6[39]|7[0589]|8[04])',
+        5 => '(0[1-57-9]|1[0235-8]|20|3[0149]|4[01]|5[19]|6[1-47]|7[013-5]|8[056])',
+        6 => '(0[1-35-9]|1[024-9]|2[03689]|[34][016]|5[017]|6[0-279]|78|8[0-29])',
+        7 => '(0[1-46-8]|1[2-9]|2[04-7]|3[1247]|4[037]|5[47]|6[02359]|7[02-59]|8[156])',
+        8 => '(0[1-68]|1[02-8]|2[08]|3[0-28]|4[3578]|5[046-9]|6[02-5]|7[028])',
+        9 => '(0[1346-9]|1[02-9]|2[0589]|3[0146-8]|4[0179]|5[12469]|7[0-389]|8[04-69])',
+    ];
+
+    /**
      * @see https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#United_States.2C_Canada.2C_and_other_NANP_countries
      */
     protected static $formats = [
@@ -89,11 +103,9 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      */
     public static function areaCode()
     {
-        $digits[] = self::numberBetween(2, 9);
-        $digits[] = self::randomDigit();
-        $digits[] = self::randomDigitNot($digits[1]);
+        $firstDigit = self::numberBetween(2, 9);
 
-        return implode('', $digits);
+        return $firstDigit . self::regexify(self::$areaCodeRegexes[$firstDigit]);
     }
 
     /**


### PR DESCRIPTION
See https://github.com/fzaninotto/Faker/pull/1838:

> Regular expressions extracted from the PHP port of Google's [libphonenumber](https://github.com/google/libphonenumber) via the PHP port:
https://github.com/giggsey/libphonenumber-for-php/blob/f3a55dcb6fead9d4fb291c6dadda0564e5ae8d3f/src/data/PhoneNumberMetadata_US.php#L29

### What is the reason for this PR?

- [x] fixes #251

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Replaces https://github.com/fzaninotto/Faker/pull/1838.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
