### PR TITLE
Add photo provider

### DIFF
--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -6,7 +6,7 @@ class Factory
 {
     public const DEFAULT_LOCALE = 'en_US';
 
-    protected static $defaultProviders = ['Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Medical', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid'];
+    protected static $defaultProviders = ['Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Medical', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Photo', 'Text', 'UserAgent', 'Uuid'];
 
     /**
      * Create a new generator

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -294,6 +294,14 @@ use Psr\Container\ContainerInterface;
  *
  * @method string image($dir = null, $width = 640, $height = 480, $category = null, $fullPath = true, $randomize = true, $word = null, $gray = false)
  *
+ * @property string $photoUrl
+ *
+ * @method string photoUrl($width = 640, $height = 480, $filters = [], $format = 'jpg')
+ *
+ * @property string $photo
+ *
+ * @method string photo($dir = null, $width = 640, $height = 480, $filters = [], $format = 'jpg', $fullPath = true)
+ *
  * @property string $email
  *
  * @method string email()

--- a/src/Faker/Provider/Photo.php
+++ b/src/Faker/Provider/Photo.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Faker\Provider;
+
+/**
+ * Depends on image generation from http://picsum.photos/
+ */
+class Photo extends Base
+{
+    /**
+     * @var string
+     */
+    public const BASE_URL = 'https://picsum.photos';
+
+    /**
+     * @var array
+     */
+    protected static $formats = ['jpg', 'webp'];
+
+    /**
+     * Generate the URL that will return a random photo
+     *
+     * Set randomize to false to remove the random GET parameter at the end of the url.
+     *
+     * @example 'https://picsum.photos/640/480'
+     *
+     * @param int    $width
+     * @param int    $height
+     * @param array  $filters
+     * @param string $format
+     *
+     * @return string
+     */
+    public static function photoUrl(
+        $width = 640,
+        $height = 480,
+        $filters = [],
+        $format = 'jpg'
+    ) {
+        if (!in_array($format, self::$formats, true)) {
+            throw new \InvalidArgumentException(sprintf('Format is invalid, must be one of "%s"', implode(', ', self::$formats)));
+        }
+        $format = strtolower($format);
+        $url = sprintf(
+            '%s/%d/%d.%s',
+            self::BASE_URL,
+            $width,
+            $height,
+            $format
+        );
+
+        if (!empty($filters)) {
+            $url .= '?' . http_build_query($filters);
+        }
+
+        return $url;
+    }
+
+    /**
+     * Download a remote random photo to disk and return its location
+     *
+     * Requires curl, or allow_url_fopen to be on in php.ini.
+     *
+     * @example '/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
+     *
+     * @return bool|string
+     */
+    public static function photo(
+        $dir = null,
+        $width = 640,
+        $height = 480,
+        $filters = [],
+        $format = 'jpg',
+        $fullPath = true
+    ) {
+        $dir = null === $dir ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
+        // Validate directory path
+        if (!is_dir($dir) || !is_writable($dir)) {
+            throw new \InvalidArgumentException(sprintf('Cannot write to directory "%s"', $dir));
+        }
+
+        // Generate a random filename. Use the server address so that a file
+        // generated at the same time on a different server won't have a collision.
+        $name = md5(uniqid(empty($_SERVER['SERVER_ADDR']) ? '' : $_SERVER['SERVER_ADDR'], true));
+        $filename = $name . '.' . $format;
+        $filepath = $dir . DIRECTORY_SEPARATOR . $filename;
+
+        $url = static::photoUrl($width, $height, $filters, $format);
+
+        // save file
+        if (function_exists('curl_exec')) {
+            // use cURL
+            $fp = fopen($filepath, 'w');
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_FILE, $fp);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); // Required for picsum to follow redirect.
+            $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
+            fclose($fp);
+            curl_close($ch);
+
+            if (!$success) {
+                unlink($filepath);
+
+                // could not contact the distant URL or HTTP error - fail silently.
+                return false;
+            }
+        } elseif (ini_get('allow_url_fopen')) {
+            // use remote fopen() via copy()
+            $success = copy($url, $filepath);
+        } else {
+            return new \RuntimeException('The photo formatter downloads a photo from a remote HTTP server. Therefore, it requires that PHP can request remote hosts, either via cURL or fopen()');
+        }
+
+        return $fullPath ? $filepath : $filename;
+    }
+}

--- a/test/Faker/Provider/PhotoTest.php
+++ b/test/Faker/Provider/PhotoTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Faker\Test\Provider;
+
+use Faker\Provider\Photo;
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class PhotoTest extends TestCase
+{
+    public function testPhotoUrlUses640x680AsTheDefaultSize()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://picsum.photos/640/480.jpg#',
+            Photo::photoUrl()
+        );
+    }
+
+    public function testPhotoUrlAcceptsCustomWidthAndHeight()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://picsum.photos/800/400.jpg#',
+            Photo::photoUrl(800, 400)
+        );
+    }
+
+    public function testPhotoUrlAcceptsFilters()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://picsum.photos/800/400.jpg\?grayscale=1.*#',
+            Photo::photoUrl(800, 400, ['grayscale' => '1'])
+        );
+
+        self::assertMatchesRegularExpression(
+            '#^https://picsum.photos/800/400.jpg\?grayscale=1&blur=1.*#',
+            Photo::photoUrl(800, 400, ['grayscale' => '1', 'blur' => '1'])
+        );
+    }
+
+    public function testPhotoUrlAcceptsSupportedFormats()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://picsum.photos/800/400.jpg#',
+            Photo::photoUrl(800, 400, [], 'jpg')
+        );
+
+        self::assertMatchesRegularExpression(
+            '#^https://picsum.photos/800/400.webp#',
+            Photo::photoUrl(800, 400, [], 'webp')
+        );
+    }
+
+    public function testPhotoUrlSetsFormatToJpgByDefault()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://picsum.photos/800/400.jpg#',
+            Photo::photoUrl(800, 400)
+        );
+    }
+
+    public function testPhotoUrlThrowsExceptionOnInvalidFormat()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Format is invalid, must be one of "%s"', implode(', ', ['jpg', 'webp'])));
+        Photo::photoUrl(800, 400, [], 'png');
+    }
+
+    public function testDownloadWithDefaults()
+    {
+        $curlPing = curl_init(Photo::BASE_URL);
+        curl_setopt($curlPing, CURLOPT_TIMEOUT, 5);
+        curl_setopt($curlPing, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($curlPing, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curlPing, CURLOPT_FOLLOWLOCATION, true);
+        $data = curl_exec($curlPing);
+        $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
+        curl_close($curlPing);
+
+        if ($httpCode < 200 | $httpCode > 400) {
+            self::markTestSkipped('picsum.photos is offline, skipping photo download');
+        }
+
+        $file = Photo::photo(sys_get_temp_dir());
+        self::assertFileExists($file);
+
+        if (function_exists('getphotosize')) {
+            [$width, $height, $type, $attr] = getphotosize($file);
+            self::assertEquals(640, $width);
+            self::assertEquals(480, $height);
+            self::assertEquals(constant('IMAGETYPE_JPG'), $type);
+        } else {
+            self::assertEquals('jpg', pathinfo($file, PATHINFO_EXTENSION));
+        }
+
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+}


### PR DESCRIPTION
I know, [you're not accepting new features](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md#contributing) so **feel free to close without merge or review**, but I thought it may be useful none the less. Even if just to give people a reference if they are searching this repo for picsum and want to create their own provider.

If you've gotten this far and _are_ interested in the feature though...should it be added to `Core` as opposed to `Provider`? Also, I can add some docs too if you did want to keep it.

Really important though as don't want to create work for anyone, **please don't waste your time reviewing if it's just noise and close straight away**, had the code hanging around and thought why not share. Thanks! 

### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [x] A new feature
- [x] Fixed an issue (resolve #144)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Add new photo provider to use picsum for providing photos. This should
be considered different to the existing image provider which provides
an image (i.e. a plain coloured image with a text overlay).

It's useful when users want a photo rather than just a coloured block.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
