### PR TITLE
Ensure that randomNumber holds a default nullable option

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -470,7 +470,10 @@ class Generator
      */
     public function randomNumber($nbDigits = null, $strict = false): int
     {
-        return $this->ext(Extension\NumberExtension::class)->randomNumber((int) $nbDigits, (bool) $strict);
+        return $this->ext(Extension\NumberExtension::class)->randomNumber(
+            $nbDigits !== null ? (int) $nbDigits : null,
+            (bool) $strict
+        );
     }
 
     protected function callFormatWithMatches($matches)

--- a/test/Faker/Core/NumberTest.php
+++ b/test/Faker/Core/NumberTest.php
@@ -40,6 +40,11 @@ final class NumberTest extends TestCase
         $this->faker->randomNumber(10);
     }
 
+    public function testRandomNumberHasValidNullableAutogenerate()
+    {
+        self::assertGreaterThan(0, $this->faker->randomNumber());
+    }
+
     public function testRandomNumberReturnsInteger()
     {
         self::assertIsInt($this->faker->randomNumber());


### PR DESCRIPTION
### What is the reason for this PR?

- [x] Fixed an issue (resolve #290 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

By moving methods to Core we decided to make things more strict. The proxy therefor casts the value to int however initially it is nullable which breaks the functionality. A null check is added to keep the strict typing on the core method itself.

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
