### PR TITLE
Ensure that randomFloat holds a default nullable option

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -455,7 +455,11 @@ class Generator
      */
     public function randomFloat($nbMaxDecimals = null, $min = 0, $max = null): float
     {
-        return $this->ext(Extension\NumberExtension::class)->randomFloat((int) $nbMaxDecimals, (float) $min, (float) $max);
+        return $this->ext(Extension\NumberExtension::class)->randomFloat(
+            $nbMaxDecimals !== null ? (int) $nbMaxDecimals : null,
+            (float) $min,
+            $max !== null ? (float) $max : null
+        );
     }
 
     /**

--- a/test/Faker/Core/NumberTest.php
+++ b/test/Faker/Core/NumberTest.php
@@ -86,4 +86,9 @@ final class NumberTest extends TestCase
         self::assertLessThanOrEqual($max, $result);
         self::assertLessThanOrEqual($nbMaxDecimals, strlen($parts[1]));
     }
+
+    public function testRandomFloatHasValidNullableAutogenerate()
+    {
+        self::assertGreaterThan(0, $this->faker->randomFloat());
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

- [ ] A new feature
- [x] Fixed an issue (resolve #291)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Fixes what is described in #219, only for `randomFloat`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
