### PR TITLE
Support Payment Provider for ne_NP

### DIFF
--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -17,6 +17,12 @@ class Payment extends \Faker\Provider\Payment
     protected static $developmentBanks = ['Corporate Development Bank', 'Excel Development Bank', 'Garima Bikas Bank', 'Green Development Bank', 'Jyoti Bikas Bank', 'Kamana Sewa Bikash Bank', 'Karnali Development Bank', 'Lumbini Bikas Bank', 'Mahalaxmi Bikas Bank', 'Miteri Development Bank', 'Muktinath  Bikas Bank', 'Narayani Development Bank', 'Nepal Infrastructure Bank', 'Sahara Bikas Bank', 'Salapa Bikas Bank', 'Saptakoshi Development Bank', 'Shangrila Development Bank', 'Shine Resunga Development Bank', 'Sindhu Bikas Bank'];
 
     /**
+     * List of finance companies sorted in alphabetical order.
+     * @var string[]
+     */
+    protected static $financeCompanies = ['Best Finance Company', 'Capital Merchant Banking & Finance', 'Central Finance', 'Goodwill Finance Company', 'Guheshwori Merchant Banking & Finance', 'Gurkhas Finance', 'ICFC Finance', 'Janaki Finance Company', 'Manjushree Finance', 'Multipurpose Finance Company', 'Nepal Finance', 'Nepal Share Markets', 'Pokhara Finance', 'Progressive Finance', 'Reliance Finance', 'Samriddhi Finance Company', 'Shree Investment Finance Company'];
+
+    /**
      * List of digital wallets sorted in alphabetical order.
      * @var string[]
      */
@@ -38,6 +44,15 @@ class Payment extends \Faker\Provider\Payment
     public function developmentBank(): string
     {
         return static::randomElement(static::$developmentBanks);
+    }
+
+    /**
+     * @return string
+     * @example 'Gurkhas Finance'
+     */
+    public function financeCompany(): string
+    {
+        return static::randomElement(static::$financeCompanies);
     }
 
     /**

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -35,6 +35,13 @@ class Payment extends \Faker\Provider\Payment
     protected static $digitalWallets = ['CellPay', 'CG Pay', 'Chito Paisa', 'DigiPay', 'dPaisa', 'EnetPay', 'eSewa', 'Fonepay', 'GME Pay', 'iCash', 'IME Pay', 'Ipay', 'Khalti', 'Kurakani Pay', 'Lenden', 'Mobalet', 'MOCO', 'Mohar', 'Moru', 'N-Cash', 'Namaste Pay', 'PayTime', 'PayWell', 'PrabhuPAY', 'QPay', 'SajiloPay', 'WePay'];
 
     /**
+     * List of Swift Codes in alphabetical order.
+     * @link https://www.theswiftcodes.com/nepal/
+     * @var string[]
+     */
+    protected static $swiftCodes = ['ADBLNPKA', 'BOKLNPKA', 'CCBNNPKA', 'CIVLNPKA', 'CTZNNPKA', 'EVBLNPKA', 'GLBBNPKA', 'HIMANPKA', 'KMBLNPKA', 'LXBLNPKA', 'MBLNNPKA', 'MBNLNPKA', 'NARBNPKA', 'NBOCNPKA', 'NBOCNPKANRD', 'NEBLNPKA', 'NIBLNPKT', 'NICENPKA', 'NMBBNPKA', 'NPBBNPKA', 'NRBLNPKA', 'NRBLNPKAFED', 'NSBINPKA', 'NSBINPKA001', 'PCBLNPKA', 'PRVUNPKA', 'RBBANPKA', 'SCBLNPKA', 'SIDDNPKA', 'SNMANPKA', 'SRBLNPKA'];
+
+    /**
      * @return string
      * @example 'Agricultural Development Bank'
      */
