### PR TITLE
Fix uninitialized Base::unique

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -761,11 +761,6 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: src/Faker/Provider/Base.php
-
-		-
 			message: "#^Parameter \\$validator of method Faker\\\\Provider\\\\Base\\:\\:valid\\(\\) has invalid typehint type Faker\\\\Provider\\\\Closure\\.$#"
 			count: 1
 			path: src/Faker/Provider/Base.php

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -17,7 +17,7 @@ class Base
     /**
      * @var \Faker\UniqueGenerator|null
      */
-    protected $unique = null;
+    protected $unique;
 
     public function __construct(Generator $generator)
     {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -15,9 +15,9 @@ class Base
     protected $generator;
 
     /**
-     * @var \Faker\UniqueGenerator
+     * @var \Faker\UniqueGenerator|null
      */
-    protected $unique;
+    protected $unique = null;
 
     public function __construct(Generator $generator)
     {
@@ -621,7 +621,7 @@ class Base
      */
     public function unique($reset = false, $maxRetries = 10000)
     {
-        if ($reset || !$this->unique) {
+        if ($reset || $this->unique === null) {
             $this->unique = new UniqueGenerator($this->generator, $maxRetries);
         }
 


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

`Base::unique` property was not initialized in constructor and did not allow `null`. That may cause issues in classes accessing it while extending `Base`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
