### PR TITLE
Ensure php 8.1 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
         include:
           - operating-system: 'windows-latest'
             php-version: '7.1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,9 +56,16 @@ jobs:
             composer-
 
       - name: Download dependencies
+        if: ${{ '8.1' <> matrix.php-version }}
         run: |
           composer update --no-interaction --no-progress --optimize-autoloader
           ./vendor/bin/simple-phpunit install
+
+      - name: Download dependencies for php 8.1
+        if: ${{ '8.1' == matrix.php-version }}
+        run: |
+          composer update --no-interaction --no-progress --optimize-autoloader
+          SYMFONY_PHPUNIT_VERSION=9.5.5 ./vendor/bin/simple-phpunit install
 
       - name: Run tests with PHPUnit
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,17 +56,12 @@ jobs:
             composer-
 
       - name: Download dependencies
-        if: ${{ '8.1' > matrix.php-version }}
-        run: |
-          composer update --no-interaction --no-progress --optimize-autoloader
-          ./vendor/bin/simple-phpunit install
+        run: composer update --no-interaction --no-progress --optimize-autoloader
 
-      - name: Download dependencies for php 8.1
-        if: ${{ '8.1' <= matrix.php-version }}
-        run: |
-          composer update --no-interaction --no-progress --optimize-autoloader
-          SYMFONY_PHPUNIT_VERSION=9.5.5 ./vendor/bin/simple-phpunit install
+      - name: Run tests
+        if: ${{ '8.1' != matrix.php-version }}
+        run: ./vendor/bin/simple-phpunit
 
-      - name: Run tests with PHPUnit
-        run: |
-          ./vendor/bin/simple-phpunit
+      - name: Run tests for php 8.1
+        if: ${{ '8.1' == matrix.php-version }}
+        run: SYMFONY_PHPUNIT_VERSION=9.5.5 ./vendor/bin/simple-phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,4 +64,4 @@ jobs:
 
       - name: Run tests for php 8.1
         if: ${{ '8.1' == matrix.php-version }}
-        run: SYMFONY_PHPUNIT_VERSION=9.5.5 ./vendor/bin/simple-phpunit
+        run: SYMFONY_PHPUNIT_VERSION=9.5 ./vendor/bin/simple-phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,13 +56,13 @@ jobs:
             composer-
 
       - name: Download dependencies
-        if: ${{ '8.1' <> matrix.php-version }}
+        if: ${{ '8.1' > matrix.php-version }}
         run: |
           composer update --no-interaction --no-progress --optimize-autoloader
           ./vendor/bin/simple-phpunit install
 
       - name: Download dependencies for php 8.1
-        if: ${{ '8.1' == matrix.php-version }}
+        if: ${{ '8.1' <= matrix.php-version }}
         run: |
           composer update --no-interaction --no-progress --optimize-autoloader
           SYMFONY_PHPUNIT_VERSION=9.5.5 ./vendor/bin/simple-phpunit install

--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -148,7 +148,7 @@ class Person extends \Faker\Provider\Person
         }
         $birthDateString = $birthdate->format('ymd');
 
-        switch (strtolower($gender)) {
+        switch (strtolower($gender ?: '')) {
             case static::GENDER_FEMALE:
                 $genderDigit = self::numberBetween(0, 4);
 

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -193,7 +193,7 @@ final class DateTimeTest extends TestCase
         $date = DateTimeProvider::dateTimeBetween($start, $end);
         self::assertInstanceOf('\DateTime', $date);
         self::assertGreaterThanOrEqual(new \DateTime($start), $date);
-        self::assertLessThanOrEqual(new \DateTime($end), $date);
+        self::assertLessThanOrEqual(new \DateTime($end ?: 'now'), $date);
         self::assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
@@ -201,7 +201,7 @@ final class DateTimeTest extends TestCase
     {
         return [
             ['-1 year', false],
-            ['-1 year', ''],
+            ['-1 year', null],
             ['-1 day', '-1 hour'],
             ['-1 day', 'now'],
         ];

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -201,7 +201,7 @@ final class DateTimeTest extends TestCase
     {
         return [
             ['-1 year', false],
-            ['-1 year', null],
+            ['-1 year', ''],
             ['-1 day', '-1 hour'],
             ['-1 day', 'now'],
         ];

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -18,7 +18,7 @@ final class PersonTest extends TestCase
         $sum = -1 * $idNumber % 10;
 
         for ($multiplier = 2; $idNumber > 0; ++$multiplier) {
-            $val = ($idNumber /= 10) % 10;
+            $val = (int) ($idNumber /= 10) % 10;
             $sum += $multiplier * $val;
         }
         self::assertTrue($sum != 0 && $sum % 11 == 0);


### PR DESCRIPTION
### What is the reason for this PR?

`phpspec/prophecy` has released version [`1.14.0`](https://github.com/phpspec/prophecy/releases/tag/1.14.0) today, which now allows to use the latest tagged phpunit under php 8.1.

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

I have added php 8.1 to the test workflow to test new changes with php 8.1 in the future to ensure compatibility. I had to fix some deprecations though in order for phpunit to run successfully.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
