### PR TITLE
Prevent direct access and triggered deprecation warning for "word" me…

### DIFF
--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -152,7 +152,7 @@ class HtmlLorem extends Base
 
         switch ($rand) {
             case 1:
-                $node->setAttribute('class', $this->generator->word);
+                $node->setAttribute('class', $this->generator->word());
 
                 break;
 
@@ -234,7 +234,7 @@ class HtmlLorem extends Base
 
         $textLabel = $element->ownerDocument->createElement(static::LABEL_TAG);
         $textLabel->setAttribute('for', 'username');
-        $textLabel->textContent = $this->generator->word;
+        $textLabel->textContent = $this->generator->word();
 
         $passwordInput = $element->ownerDocument->createElement(static::INPUT_TAG);
         $passwordInput->setAttribute('type', 'password');
@@ -242,11 +242,11 @@ class HtmlLorem extends Base
 
         $passwordLabel = $element->ownerDocument->createElement(static::LABEL_TAG);
         $passwordLabel->setAttribute('for', 'password');
-        $passwordLabel->textContent = $this->generator->word;
+        $passwordLabel->textContent = $this->generator->word();
 
         $submit = $element->ownerDocument->createElement(static::INPUT_TAG);
         $submit->setAttribute('type', 'submit');
-        $submit->setAttribute('value', $this->generator->word);
+        $submit->setAttribute('value', $this->generator->word());
 
         $submit = $element->ownerDocument->createElement(static::FORM_TAG);
         $submit->setAttribute('action', $this->generator->safeEmailDomain);


### PR DESCRIPTION
### What is the reason for this PR?

Deprecation warnings are thrown from core methods while direct accessing properties which is not allowed anymore since 1.14

- [ ] A new feature
- [x] Fixed an issue (resolve #298)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

The internal methods now call the function instead of accessing the properties directly.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
