### PR TITLE
Don't generate birth number of '000' for Swedish personal identity number

### DIFF
--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -146,16 +146,22 @@ class Person extends \Faker\Provider\Person
      */
     protected function getBirthNumber($gender = null)
     {
-        do {
-            if ($gender && $gender == static::GENDER_MALE) {
-                $randomDigits = (string) static::numerify('##') . static::randomElement([1, 3, 5, 7, 9]);
-            } elseif ($gender && $gender == static::GENDER_FEMALE) {
-                $randomDigits = (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]);
-            } else {
-                $randomDigits = (string) static::numerify('###');
-            }
-        } while ($randomDigits === '000');
+        if ($gender && $gender == static::GENDER_MALE) {
+            return (string) static::numerify('##') . static::randomElement([1, 3, 5, 7, 9]);
+        }
 
-        return $randomDigits;
+        $zeroCheck = function($callback) {
+            do {
+                $randomDigits = $callback();
+            } while ($randomDigits === '000');
+
+            return $randomDigits;
+        };
+
+        if ($gender && $gender == static::GENDER_FEMALE) {
+            return $zeroCheck(fn() => (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]));
+        }
+
+        return  $zeroCheck(fn() => (string) static::numerify('###'));
     }
 }

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -140,11 +140,11 @@ class Person extends \Faker\Provider\Person
     }
 
     /**
-     * @param $gender
+     * @param string $gender Person::GENDER_MALE || Person::GENDER_FEMALE
      *
-     * @return string
+     * @return string of three digits
      */
-    protected function getBirthNumber($gender)
+    protected function getBirthNumber($gender = null)
     {
         do {
             if ($gender && $gender == static::GENDER_MALE) {

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -146,7 +146,7 @@ class Person extends \Faker\Provider\Person
      */
     protected function getBirthNumber($gender = null)
     {
-        if ($gender && $gender == static::GENDER_MALE) {
+        if ($gender && $gender === static::GENDER_MALE) {
             return (string) static::numerify('##') . static::randomElement([1, 3, 5, 7, 9]);
         }
 
@@ -158,7 +158,7 @@ class Person extends \Faker\Provider\Person
             return $randomDigits;
         };
 
-        if ($gender && $gender == static::GENDER_FEMALE) {
+        if ($gender && $gender === static::GENDER_FEMALE) {
             return $zeroCheck(function() {
                 return (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]);
             });

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -132,17 +132,30 @@ class Person extends \Faker\Provider\Person
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();
         }
         $datePart = $birthdate->format('ymd');
-
-        if ($gender && $gender == static::GENDER_MALE) {
-            $randomDigits = (string) static::numerify('##') . static::randomElement([1, 3, 5, 7, 9]);
-        } elseif ($gender && $gender == static::GENDER_FEMALE) {
-            $randomDigits = (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]);
-        } else {
-            $randomDigits = (string) static::numerify('###');
-        }
+        $randomDigits = $this->getBirthNumber($gender);
 
         $checksum = Luhn::computeCheckDigit($datePart . $randomDigits);
 
         return $datePart . '-' . $randomDigits . $checksum;
+    }
+
+    /**
+     * @param $gender
+     *
+     * @return string
+     */
+    protected function getBirthNumber($gender)
+    {
+        do {
+            if ($gender && $gender == static::GENDER_MALE) {
+                $randomDigits = (string) static::numerify('##') . static::randomElement([1, 3, 5, 7, 9]);
+            } elseif ($gender && $gender == static::GENDER_FEMALE) {
+                $randomDigits = (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]);
+            } else {
+                $randomDigits = (string) static::numerify('###');
+            }
+        } while ($randomDigits === '000');
+
+        return $randomDigits;
     }
 }

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -159,9 +159,13 @@ class Person extends \Faker\Provider\Person
         };
 
         if ($gender && $gender == static::GENDER_FEMALE) {
-            return $zeroCheck(fn() => (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]));
+            return $zeroCheck(function() {
+                return (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]);
+            });
         }
 
-        return  $zeroCheck(fn() => (string) static::numerify('###'));
+        return  $zeroCheck(function() {
+            return (string) static::numerify('###');
+        });
     }
 }

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -150,7 +150,7 @@ class Person extends \Faker\Provider\Person
             return (string) static::numerify('##') . static::randomElement([1, 3, 5, 7, 9]);
         }
 
-        $zeroCheck = function($callback) {
+        $zeroCheck = static function ($callback) {
             do {
                 $randomDigits = $callback();
             } while ($randomDigits === '000');
@@ -159,12 +159,12 @@ class Person extends \Faker\Provider\Person
         };
 
         if ($gender && $gender === static::GENDER_FEMALE) {
-            return $zeroCheck(function() {
+            return $zeroCheck(static function () {
                 return (string) static::numerify('##') . static::randomElement([0, 2, 4, 6, 8]);
             });
         }
 
-        return  $zeroCheck(function() {
+        return  $zeroCheck(static function () {
             return (string) static::numerify('###');
         });
     }

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -51,6 +51,25 @@ final class PersonTest extends TestCase
         self::assertEquals(0, $pin[9] % 2);
     }
 
+    public function testBirthNumberNot000()
+    {
+        $faker = $this->faker;
+        $faker->seed(97270);
+        $pin = $this->faker->personalIdentityNumber();
+
+        self::assertNotEquals('000', substr($pin, 7, 3));
+    }
+
+    public function testBirthNumberGeneratesEvenValuesForFemales()
+    {
+        $faker = $this->faker;
+        $faker->seed(372920);
+        $pin = $this->faker->personalIdentityNumber(null, 'female');
+
+
+        self::assertNotEquals('000', substr($pin, 7, 3));
+    }
+
     protected function getProviders(): iterable
     {
         yield new Person($this->faker);

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -66,7 +66,6 @@ final class PersonTest extends TestCase
         $faker->seed(372920);
         $pin = $this->faker->personalIdentityNumber(null, 'female');
 
-
         self::assertNotEquals('000', substr($pin, 7, 3));
     }
 


### PR DESCRIPTION
### What is the reason for this PR?

- [ ] A new feature
- [x] Fixed an issue (resolve #305)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Swedish personal identity number with a birth number of 000 is not valid. The birth number is the first 3 numbers of the last 4, marked with X here 19900101-XXX0

Note: There are no tests for this. I'm not sure how to test this in a good way as this only happen one time in 1000 on average. Any suggestions for this, or can we skip the test?

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
