### PR TITLE
Use valid area codes for North America E164 phone numbers

### DIFF
--- a/src/Faker/Provider/en_US/PhoneNumber.php
+++ b/src/Faker/Provider/en_US/PhoneNumber.php
@@ -59,7 +59,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     ];
 
     protected static $e164Formats = [
-        '+1##########',
+        '+1{{areaCode}}#######',
     ];
 
     /**

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -76,7 +76,7 @@ final class PhoneNumberTest extends TestCase
     {
         for ($i = 0; $i < 10; ++$i) {
             $number = $this->faker->e164PhoneNumber();
-            self::assertMatchesRegularExpression('/^\+1\d{1,14}$/', $number);
+            self::assertMatchesRegularExpression('/^\+1[2-9]\d{9}$/', $number);
         }
     }
 


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue (no issue ticket)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io) (N/A)

### Summary of changes

This builds on #261 and #264 to ensure that North American (`en_US`) E.164 phone numbers have valid area codes. Currently, generated E.164 phone numbers for the `en_US` locale can still be invalid without this change.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
