### PR TITLE
Proper format for E.164 numbers

### DIFF
--- a/src/Faker/Provider/en_US/PhoneNumber.php
+++ b/src/Faker/Provider/en_US/PhoneNumber.php
@@ -59,7 +59,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     ];
 
     protected static $e164Formats = [
-        '+1{{areaCode}}#######',
+        '+1{{areaCode}}{{exchangeCode}}####',
     ];
 
     /**


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue (resolve #332)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [n/a] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->
Ensure the `e164PhoneNumber` formatter in en-US locale follows the same rules as other formatters and doesn't generate invalid phone numbers.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
