### PR TITLE
Add version extension and semantic versioning support

### DIFF
--- a/src/Faker/Core/Version.php
+++ b/src/Faker/Core/Version.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Core;
+
+use Faker\Extension\Helper;
+use Faker\Extension\VersionExtension;
+use Faker\Provider\DateTime;
+
+final class Version implements VersionExtension
+{
+    /**
+     * @var string[]
+     */
+    private $semverCommonPreReleaseIdentifiers = ['alpha', 'beta', 'rc'];
+
+    /**
+     * Represents v2.0.0 of the semantic versioning: https://semver.org/spec/v2.0.0.html
+     */
+    public function semver(bool $preRelease = false, bool $build = false): string
+    {
+        return sprintf(
+            '%d.%d.%d%s%s',
+            mt_rand(0, 9),
+            mt_rand(0, 99),
+            mt_rand(0, 99),
+            $preRelease && mt_rand(0, 1) ? '-' . $this->semverPreReleaseIdentifier() : '',
+            $build && mt_rand(0, 1) ? '+' . $this->semverBuildIdentifier() : ''
+        );
+    }
+
+    /**
+     * Common pre-release identifier
+     */
+    private function semverPreReleaseIdentifier(): string
+    {
+        $ident = Helper::randomElement($this->semverCommonPreReleaseIdentifiers);
+        if (!mt_rand(0, 1)) {
+            return $ident;
+        }
+
+        return $ident . '.' . mt_rand(1, 99);
+    }
+
+    /**
+     * Common random build identifier
+     */
+    private function semverBuildIdentifier(): string
+    {
+        if (mt_rand(0, 1)) {
+            // short git revision syntax: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
+            return substr(sha1(Helper::lexify('??????')), 0, 7);
+        }
+
+        // date syntax
+        return DateTime::date('YmdHis');
+    }
+}

--- a/src/Faker/Core/Version.php
+++ b/src/Faker/Core/Version.php
@@ -36,6 +36,7 @@ final class Version implements VersionExtension
     private function semverPreReleaseIdentifier(): string
     {
         $ident = Helper::randomElement($this->semverCommonPreReleaseIdentifiers);
+
         if (!mt_rand(0, 1)) {
             return $ident;
         }

--- a/src/Faker/Extension/ContainerBuilder.php
+++ b/src/Faker/Extension/ContainerBuilder.php
@@ -65,6 +65,7 @@ final class ContainerBuilder
             BloodExtension::class => Core\Blood::class,
             FileExtension::class => Core\File::class,
             NumberExtension::class => Core\Number::class,
+            VersionExtension::class => Core\Version::class,
         ];
     }
 

