### PR TITLE
Make the special generators compatible with static analysis

### DIFF
--- a/src/Faker/DefaultGenerator.php
+++ b/src/Faker/DefaultGenerator.php
@@ -5,6 +5,8 @@ namespace Faker;
 /**
  * This generator returns a default value for all called properties
  * and methods. It works with Faker\Generator\Base->optional().
+ *
+ * @mixin Generator
  */
 class DefaultGenerator
 {

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -5,6 +5,8 @@ namespace Faker;
 /**
  * Proxy for other generators, to return only unique values. Works with
  * Faker\Generator\Base->unique()
+ *
+ * @mixin Generator
  */
 class UniqueGenerator
 {

--- a/src/Faker/ValidGenerator.php
+++ b/src/Faker/ValidGenerator.php
@@ -5,6 +5,8 @@ namespace Faker;
 /**
  * Proxy for other generators, to return only valid values. Works with
  * Faker\Generator\Base->valid()
+ *
+ * @mixin Generator
  */
 class ValidGenerator
 {


### PR DESCRIPTION
### What is the reason for this PR?

As those generators are re-exposing the Generator API through magic methods, this makes static analyzers know about it thanks to the mixin annotation.
Prior to 1.15, the generator methods were documented as returning Generator instead of those special generators to make methods available, but that was lying about the actual type (which would break typehints).

- [ ] A new feature
- [x] Fixed an issue (resolve https://github.com/FakerPHP/Faker/pull/307#issuecomment-876501573)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
