### PR TITLE
Improve type hints in UniqueGenerator

### DIFF
--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -3,19 +3,30 @@
 namespace Faker;
 
 /**
- * Proxy for other generators, to return only unique values. Works with
- * Faker\Generator\Base->unique()
+ * Proxy for other generators that returns only unique values.
+ *
+ * Instantiated through @see Generator::unique().
+ *
+ * @mixin Generator
  */
 class UniqueGenerator
 {
+    /**
+     * @var Generator
+     */
     protected $generator;
-    protected $maxRetries;
-    protected $uniques = [];
 
     /**
-     * @param int $maxRetries
+     * @var int
      */
-    public function __construct(Generator $generator, $maxRetries = 10000)
+    protected $maxRetries;
+
+    /**
+     * @var array<string, array<string, null>>
+     */
+    protected $uniques = [];
+
+    public function __construct(Generator $generator, int $maxRetries = 10000)
     {
         $this->generator = $generator;
         $this->maxRetries = $maxRetries;

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -22,6 +22,13 @@ class UniqueGenerator
     protected $maxRetries;
 
     /**
+     * Maps from method names to a map with serialized result keys.
+     *
+     * @example [
+     *   'phone' => ['0123' => null],
+     *   'city' => ['London' => null, 'Tokyo' => null],
+     * ]
+     *
      * @var array<string, array<string, null>>
      */
     protected $uniques = [];

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -26,7 +26,10 @@ class UniqueGenerator
      */
     protected $uniques = [];
 
-    public function __construct(Generator $generator, int $maxRetries = 10000)
+    /**
+     * @param int $maxRetries
+     */
+    public function __construct(Generator $generator, $maxRetries = 10000)
     {
         $this->generator = $generator;
         $this->maxRetries = $maxRetries;


### PR DESCRIPTION
### What is the reason for this PR?

- [x] Fixed an issue

With version 1.15.0 of Faker, PHPStan started showing static analysis issues related to the usage of `unique()`.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- ~[ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)~

### Summary of changes

- Clarifies the intent of the code
- Aids autocompletion
- Aids static analysis tools

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
