### PR TITLE
Update pull request description for branch alias changes

### DIFF
--- a/.github/workflows/branch-alias.yml
+++ b/.github/workflows/branch-alias.yml
@@ -63,4 +63,4 @@ jobs:
           commit-message: Updating branch alias to ${{ steps.find_alias.outputs.alias }}
           title: Update branch alias
           body: |
-            Since we just tagged a new version, we need to update composer.json branch alias. This should not be merged until there are new features, as it would prevent a patch release.
+            Since we just tagged a new version, we need to update composer.json branch alias. This should not be merged until there are new features, as it would prevent patch releases.

--- a/.github/workflows/branch-alias.yml
+++ b/.github/workflows/branch-alias.yml
@@ -63,4 +63,4 @@ jobs:
           commit-message: Updating branch alias to ${{ steps.find_alias.outputs.alias }}
           title: Update branch alias
           body: |
-            Since we just tagged a new version, we need to update composer.json branch alias.
+            Since we just tagged a new version, we need to update composer.json branch alias. This should not be merged until there are new features, as it would prevent a patch release.


### PR DESCRIPTION
### What is the reason for this PR?

As suggested by @GrahamCampbell (https://github.com/FakerPHP/Faker/pull/371#issuecomment-913713389), we should only update the branch alias if there are new feature updates, as it would prevent patch releases. I think it makes sense to update the automatic pull request description accordingly to remind us.