### PR TITLE
[Image provider] Fix bad return when unsuccessful download

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -125,6 +125,11 @@ class Image extends Base
         } elseif (ini_get('allow_url_fopen')) {
             // use remote fopen() via copy()
             $success = copy($url, $filepath);
+
+            if (!$success) {
+                // could not contact the distant URL or HTTP error - fail silently.
+                return false;
+            }
         } else {
             return new \RuntimeException('The image formatter downloads an image from a remote HTTP server. Therefore, it requires that PHP can request remote hosts, either via cURL or fopen()');
         }


### PR DESCRIPTION
return false when remote fopen() is unsuccessful