@@ -78,5 +85,14 @@ class Payment extends \Faker\Provider\Payment
     public function digitalWallet(): string
     {
         return static::randomElement(static::$digitalWallets);
+    }
+
+    /**
+     * @return string
+     * @example 'ADBLNPKA'
+     */
+    public function swiftCode(): string
+    {
+        return static::randomElement(static::$swiftCodes);
     }
 }

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -5,17 +5,32 @@ namespace Faker\Provider\ne_NP;
 class Payment extends \Faker\Provider\Payment
 {
     /**
-     * List of Popular digital wallet providers in Nepal sorted in Alphabetical order.
+     * List of commercial banks sorted in alphabetical order.
      * @var string[]
      */
-    protected static $walletProviders = ['CellPay', 'CGPay', 'dPaisa', 'EnetPay', 'eSewa', 'iCash', 'IME Pay', 'Khalti', 'MoRu', 'PayWell', 'PrabhuPAY', 'QPay'];
+    protected static $commercialBanks = ['Agricultural Development Bank', 'Bank Of Kathmandu', 'Century Commercial Bank', 'Citizens Bank International', 'Civil Bank', 'Everest Bank', 'Global IME Bank', 'Himalayan Bank', 'Kumari Bank', 'Laxmi Bank', 'Machhapuchchhre Bank', 'Mega Bank Nepal', 'Nabil Bank', 'Nepal Bangladesh Bank', 'Nepal Bank', 'Nepal Credit & Commerce Bank', 'Nepal Investment Bank', 'Nepal SBI Bank', 'NIC ASIA Bank', 'NMB Bank', 'Prabhu Bank', 'Prime Commercial Bank', 'Rastriya Banijya Bank', 'Sanima Bank', 'Siddhartha Bank', 'Standard Chartered Bank Nepal', 'Sunrise Bank'];
+
+    /**
+     * List of digital wallets sorted in alphabetical order.
+     * @var string[]
+     */
+    protected static $digitalWallets = ['CellPay', 'CGPay', 'dPaisa', 'EnetPay', 'eSewa', 'iCash', 'IME Pay', 'Khalti', 'MoRu', 'PayWell', 'PrabhuPAY', 'QPay'];
+
+    /**
+     * @return string
+     * @example 'Agricultural Development Bank'
+     */
+    public function commercialBank(): string
+    {
+        return static::randomElement(static::$commercialBanks);
+    }
 
     /**
      * @return string
      * @example 'Khalti'
      */
-    public function walletProvider(): string
+    public function digitalWallet(): string
     {
-        return static::randomElement(static::$walletProviders);
+        return static::randomElement(static::$digitalWallets);
     }
 }

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Faker\Provider\ne_NP;
+
+class Payment extends \Faker\Provider\Payment
+{
+    /**
+     * List of Popular digital wallet providers in Nepal sorted in Alphabetical order.
+     * @var string[]
+     */
+    protected static $walletProviders = ['CellPay', 'CGPay', 'dPaisa', 'EnetPay', 'eSewa', 'iCash', 'IME Pay', 'Khalti', 'MoRu', 'PayWell', 'PrabhuPAY', 'QPay'];
+
+    /**
+     * @return string
+     * @example 'Khalti'
+     */
+    public function walletProvider(): string
+    {
+        return static::randomElement(static::$walletProviders);
+    }
+}

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -95,4 +95,17 @@ class Payment extends \Faker\Provider\Payment
     {
         return static::randomElement(static::$swiftCodes);
     }
+
+    /**
+     * @return string
+     */
+    public function bankAccountNumber(): string
+    {
+        $prefixType = self::randomElement(['alpha', 'zero']);
+        $length = $prefixType === 'alpha' ? self::numberBetween(8, 19) : self::numberBetween(7, 18);
+
+        // format account
+        $format = $prefixType === 'alpha' ? '[A-Z]' : '00';
+        return self::regexify(sprintf('%s[1-9]{%d}', $format, $length));
+    }
 }

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -11,6 +11,12 @@ class Payment extends \Faker\Provider\Payment
     protected static $commercialBanks = ['Agricultural Development Bank', 'Bank Of Kathmandu', 'Century Commercial Bank', 'Citizens Bank International', 'Civil Bank', 'Everest Bank', 'Global IME Bank', 'Himalayan Bank', 'Kumari Bank', 'Laxmi Bank', 'Machhapuchchhre Bank', 'Mega Bank Nepal', 'Nabil Bank', 'Nepal Bangladesh Bank', 'Nepal Bank', 'Nepal Credit & Commerce Bank', 'Nepal Investment Bank', 'Nepal SBI Bank', 'NIC ASIA Bank', 'NMB Bank', 'Prabhu Bank', 'Prime Commercial Bank', 'Rastriya Banijya Bank', 'Sanima Bank', 'Siddhartha Bank', 'Standard Chartered Bank Nepal', 'Sunrise Bank'];
 
     /**
+     * List of development banks sorted in alphabetical order.
+     * @var string[]
+     */
+    protected static $developmentBanks = ['Corporate Development Bank', 'Excel Development Bank', 'Garima Bikas Bank', 'Green Development Bank', 'Jyoti Bikas Bank', 'Kamana Sewa Bikash Bank', 'Karnali Development Bank', 'Lumbini Bikas Bank', 'Mahalaxmi Bikas Bank', 'Miteri Development Bank', 'Muktinath  Bikas Bank', 'Narayani Development Bank', 'Nepal Infrastructure Bank', 'Sahara Bikas Bank', 'Salapa Bikas Bank', 'Saptakoshi Development Bank', 'Shangrila Development Bank', 'Shine Resunga Development Bank', 'Sindhu Bikas Bank'];
+
+    /**
      * List of digital wallets sorted in alphabetical order.
      * @var string[]
      */
