### PR TITLE
Add replace for fzaninotto/faker:1.9.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
     "conflict": {
         "fzaninotto/faker": "*"
     },
+    "replace": {
+        "fzaninotto/faker": "1.9.*"
+    },
     "suggest": {
         "ext-curl": "Required by Faker\\Provider\\Image to download images.",
         "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",


### PR DESCRIPTION
If a package is requiring `fzaninotto/faker: ^1.8`, they will be able to install fakerphp/faker: 1.9.2 but no other version of fakerphp/faker. This means that a user that has a dependency on library A which depends on `fzaninotto/faker: ^1.8`, they cannot use the new cool features we've created in this library. 

Since  `fakerphp/faker: 1.x` is compatible with `fzaninotto/faker: ^1.9`, then I suggest to help this user. 

Of course, we can argue that library A should update their dependencies too. 