### PR TITLE
Fix error that occurs when getting a polish title 'Error: Non-static …

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -916,11 +916,6 @@ parameters:
 			path: src/Faker/Provider/pl_PL/Company.php
 
 		-
-			message: "#^Static call to instance method Faker\\\\Provider\\\\pl_PL\\\\Person\\:\\:title\\(\\)\\.$#"
-			count: 2
-			path: src/Faker/Provider/pl_PL/Person.php
-
-		-
 			message: "#^Parameter \\$birthdate of method Faker\\\\Provider\\\\pl_PL\\\\Person\\:\\:pesel\\(\\) has invalid typehint type Faker\\\\Provider\\\\pl_PL\\\\DateTime\\.$#"
 			count: 1
 			path: src/Faker/Provider/pl_PL/Person.php

--- a/src/Faker/Provider/pl_PL/Person.php
+++ b/src/Faker/Provider/pl_PL/Person.php
@@ -125,7 +125,7 @@ class Person extends \Faker\Provider\Person
      */
     public static function titleMale()
     {
-        return static::title();
+        return static::randomElement(static::$title);
     }
 
     /**
@@ -133,7 +133,7 @@ class Person extends \Faker\Provider\Person
      */
     public static function titleFemale()
     {
-        return static::title();
+        return static::randomElement(static::$title);
     }
 
     /**

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -89,6 +89,13 @@ final class PersonTest extends TestCase
         self::assertEquals(0, $sum % 10);
     }
 
+    public function testTitle()
+    {
+        self::assertContains($this->faker->titleFemale(),  ['mgr', 'inż.', 'dr', 'doc.']);
+        self::assertContains($this->faker->titleMale(),  ['mgr', 'inż.', 'dr', 'doc.']);
+    }
+
+
     protected function getProviders(): iterable
     {
         yield new Person($this->faker);

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -91,10 +91,9 @@ final class PersonTest extends TestCase
 
     public function testTitle()
     {
-        self::assertContains($this->faker->titleFemale(),  ['mgr', 'inż.', 'dr', 'doc.']);
-        self::assertContains($this->faker->titleMale(),  ['mgr', 'inż.', 'dr', 'doc.']);
+        self::assertContains($this->faker->titleFemale(), ['mgr', 'inż.', 'dr', 'doc.']);
+        self::assertContains($this->faker->titleMale(), ['mgr', 'inż.', 'dr', 'doc.']);
     }
-
 
     protected function getProviders(): iterable
     {


### PR DESCRIPTION
…method Faker\Provider\pl_PL\Person::title() cannot be called statically'

### What is the reason for this PR?

When using a polish provider, and calling `$this->faker->title` I get the following error message
```
Error: Non-static method Faker\Provider\pl_PL\Person::title() cannot be called statically
```
- [ ] A new feature
- [X] Fixed an issue (resolve #ID)

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This changes the `titleFemale` and `titleMale` methods to pick an item from the list of titles, instead of statically calling a non static method `Person::title()`
I added a test for this.

Note that the reason behind not having gendered titles in Polish are beyond me, I found this logic and simply fixed the code that is used to implement it. I am not Polish.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