@@ -23,6 +29,15 @@ class Payment extends \Faker\Provider\Payment
     public function commercialBank(): string
     {
         return static::randomElement(static::$commercialBanks);
+    }
+
+    /**
+     * @return string
+     * @example 'Nepal Infrastructure Bank'
+     */
+    public function developmentBank(): string
+    {
+        return static::randomElement(static::$developmentBanks);
     }
 
     /**

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -103,8 +103,8 @@ class Payment extends \Faker\Provider\Payment
      */
     public function bankAccountNumber(): string
     {
-        $prefixType = self::randomElement(['alpha', 'zero']);
-        $format = $prefixType === 'alpha' ? '[A-Z][1-9]{8,19}' : '[0]{2}[1-9]{7,18}';
+        $alphaPrefix = self::randomElement([true, false]);
+        $format = $alphaPrefix ? '[A-Z][1-9]{8,19}' : '[0]{2}[1-9]{7,18}';
 
         return static::regexify($format);
     }

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -7,37 +7,211 @@ class Payment extends \Faker\Provider\Payment
     /**
      * List of commercial banks sorted in alphabetical order.
      *
+     * @see https://en.wikipedia.org/wiki/List_of_banks_in_Nepal
+     *
      * @var string[]
      */
-    protected static $commercialBanks = ['Agricultural Development Bank', 'Bank Of Kathmandu', 'Century Commercial Bank', 'Citizens Bank International', 'Civil Bank', 'Everest Bank', 'Global IME Bank', 'Himalayan Bank', 'Kumari Bank', 'Laxmi Bank', 'Machhapuchchhre Bank', 'Mega Bank Nepal', 'Nabil Bank', 'Nepal Bangladesh Bank', 'Nepal Bank', 'Nepal Credit & Commerce Bank', 'Nepal Investment Bank', 'Nepal SBI Bank', 'NIC ASIA Bank', 'NMB Bank', 'Prabhu Bank', 'Prime Commercial Bank', 'Rastriya Banijya Bank', 'Sanima Bank', 'Siddhartha Bank', 'Standard Chartered Bank Nepal', 'Sunrise Bank'];
+    protected static $commercialBanks = [
+        'Agricultural Development Bank',
+        'Bank Of Kathmandu',
+        'Century Commercial Bank',
+        'Citizens Bank International',
+        'Civil Bank',
+        'Everest Bank',
+        'Global IME Bank',
+        'Himalayan Bank',
+        'Kumari Bank',
+        'Laxmi Bank',
+        'Machhapuchchhre Bank',
+        'Mega Bank Nepal',
+        'Nabil Bank',
+        'Nepal Bangladesh Bank',
+        'Nepal Bank',
+        'Nepal Credit & Commerce Bank',
+        'Nepal Investment Bank',
+        'Nepal SBI Bank',
+        'NIC ASIA Bank',
+        'NMB Bank',
+        'Prabhu Bank',
+        'Prime Commercial Bank',
+        'Rastriya Banijya Bank',
+        'Sanima Bank',
+        'Siddhartha Bank',
+        'Standard Chartered Bank Nepal',
+        'Sunrise Bank',
+    ];
 
     /**
      * List of development banks sorted in alphabetical order.
      *
+     * @see https://en.wikipedia.org/wiki/List_of_banks_in_Nepal
+     *
      * @var string[]
      */
-    protected static $developmentBanks = ['Corporate Development Bank', 'Excel Development Bank', 'Garima Bikas Bank', 'Green Development Bank', 'Jyoti Bikas Bank', 'Kamana Sewa Bikash Bank', 'Karnali Development Bank', 'Lumbini Bikas Bank', 'Mahalaxmi Bikas Bank', 'Miteri Development Bank', 'Muktinath  Bikas Bank', 'Narayani Development Bank', 'Nepal Infrastructure Bank', 'Sahara Bikas Bank', 'Salapa Bikas Bank', 'Saptakoshi Development Bank', 'Shangrila Development Bank', 'Shine Resunga Development Bank', 'Sindhu Bikas Bank'];
+    protected static $developmentBanks = [
+        'Corporate Development Bank',
+        'Excel Development Bank',
+        'Garima Bikas Bank',
+        'Green Development Bank',
+        'Jyoti Bikas Bank',
+        'Kamana Sewa Bikash Bank',
+        'Karnali Development Bank',
+        'Lumbini Bikas Bank',
+        'Mahalaxmi Bikas Bank',
+        'Miteri Development Bank',
+        'Muktinath  Bikas Bank',
+        'Narayani Development Bank',
+        'Nepal Infrastructure Bank',
+        'Sahara Bikas Bank',
+        'Salapa Bikas Bank',
+        'Saptakoshi Development Bank',
+        'Shangrila Development Bank',
+        'Shine Resunga Development Bank',
+        'Sindhu Bikas Bank',
+    ];
 
     /**
      * List of finance companies sorted in alphabetical order.
      *
+     * @see https://en.wikipedia.org/wiki/List_of_banks_in_Nepal
+     *
      * @var string[]
      */
