### PR TITLE
Update the Generator::getFormatter to support extensions

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -666,9 +666,11 @@ class Generator
      */
     public function parse($string)
     {
-        return preg_replace_callback('/\{\{\s?(\w+)\s?\}\}/u', function ($matches) {
+        $callback = function ($matches) {
             return $this->format($matches[1]);
-        }, $string);
+        };
+
+        return preg_replace_callback('/\{\{\s?(\w+)\s?\}\}/u', $callback, $string);
     }
 
     /**

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -861,7 +861,7 @@ class Generator
      */
     protected function callFormatWithMatches($matches)
     {
-        trigger_deprecation('fakerphp/faker', '1.14', 'Protected method "callFormatWithMatches()" is deprecated and will me removed.');
+        trigger_deprecation('fakerphp/faker', '1.14', 'Protected method "callFormatWithMatches()" is deprecated and will be removed.');
 
         return $this->format($matches[1]);
     }

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -617,31 +617,44 @@ class Generator
         }
     }
 
-    public function format($formatter, $arguments = [])
+    public function format($format, $arguments = [])
     {
-        return call_user_func_array($this->getFormatter($formatter), $arguments);
+        return call_user_func_array($this->getFormatter($format), $arguments);
     }
 
     /**
-     * @param string $formatter
+     * @param string $format
      *
      * @return callable
      */
-    public function getFormatter($formatter)
+    public function getFormatter($format)
     {
-        if (isset($this->formatters[$formatter])) {
-            return $this->formatters[$formatter];
+        if (isset($this->formatters[$format])) {
+            return $this->formatters[$format];
+        }
+
+        if (method_exists($this, $format)) {
+            $this->formatters[$format] = [$this, $format];
+
+            return $this->formatters[$format];
+        }
+
+        // "Faker\Core\Barcode->ean13"
+        if (preg_match('|^([a-zA-Z0-9\\\]+)->([a-zA-Z0-9]+)$|', $format, $matches)) {
+            $this->formatters[$format] = [$this->ext($matches[1]), $matches[2]];
+
+            return $this->formatters[$format];
         }
 
         foreach ($this->providers as $provider) {
-            if (method_exists($provider, $formatter)) {
-                $this->formatters[$formatter] = [$provider, $formatter];
+            if (method_exists($provider, $format)) {
+                $this->formatters[$format] = [$provider, $format];
 
-                return $this->formatters[$formatter];
+                return $this->formatters[$format];
             }
         }
 
-        throw new \InvalidArgumentException(sprintf('Unknown formatter "%s"', $formatter));
+        throw new \InvalidArgumentException(sprintf('Unknown format "%s"', $format));
     }
 
     /**
@@ -653,7 +666,9 @@ class Generator
      */
     public function parse($string)
     {
-        return preg_replace_callback('/\{\{\s?(\w+)\s?\}\}/u', [$this, 'callFormatWithMatches'], $string);
+        return preg_replace_callback('/\{\{\s?(\w+)\s?\}\}/u', function ($matches) {
+            return $this->format($matches[1]);
+        }, $string);
     }
 
     /**
@@ -839,8 +854,13 @@ class Generator
         return $this->ext(Extension\VersionExtension::class)->semver($preRelease, $build);
     }
 
+    /**
+     * @deprecated
+     */
     protected function callFormatWithMatches($matches)
     {
+        trigger_deprecation('fakerphp/faker', '1.14', 'Protected method "callFormatWithMatches()" is deprecated and will me removed.');
+
         return $this->format($matches[1]);
     }
 

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -2,7 +2,6 @@
 
 namespace Faker\Test;
 
-use Faker\Core\Barcode;
 use Faker\Core\Blood;
 use Faker\Core\File;
 use Faker\Extension\BloodExtension;
@@ -122,7 +121,7 @@ final class GeneratorTest extends TestCase
         $faker = new Generator($builder->build());
 
         $output = $faker->format('bloodType');
-        self::assertTrue(in_array($output, ['A', 'AB', 'B', '0']));
+        self::assertTrue(in_array($output, ['A', 'AB', 'B', '0'], true));
     }
 
     public function testFormatterCallsExtension()
@@ -132,7 +131,7 @@ final class GeneratorTest extends TestCase
         $faker = new Generator($builder->build());
 
         $output = $faker->format('Faker\Core\Blood->bloodType');
-        self::assertTrue(in_array($output, ['A', 'AB', 'B', '0']));
+        self::assertTrue(in_array($output, ['A', 'AB', 'B', '0'], true));
     }
 
     public function testParseReturnsSameStringWhenItContainsNoCurlyBraces()

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -2,8 +2,12 @@
 
 namespace Faker\Test;
 
+use Faker\Core\Barcode;
+use Faker\Core\Blood;
 use Faker\Core\File;
+use Faker\Extension\BloodExtension;
 use Faker\Extension\Container;
+use Faker\Extension\ContainerBuilder;
 use Faker\Extension\ExtensionNotFound;
 use Faker\Extension\FileExtension;
 use Faker\Generator;
@@ -109,6 +113,26 @@ final class GeneratorTest extends TestCase
         $provider = new Fixture\Provider\FooProvider();
         $this->faker->addProvider($provider);
         self::assertEquals('bazfoo', $this->faker->format('fooFormatterWithArguments', ['foo']));
+    }
+
+    public function testFormatterCallsGenerator()
+    {
+        $builder = new ContainerBuilder();
+        $builder->add(Blood::class, BloodExtension::class);
+        $faker = new Generator($builder->build());
+
+        $output = $faker->format('bloodType');
+        self::assertTrue(in_array($output, ['A', 'AB', 'B', '0']));
+    }
+
+    public function testFormatterCallsExtension()
+    {
+        $builder = new ContainerBuilder();
+        $builder->add(Blood::class);
+        $faker = new Generator($builder->build());
+
+        $output = $faker->format('Faker\Core\Blood->bloodType');
+        self::assertTrue(in_array($output, ['A', 'AB', 'B', '0']));
     }
 
     public function testParseReturnsSameStringWhenItContainsNoCurlyBraces()


### PR DESCRIPTION
This will allow us to write: 

```
$this->generator->parse('My blood type is {{'Faker\Core\Blood->bloodType'}}.');
```

Which is needed by extensions implementing `GeneratorAwareExtension`
