### PR TITLE
add support for psr/container >= 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "symfony/deprecation-contracts": "^2.2"
     },
     "require-dev": {

--- a/src/Faker/Extension/Container.php
+++ b/src/Faker/Extension/Container.php
@@ -32,6 +32,8 @@ final class Container implements ContainerInterface
     }
 
     /**
+     * @param string $id
+     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      * @throws ContainerException
@@ -39,7 +41,7 @@ final class Container implements ContainerInterface
      *
      * @return Extension
      */
-    public function get(string $id)
+    public function get($id)
     {
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(
@@ -117,9 +119,11 @@ final class Container implements ContainerInterface
     }
 
     /**
+     * @param string $id
+     *
      * @throws \InvalidArgumentException
      */
-    public function has(string $id)
+    public function has($id): bool
     {
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Faker/Extension/Container.php
+++ b/src/Faker/Extension/Container.php
@@ -119,7 +119,7 @@ final class Container implements ContainerInterface
     /**
      * @throws \InvalidArgumentException
      */
-    public function has(string $id): bool
+    public function has(string $id)
     {
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Faker/Extension/Container.php
+++ b/src/Faker/Extension/Container.php
@@ -39,7 +39,7 @@ final class Container implements ContainerInterface
      *
      * @return Extension
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(
@@ -119,7 +119,7 @@ final class Container implements ContainerInterface
     /**
      * @throws \InvalidArgumentException
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(


### PR DESCRIPTION
### What is the reason for this PR?

Make the project compatible with `psr/container` >=2.0

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Updated `Faker\Extension\Container` to be compatible with `psr/container` >= 2.0 .
Tested that static analysis still pass with `psr/container` 1.0 (on PHP 7.4).

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