--- a/src/Faker/Extension/VersionExtension.php
+++ b/src/Faker/Extension/VersionExtension.php
@@ -11,7 +11,7 @@ interface VersionExtension extends Extension
      * Get a version number in semantic versioning syntax 2.0.0. (https://semver.org/spec/v2.0.0.html)
      *
      * @param bool $preRelease Pre release parts may be randomly included
-     * @param bool $build Build parts may be randomly included
+     * @param bool $build      Build parts may be randomly included
      *
      * @example 1.0.0
      * @example 1.0.0-alpha.1

--- a/src/Faker/Extension/VersionExtension.php
+++ b/src/Faker/Extension/VersionExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Faker\Extension;
+
+/**
+ * @experimental This interface is experimental and does not fall under our BC promise
+ */
+interface VersionExtension extends Extension
+{
+    /**
+     * Get a version number in semantic versioning syntax 2.0.0. (https://semver.org/spec/v2.0.0.html)
+     *
+     * @param bool $preRelease Pre release parts may be randomly included
+     * @param bool $build Build parts may be randomly included
+     *
+     * @example 1.0.0
+     * @example 1.0.0-alpha.1
+     * @example 1.0.0-alpha.1+b71f04d
+     */
+    public function semver(bool $preRelease = false, bool $build = false): string;
+}

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -830,6 +830,7 @@ class Generator
 
     /**
      * Get a version number in semantic versioning syntax 2.0.0. (https://semver.org/spec/v2.0.0.html)
+     *
      * @param bool $preRelease Pre release parts may be randomly included
      * @param bool $build      Build parts may be randomly included
      *

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -830,7 +830,6 @@ class Generator
 
     /**
      * Get a version number in semantic versioning syntax 2.0.0. (https://semver.org/spec/v2.0.0.html)
-
      * @param bool $preRelease Pre release parts may be randomly included
      * @param bool $build      Build parts may be randomly included
      *

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -557,10 +557,6 @@ use Psr\Container\ContainerInterface;
  * @property string $uuid
  *
  * @method string uuid()
- *
- * @property string $semver
- *
- * @method string semver(bool $preRelease = false, bool $build = false)
  */
 class Generator
 {

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -557,6 +557,10 @@ use Psr\Container\ContainerInterface;
  * @property string $uuid
  *
  * @method string uuid()
+ *
+ * @property string $semver
+ *
+ * @method string semver(bool $preRelease = false, bool $build = false)
  */
 class Generator
 {
@@ -822,6 +826,21 @@ class Generator
             $nbDigits !== null ? (int) $nbDigits : null,
             (bool) $strict
         );
+    }
+
+    /**
+     * Get a version number in semantic versioning syntax 2.0.0. (https://semver.org/spec/v2.0.0.html)
+
+     * @param bool $preRelease Pre release parts may be randomly included
+     * @param bool $build Build parts may be randomly included
+     *
+     * @example 1.0.0
+     * @example 1.0.0-alpha.1
+     * @example 1.0.0-alpha.1+b71f04d
+     */
+    public function semver(bool $preRelease = false, bool $build = false): string
+    {
+        return $this->ext(Extension\VersionExtension::class)->semver($preRelease, $build);
     }
 
     protected function callFormatWithMatches($matches)

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -832,7 +832,7 @@ class Generator
      * Get a version number in semantic versioning syntax 2.0.0. (https://semver.org/spec/v2.0.0.html)
 
      * @param bool $preRelease Pre release parts may be randomly included
-     * @param bool $build Build parts may be randomly included
+     * @param bool $build      Build parts may be randomly included
      *
      * @example 1.0.0
      * @example 1.0.0-alpha.1

--- a/test/Faker/Core/VersionTest.php
+++ b/test/Faker/Core/VersionTest.php
@@ -10,6 +10,7 @@ final class VersionTest extends TestCase
     {
         // taken from: https://semver.org/spec/v2.0.0.html
         $regex = '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/';
+
         for ($i = 0; $i <= 9; ++$i) {
             self::assertMatchesRegularExpression($regex, $this->faker->semver());
             self::assertMatchesRegularExpression($regex, $this->faker->semver(true));

--- a/test/Faker/Core/VersionTest.php
+++ b/test/Faker/Core/VersionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Faker\Test\Core;
+
+use Faker\Test\TestCase;
+
+final class VersionTest extends TestCase
+{
+    public function testSemver(): void
+    {
+        // taken from: https://semver.org/spec/v2.0.0.html
+        $regex = '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/';
+        for ($i = 0; $i <= 9; ++$i) {
+            self::assertMatchesRegularExpression($regex, $this->faker->semver());
+            self::assertMatchesRegularExpression($regex, $this->faker->semver(true));
+            self::assertMatchesRegularExpression($regex, $this->faker->semver(true, true));
+            self::assertMatchesRegularExpression($regex, $this->faker->semver(false, true));
+        }
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

For a long time I wanted some sort of version generator in Faker. #335 reminded me of that idea, so I tried to implement it, but only the semantic versioning syntax for now. (Others may follow later)

- [X] A new feature

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io) (https://github.com/FakerPHP/fakerphp.github.io/pull/47)

### Summary of changes

* Added a new version extension and registered it in the Generator
* Added semver method to version extension and registered it in the Generator
* Added a test case

Some examples from the random generation:
```
9.21.81+1343915
0.62.59+20031002130830
5.94.22+eb3fa72
2.74.43+20021105093641
2.55.51-beta
4.83.31+cc71761
3.81.0
9.13.97+6ad6819
2.63.18
0.49.31-rc.97+20170720134141
```

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
