### PR TITLE
nl_NL locale should use direct method instead of magic method

### DIFF
--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -84,7 +84,7 @@ class Company extends \Faker\Provider\Company
                 break;
 
             case 2:
-                $companyName = static::randomElement(static::$store) . ' ' . $this->generator->lastName;
+                $companyName = static::randomElement(static::$store) . ' ' . $this->generator->lastName();
 
                 break;
         }


### PR DESCRIPTION
### What is the reason for this PR?

Locale is accessing magic methods which cause notices

- [ ] A new feature
- [x] Fixed an issue (resolve #344 344)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
