### PR TITLE
Fix: Remove command name when running phpstan

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run PHPStan
         run: |
-          vendor/bin/phpstan analyze --no-progress
+          vendor/bin/phpstan --no-progress
 
   psalm:
     name: Psalm

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ test: vendor ## Runs tests with phpunit
 
 .PHONY: static
 static: vendor ## Runs static analyzers
-	vendor/bin/phpstan analyze
+	vendor/bin/phpstan
 	vendor/bin/psalm
 
 .PHONY: baseline
 baseline: vendor ## Generate baseline files
-	vendor/bin/phpstan analyze --generate-baseline
+	vendor/bin/phpstan --generate-baseline
 	vendor/bin/psalm --update-baseline
 
 .PHONY: clean


### PR DESCRIPTION
This pull request 

- [x] removes the command name when running `phpstan`