-    protected static $financeCompanies = ['Best Finance Company', 'Capital Merchant Banking & Finance', 'Central Finance', 'Goodwill Finance Company', 'Guheshwori Merchant Banking & Finance', 'Gurkhas Finance', 'ICFC Finance', 'Janaki Finance Company', 'Manjushree Finance', 'Multipurpose Finance Company', 'Nepal Finance', 'Nepal Share Markets', 'Pokhara Finance', 'Progressive Finance', 'Reliance Finance', 'Samriddhi Finance Company', 'Shree Investment Finance Company'];
+    protected static $financeCompanies = [
+        'Best Finance Company',
+        'Capital Merchant Banking & Finance',
+        'Central Finance',
+        'Goodwill Finance Company',
+        'Guheshwori Merchant Banking & Finance',
+        'Gurkhas Finance',
+        'ICFC Finance',
+        'Janaki Finance Company',
+        'Manjushree Finance',
+        'Multipurpose Finance Company',
+        'Nepal Finance',
+        'Nepal Share Markets',
+        'Pokhara Finance',
+        'Progressive Finance',
+        'Reliance Finance',
+        'Samriddhi Finance Company',
+        'Shree Investment Finance Company',
+    ];
 
     /**
      * List of microfinance companies sorted in alphabetical order.
      *
+     * @see https://en.wikipedia.org/wiki/List_of_banks_in_Nepal
+     *
      * @var string[]
      */
-    protected static $microFinances = ['Aatmanirbhar', 'Adarsha', 'Adhikhola', 'Arambha Chautari', 'Asha', 'Aviyan', 'BPW', 'Buddha Jyoti', 'Chhimek', 'Civil', 'CYC Nepal', 'Deprosc', 'Deurali', 'Dhaulagiri', 'First Microfinance', 'Forward Microfinance', 'Ganapati', 'Ghodighoda', 'Global IME', 'Grameen Bikas', 'Gurans', 'Infinity', 'Jalpa Samudayik', 'Janautthan Samudayik', 'Jeevan Bikas', 'Kalika', 'Khaptad', 'Kisan', 'Laxmi', 'Mahila', 'Mahuli', 'Manakamana Smart', 'Manushi', 'Meromicrofinance', 'Mirmire', 'Mithila', 'NADEP', 'National Microfinance', 'Naya Sarathi', 'Nepal Sewa', 'Nerude', 'NESDO Samriddha', 'NIC Asia', 'Nirdhan Utthan', 'NMB', 'Rastra Utthan', 'RMDC', 'RSDC', 'Sabaiko', 'Sadhana', 'Samaj', 'Samata Gharelu', 'Samudayik', 'Sana Kisan Bikas', 'Shrijanshil', 'Summit', 'Super', 'Support', 'Suryodaya', 'Swabalamban', 'Swabhiman', 'Swastik', 'Sworojagar', 'Unique Nepal', 'Unnati Sahakarya', 'Upakar', 'Vijaya', 'WEAN', 'Womi'];
+    protected static $microFinances = [
+        'Aatmanirbhar',
+        'Adarsha',
+        'Adhikhola',
+        'Arambha Chautari',
+        'Asha',
+        'Aviyan',
+        'BPW',
+        'Buddha Jyoti',
+        'Chhimek',
+        'Civil',
+        'CYC Nepal',
+        'Deprosc',
+        'Deurali',
+        'Dhaulagiri',
+        'First Microfinance',
+        'Forward Microfinance',
+        'Ganapati',
+        'Ghodighoda',
+        'Global IME',
+        'Grameen Bikas',
+        'Gurans',
+        'Infinity',
+        'Jalpa Samudayik',
+        'Janautthan Samudayik',
+        'Jeevan Bikas',
+        'Kalika',
+        'Khaptad',
+        'Kisan',
+        'Laxmi',
+        'Mahila',
+        'Mahuli',
+        'Manakamana Smart',
+        'Manushi',
+        'Meromicrofinance',
+        'Mirmire',
+        'Mithila',
+        'NADEP',
+        'National Microfinance',
+        'Naya Sarathi',
+        'Nepal Sewa',
+        'Nerude',
+        'NESDO Samriddha',
+        'NIC Asia',
+        'Nirdhan Utthan',
+        'NMB',
+        'Rastra Utthan',
+        'RMDC',
+        'RSDC',
+        'Sabaiko',
+        'Sadhana',
+        'Samaj',
+        'Samata Gharelu',
+        'Samudayik',
+        'Sana Kisan Bikas',
+        'Shrijanshil',
+        'Summit',
+        'Super',
+        'Support',
+        'Suryodaya',
+        'Swabalamban',
+        'Swabhiman',
+        'Swastik',
+        'Sworojagar',
+        'Unique Nepal',
+        'Unnati Sahakarya',
+        'Upakar',
+        'Vijaya',
+        'WEAN',
+        'Womi',
+    ];
 
     /**
      * List of digital wallets sorted in alphabetical order.
      *
+     * @see https://www.nrb.org.np/bank-list/
+     *
      * @var string[]
      */
