### PR TITLE
Remove french domains that no longer exists

### DIFF
--- a/src/Faker/Provider/fr_FR/Internet.php
+++ b/src/Faker/Provider/fr_FR/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\fr_FR;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['voila.fr', 'gmail.com', 'hotmail.fr', 'yahoo.fr', 'laposte.net', 'free.fr', 'sfr.fr', 'orange.fr', 'bouygtel.fr', 'club-internet.fr', 'dbmail.com', 'live.com', 'ifrance.com', 'noos.fr', 'tele2.fr', 'tiscali.fr', 'wanadoo.fr'];
+    protected static $freeEmailDomain = ['voila.fr', 'gmail.com', 'hotmail.fr', 'yahoo.fr', 'laposte.net', 'free.fr', 'sfr.fr', 'orange.fr', 'club-internet.fr', 'dbmail.com', 'live.com', 'noos.fr', 'tele2.fr', 'wanadoo.fr'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'fr', 'fr', 'fr'];
 }


### PR DESCRIPTION
### What is the reason for this PR?
Some free domains used in the French locale no longer exists. That causes issue when using advance validation of domains (DNS...).

Email validation example with Laravel:
```php
validator(['email' => 'mail@bouygtel.fr'], ['email' => 'email:rfc,dns,spoof'])->validated();
validator(['email' => 'mail@ifrance.com'], ['email' => 'email:rfc,dns,spoof'])->validated();
validator(['email' => 'mail@tiscali.fr'], ['email' => 'email:rfc,dns,spoof'])->validated();
```

- [ ] A new feature
- [x] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

I tried every freeDomains for the french locale and removed the one that were causing issues.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
