### PR TITLE
Restore missing union types

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -78,13 +78,13 @@ use Psr\Container\ContainerInterface;
  *
  * @method mixed randomElement($array = ['a', 'b', 'c'])
  *
- * @property int $randomKey
+ * @property int|string|null $randomKey
  *
- * @method int randomKey($array = [])
+ * @method int|string|null randomKey($array = [])
  *
- * @property array $shuffle
+ * @property array|string $shuffle
  *
- * @method array shuffle($arg = '')
+ * @method array|string shuffle($arg = '')
  *
  * @property array $shuffleArray
  *
@@ -366,25 +366,25 @@ use Psr\Container\ContainerInterface;
  *
  * @method string word()
  *
- * @property array $words
+ * @property array|string $words
  *
- * @method array words($nb = 3, $asText = false)
+ * @method array|string words($nb = 3, $asText = false)
  *
  * @property string $sentence
  *
  * @method string sentence($nbWords = 6, $variableNbWords = true)
  *
- * @property array $sentences
+ * @property array|string $sentences
  *
- * @method array sentences($nb = 3, $asText = false)
+ * @method array|string sentences($nb = 3, $asText = false)
  *
  * @property string $paragraph
  *
  * @method string paragraph($nbSentences = 3, $variableNbSentences = true)
  *
- * @property array $paragraphs
+ * @property array|string $paragraphs
  *
- * @method array paragraphs($nb = 3, $asText = false)
+ * @method array|string paragraphs($nb = 3, $asText = false)
  *
  * @property string $text
  *


### PR DESCRIPTION
### What is the reason for this PR?

Fixes #349

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes
As described in the linked issue, this PR restores the Union types that were incorrectly changed in an earlier PR.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