-    protected static $digitalWallets = ['CellPay', 'CG Pay', 'Chito Paisa', 'DigiPay', 'dPaisa', 'EnetPay', 'eSewa', 'Fonepay', 'GME Pay', 'iCash', 'IME Pay', 'Ipay', 'Khalti', 'Kurakani Pay', 'Lenden', 'Mobalet', 'MOCO', 'Mohar', 'Moru', 'N-Cash', 'Namaste Pay', 'PayTime', 'PayWell', 'PrabhuPAY', 'QPay', 'SajiloPay', 'WePay'];
+    protected static $digitalWallets = [
+        'CellPay',
+        'CG Pay',
+        'Chito Paisa',
+        'DigiPay',
+        'dPaisa',
+        'EnetPay',
+        'eSewa',
+        'Fonepay',
+        'GME Pay',
+        'iCash',
+        'IME Pay',
+        'Ipay',
+        'Khalti',
+        'Kurakani Pay',
+        'Lenden',
+        'Mobalet',
+        'MOCO',
+        'Mohar',
+        'Moru',
+        'N-Cash',
+        'Namaste Pay',
+        'PayTime',
+        'PayWell',
+        'PrabhuPAY',
+        'QPay',
+        'SajiloPay',
+        'WePay',
+    ];
 
     /**
      * List of Swift Codes in alphabetical order.
@@ -46,7 +220,39 @@ class Payment extends \Faker\Provider\Payment
      *
      * @var string[]
      */
-    protected static $swiftCodes = ['ADBLNPKA', 'BOKLNPKA', 'CCBNNPKA', 'CIVLNPKA', 'CTZNNPKA', 'EVBLNPKA', 'GLBBNPKA', 'HIMANPKA', 'KMBLNPKA', 'LXBLNPKA', 'MBLNNPKA', 'MBNLNPKA', 'NARBNPKA', 'NBOCNPKA', 'NBOCNPKANRD', 'NEBLNPKA', 'NIBLNPKT', 'NICENPKA', 'NMBBNPKA', 'NPBBNPKA', 'NRBLNPKA', 'NRBLNPKAFED', 'NSBINPKA', 'NSBINPKA001', 'PCBLNPKA', 'PRVUNPKA', 'RBBANPKA', 'SCBLNPKA', 'SIDDNPKA', 'SNMANPKA', 'SRBLNPKA'];
+    protected static $swiftCodes = [
+        'ADBLNPKA',
+        'BOKLNPKA',
+        'CCBNNPKA',
+        'CIVLNPKA',
+        'CTZNNPKA',
+        'EVBLNPKA',
+        'GLBBNPKA',
+        'HIMANPKA',
+        'KMBLNPKA',
+        'LXBLNPKA',
+        'MBLNNPKA',
+        'MBNLNPKA',
+        'NARBNPKA',
+        'NBOCNPKA',
+        'NBOCNPKANRD',
+        'NEBLNPKA',
+        'NIBLNPKT',
+        'NICENPKA',
+        'NMBBNPKA',
+        'NPBBNPKA',
+        'NRBLNPKA',
+        'NRBLNPKAFED',
+        'NSBINPKA',
+        'NSBINPKA001',
+        'PCBLNPKA',
+        'PRVUNPKA',
+        'RBBANPKA',
+        'SCBLNPKA',
+        'SIDDNPKA',
+        'SNMANPKA',
+        'SRBLNPKA',
+    ];
 
     /**
      * @example 'Agricultural Development Bank'

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -32,7 +32,7 @@ class Payment extends \Faker\Provider\Payment
      * List of digital wallets sorted in alphabetical order.
      * @var string[]
      */
