### PR TITLE
Remove invalid french domain

### DIFF
--- a/src/Faker/Provider/fr_FR/Internet.php
+++ b/src/Faker/Provider/fr_FR/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\fr_FR;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['voila.fr', 'gmail.com', 'hotmail.fr', 'yahoo.fr', 'laposte.net', 'free.fr', 'sfr.fr', 'orange.fr', 'club-internet.fr', 'dbmail.com', 'live.com', 'noos.fr', 'tele2.fr', 'wanadoo.fr'];
+    protected static $freeEmailDomain = ['gmail.com', 'hotmail.fr', 'yahoo.fr', 'laposte.net', 'free.fr', 'sfr.fr', 'orange.fr', 'club-internet.fr', 'dbmail.com', 'live.com', 'noos.fr', 'tele2.fr', 'wanadoo.fr'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'fr', 'fr', 'fr'];
 }


### PR DESCRIPTION
Hi

### What is the reason for this PR?

This is the same goal as PR #277.
voila.fr free domain still exists but redirects to a new domain, that causes email validation DNS issue.

Sorry for missing that one in the previous pull request @pimjansen.

- [ ] A new feature
- [X] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

See #277.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