-    protected static $digitalWallets = ['CellPay', 'CGPay', 'dPaisa', 'EnetPay', 'eSewa', 'iCash', 'IME Pay', 'Khalti', 'MoRu', 'PayWell', 'PrabhuPAY', 'QPay'];
+    protected static $digitalWallets = ['CellPay', 'CG Pay', 'Chito Paisa', 'DigiPay', 'dPaisa', 'EnetPay', 'eSewa', 'Fonepay', 'GME Pay', 'iCash', 'IME Pay', 'Ipay', 'Khalti', 'Kurakani Pay', 'Lenden', 'Mobalet', 'MOCO', 'Mohar', 'Moru', 'N-Cash', 'Namaste Pay', 'PayTime', 'PayWell', 'PrabhuPAY', 'QPay', 'SajiloPay', 'WePay'];
 
     /**
      * @return string

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -309,8 +309,7 @@ class Payment extends \Faker\Provider\Payment
      */
     public function bankAccountNumber(): string
     {
-        $alphaPrefix = self::randomElement([true, false]);
-        $format = $alphaPrefix ? '[A-Z][1-9]{8,19}' : '[0]{2}[1-9]{7,18}';
+        $format = self::randomElement(['[A-Z][1-9]{8,19}', '[0]{2}[1-9]{7,18}']);
 
         return static::regexify($format);
     }

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -6,43 +6,49 @@ class Payment extends \Faker\Provider\Payment
 {
     /**
      * List of commercial banks sorted in alphabetical order.
+     *
      * @var string[]
      */
     protected static $commercialBanks = ['Agricultural Development Bank', 'Bank Of Kathmandu', 'Century Commercial Bank', 'Citizens Bank International', 'Civil Bank', 'Everest Bank', 'Global IME Bank', 'Himalayan Bank', 'Kumari Bank', 'Laxmi Bank', 'Machhapuchchhre Bank', 'Mega Bank Nepal', 'Nabil Bank', 'Nepal Bangladesh Bank', 'Nepal Bank', 'Nepal Credit & Commerce Bank', 'Nepal Investment Bank', 'Nepal SBI Bank', 'NIC ASIA Bank', 'NMB Bank', 'Prabhu Bank', 'Prime Commercial Bank', 'Rastriya Banijya Bank', 'Sanima Bank', 'Siddhartha Bank', 'Standard Chartered Bank Nepal', 'Sunrise Bank'];
 
     /**
      * List of development banks sorted in alphabetical order.
+     *
      * @var string[]
      */
     protected static $developmentBanks = ['Corporate Development Bank', 'Excel Development Bank', 'Garima Bikas Bank', 'Green Development Bank', 'Jyoti Bikas Bank', 'Kamana Sewa Bikash Bank', 'Karnali Development Bank', 'Lumbini Bikas Bank', 'Mahalaxmi Bikas Bank', 'Miteri Development Bank', 'Muktinath  Bikas Bank', 'Narayani Development Bank', 'Nepal Infrastructure Bank', 'Sahara Bikas Bank', 'Salapa Bikas Bank', 'Saptakoshi Development Bank', 'Shangrila Development Bank', 'Shine Resunga Development Bank', 'Sindhu Bikas Bank'];
 
     /**
      * List of finance companies sorted in alphabetical order.
+     *
      * @var string[]
      */
     protected static $financeCompanies = ['Best Finance Company', 'Capital Merchant Banking & Finance', 'Central Finance', 'Goodwill Finance Company', 'Guheshwori Merchant Banking & Finance', 'Gurkhas Finance', 'ICFC Finance', 'Janaki Finance Company', 'Manjushree Finance', 'Multipurpose Finance Company', 'Nepal Finance', 'Nepal Share Markets', 'Pokhara Finance', 'Progressive Finance', 'Reliance Finance', 'Samriddhi Finance Company', 'Shree Investment Finance Company'];
 
     /**
      * List of microfinance companies sorted in alphabetical order.
+     *
      * @var string[]
      */
     protected static $microFinances = ['Aatmanirbhar', 'Adarsha', 'Adhikhola', 'Arambha Chautari', 'Asha', 'Aviyan', 'BPW', 'Buddha Jyoti', 'Chhimek', 'Civil', 'CYC Nepal', 'Deprosc', 'Deurali', 'Dhaulagiri', 'First Microfinance', 'Forward Microfinance', 'Ganapati', 'Ghodighoda', 'Global IME', 'Grameen Bikas', 'Gurans', 'Infinity', 'Jalpa Samudayik', 'Janautthan Samudayik', 'Jeevan Bikas', 'Kalika', 'Khaptad', 'Kisan', 'Laxmi', 'Mahila', 'Mahuli', 'Manakamana Smart', 'Manushi', 'Meromicrofinance', 'Mirmire', 'Mithila', 'NADEP', 'National Microfinance', 'Naya Sarathi', 'Nepal Sewa', 'Nerude', 'NESDO Samriddha', 'NIC Asia', 'Nirdhan Utthan', 'NMB', 'Rastra Utthan', 'RMDC', 'RSDC', 'Sabaiko', 'Sadhana', 'Samaj', 'Samata Gharelu', 'Samudayik', 'Sana Kisan Bikas', 'Shrijanshil', 'Summit', 'Super', 'Support', 'Suryodaya', 'Swabalamban', 'Swabhiman', 'Swastik', 'Sworojagar', 'Unique Nepal', 'Unnati Sahakarya', 'Upakar', 'Vijaya', 'WEAN', 'Womi'];
 
     /**
      * List of digital wallets sorted in alphabetical order.
+     *
      * @var string[]
      */
     protected static $digitalWallets = ['CellPay', 'CG Pay', 'Chito Paisa', 'DigiPay', 'dPaisa', 'EnetPay', 'eSewa', 'Fonepay', 'GME Pay', 'iCash', 'IME Pay', 'Ipay', 'Khalti', 'Kurakani Pay', 'Lenden', 'Mobalet', 'MOCO', 'Mohar', 'Moru', 'N-Cash', 'Namaste Pay', 'PayTime', 'PayWell', 'PrabhuPAY', 'QPay', 'SajiloPay', 'WePay'];
 
     /**
      * List of Swift Codes in alphabetical order.
-     * @link https://www.theswiftcodes.com/nepal/
+     *
+     * @see https://www.theswiftcodes.com/nepal/
+     *
      * @var string[]
      */
     protected static $swiftCodes = ['ADBLNPKA', 'BOKLNPKA', 'CCBNNPKA', 'CIVLNPKA', 'CTZNNPKA', 'EVBLNPKA', 'GLBBNPKA', 'HIMANPKA', 'KMBLNPKA', 'LXBLNPKA', 'MBLNNPKA', 'MBNLNPKA', 'NARBNPKA', 'NBOCNPKA', 'NBOCNPKANRD', 'NEBLNPKA', 'NIBLNPKT', 'NICENPKA', 'NMBBNPKA', 'NPBBNPKA', 'NRBLNPKA', 'NRBLNPKAFED', 'NSBINPKA', 'NSBINPKA001', 'PCBLNPKA', 'PRVUNPKA', 'RBBANPKA', 'SCBLNPKA', 'SIDDNPKA', 'SNMANPKA', 'SRBLNPKA'];
 
     /**
-     * @return string
      * @example 'Agricultural Development Bank'
      */
     public function commercialBank(): string
@@ -51,7 +57,6 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * @return string
      * @example 'Nepal Infrastructure Bank'
      */
     public function developmentBank(): string
@@ -60,7 +65,6 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * @return string
      * @example 'Gurkhas Finance'
      */
     public function financeCompany(): string
@@ -69,17 +73,16 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * @return string
      * @example 'Adarsha Laghubitta Bittiya Sanstha'
      */
     public function microFinance(): string
     {
         $suffix = ' Laghubitta Bittiya Sanstha';
+
         return static::randomElement(static::$microFinances) . $suffix;
     }
 
     /**
-     * @return string
      * @example 'Khalti'
      */
     public function digitalWallet(): string
@@ -88,7 +91,6 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * @return string
      * @example 'ADBLNPKA'
      */
     public function swiftCode(): string
@@ -97,13 +99,13 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * @return string
      * @example '00454689832792' or 'S49646367883667'
      */
     public function bankAccountNumber(): string
     {
         $prefixType = self::randomElement(['alpha', 'zero']);
         $format = $prefixType === 'alpha' ? '[A-Z][1-9]{8,19}' : '[0]{2}[1-9]{7,18}';
+
         return static::regexify($format);
     }
 }

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -23,6 +23,12 @@ class Payment extends \Faker\Provider\Payment
     protected static $financeCompanies = ['Best Finance Company', 'Capital Merchant Banking & Finance', 'Central Finance', 'Goodwill Finance Company', 'Guheshwori Merchant Banking & Finance', 'Gurkhas Finance', 'ICFC Finance', 'Janaki Finance Company', 'Manjushree Finance', 'Multipurpose Finance Company', 'Nepal Finance', 'Nepal Share Markets', 'Pokhara Finance', 'Progressive Finance', 'Reliance Finance', 'Samriddhi Finance Company', 'Shree Investment Finance Company'];
 
     /**
+     * List of microfinance companies sorted in alphabetical order.
+     * @var string[]
+     */
+    protected static $microFinances = ['Aatmanirbhar', 'Adarsha', 'Adhikhola', 'Arambha Chautari', 'Asha', 'Aviyan', 'BPW', 'Buddha Jyoti', 'Chhimek', 'Civil', 'CYC Nepal', 'Deprosc', 'Deurali', 'Dhaulagiri', 'First Microfinance', 'Forward Microfinance', 'Ganapati', 'Ghodighoda', 'Global IME', 'Grameen Bikas', 'Gurans', 'Infinity', 'Jalpa Samudayik', 'Janautthan Samudayik', 'Jeevan Bikas', 'Kalika', 'Khaptad', 'Kisan', 'Laxmi', 'Mahila', 'Mahuli', 'Manakamana Smart', 'Manushi', 'Meromicrofinance', 'Mirmire', 'Mithila', 'NADEP', 'National Microfinance', 'Naya Sarathi', 'Nepal Sewa', 'Nerude', 'NESDO Samriddha', 'NIC Asia', 'Nirdhan Utthan', 'NMB', 'Rastra Utthan', 'RMDC', 'RSDC', 'Sabaiko', 'Sadhana', 'Samaj', 'Samata Gharelu', 'Samudayik', 'Sana Kisan Bikas', 'Shrijanshil', 'Summit', 'Super', 'Support', 'Suryodaya', 'Swabalamban', 'Swabhiman', 'Swastik', 'Sworojagar', 'Unique Nepal', 'Unnati Sahakarya', 'Upakar', 'Vijaya', 'WEAN', 'Womi'];
+
+    /**
      * List of digital wallets sorted in alphabetical order.
      * @var string[]
      */
@@ -53,6 +59,16 @@ class Payment extends \Faker\Provider\Payment
     public function financeCompany(): string
     {
         return static::randomElement(static::$financeCompanies);
+    }
+
+    /**
+     * @return string
+     * @example 'Adarsha Laghubitta Bittiya Sanstha'
+     */
+    public function microFinance(): string
+    {
+        $suffix = ' Laghubitta Bittiya Sanstha';
+        return static::randomElement(static::$microFinances) . $suffix;
     }
 
     /**

--- a/src/Faker/Provider/ne_NP/Payment.php
+++ b/src/Faker/Provider/ne_NP/Payment.php
@@ -98,14 +98,12 @@ class Payment extends \Faker\Provider\Payment
 
     /**
      * @return string
+     * @example '00454689832792' or 'S49646367883667'
      */
     public function bankAccountNumber(): string
     {
         $prefixType = self::randomElement(['alpha', 'zero']);
-        $length = $prefixType === 'alpha' ? self::numberBetween(8, 19) : self::numberBetween(7, 18);
-
-        // format account
-        $format = $prefixType === 'alpha' ? '[A-Z]' : '00';
-        return self::regexify(sprintf('%s[1-9]{%d}', $format, $length));
+        $format = $prefixType === 'alpha' ? '[A-Z][1-9]{8,19}' : '[0]{2}[1-9]{7,18}';
+        return static::regexify($format);
     }
 }

--- a/test/Faker/Provider/ne_NP/PaymentTest.php
+++ b/test/Faker/Provider/ne_NP/PaymentTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Faker\Test\Provider\ne_NP;
+
+use Faker\Provider\ne_NP\Payment;
+use Faker\Test\TestCase;
+
+final class PaymentTest extends TestCase
+{
+    public function testCommercialBank(): void
+    {
+        $str = $this->faker->commercialBank();
+        self::assertIsString($str);
+    }
+
+    public function testDevelopmentBank(): void
+    {
+        $str = $this->faker->developmentBank();
+        self::assertIsString($str);
+    }
+
+    public function testFinanceCompany(): void
+    {
+        $str = $this->faker->financeCompany();
+        self::assertIsString($str);
+    }
+
+    public function testMicroFinance(): void
+    {
+        $str = $this->faker->microFinance();
+        self::assertIsString($str);
+        self::assertStringContainsString('Laghubitta', $str);
+    }
+
+    public function testDigitalWallet(): void
+    {
+        $str = $this->faker->digitalWallet();
+        self::assertIsString($str);
+    }
+
+    public function testSwiftCode(): void
+    {
+        $str = $this->faker->swiftCode();
+        self::assertIsString($str);
+    }
+
+    public function testBankAccountNumber(): void
+    {
+        $str = $this->faker->bankAccountNumber();
+        self::assertIsString($str);
+        self::assertGreaterThanOrEqual(9, strlen($str));
+        self::assertLessThanOrEqual(20, strlen($str));
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Payment($this->faker);
+    }
+}

--- a/test/Faker/Provider/ne_NP/PaymentTest.php
+++ b/test/Faker/Provider/ne_NP/PaymentTest.php
@@ -11,18 +11,34 @@ final class PaymentTest extends TestCase
     {
         $str = $this->faker->commercialBank();
         self::assertIsString($str);
+
+        $this->faker->seed(1);
+
+        $strNext = $this->faker->commercialBank();
+        self::assertSame($str, $strNext);
     }
 
     public function testDevelopmentBank(): void
     {
         $str = $this->faker->developmentBank();
         self::assertIsString($str);
+
+        $this->faker->seed(1);
+
+        $strNext = $this->faker->developmentBank();
+        self::assertSame($str, $strNext);
+        echo " $str -> $strNext";
     }
 
     public function testFinanceCompany(): void
     {
         $str = $this->faker->financeCompany();
         self::assertIsString($str);
+
+        $this->faker->seed(1);
+
+        $strNext = $this->faker->financeCompany();
+        self::assertSame($str, $strNext);
     }
 
     public function testMicroFinance(): void
@@ -30,18 +46,33 @@ final class PaymentTest extends TestCase
         $str = $this->faker->microFinance();
         self::assertIsString($str);
         self::assertStringContainsString('Laghubitta', $str);
+
+        $this->faker->seed(1);
+
+        $strNext = $this->faker->microFinance();
+        self::assertSame($str, $strNext);
     }
 
     public function testDigitalWallet(): void
     {
         $str = $this->faker->digitalWallet();
         self::assertIsString($str);
+
+        $this->faker->seed(1);
+
+        $strNext = $this->faker->digitalWallet();
+        self::assertSame($str, $strNext);
     }
 
     public function testSwiftCode(): void
     {
         $str = $this->faker->swiftCode();
         self::assertIsString($str);
+
+        $this->faker->seed(1);
+
+        $strNext = $this->faker->swiftCode();
+        self::assertSame($str, $strNext);
     }
 
     public function testBankAccountNumber(): void
@@ -50,6 +81,11 @@ final class PaymentTest extends TestCase
         self::assertIsString($str);
         self::assertGreaterThanOrEqual(9, strlen($str));
         self::assertLessThanOrEqual(20, strlen($str));
+
+        $this->faker->seed(1);
+
+        $strNext = $this->faker->bankAccountNumber();
+        self::assertSame($str, $strNext);
     }
 
     protected function getProviders(): iterable

--- a/test/Faker/Provider/ne_NP/PaymentTest.php
+++ b/test/Faker/Provider/ne_NP/PaymentTest.php
@@ -27,7 +27,6 @@ final class PaymentTest extends TestCase
 
         $strNext = $this->faker->developmentBank();
         self::assertSame($str, $strNext);
-        echo " $str -> $strNext";
     }
 
     public function testFinanceCompany(): void


### PR DESCRIPTION
### What is the reason for this PR?

This PR supports the `Payment` provider for the `ne_NP` locale.

- [x] Get financial institutions name
- [x] Get Bank Swift Code
- [x] Get bank account number

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

The `Payment.php` and `PaymentTest.php` are new files for the `ne_NP` locale.

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by the maintainer
