### PR TITLE
updates to en_za/internet

### DIFF
--- a/src/Faker/Provider/en_ZA/Internet.php
+++ b/src/Faker/Provider/en_ZA/Internet.php
@@ -10,9 +10,9 @@ class Internet extends \Faker\Provider\Internet
      * @see https://en.wikipedia.org/wiki/.za
      */
     protected static $tld = [
-        'co.za', 'co.za', 'co.za', 'co.za', 'com', 'com', 'net', 'gov.za', 'ac.za', 'edu.za', 'law.za', 'mil.za',
-        'net.za', 'nom.za', 'org.za', 'school.za', 'ecape.school.za', 'fs.school.za', 'gp.school.za', 'kzn.school.za',
-        'mpm.za', 'ncape.school.za', 'lp.school.za', 'nw.school.za', 'wcape.school.za', 'web.za', 'agric.za', 'nis.za',
-        'grondar.za',
+        'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'com', 'com', 'com', 'net', 'gov.za',
+        'ac.za', 'edu.za', 'law.za', 'mil.za', 'net.za', 'nom.za', 'org.za', 'school.za', 'ecape.school.za',
+        'fs.school.za', 'gp.school.za', 'kzn.school.za', 'mpm.za', 'ncape.school.za', 'lp.school.za', 'nw.school.za',
+        'wcape.school.za', 'web.za', 'agric.za', 'nis.za', 'grondar.za', 'joburg', 'capetown', 'durban', 'africa',
     ];
 }

--- a/src/Faker/Provider/en_ZA/Internet.php
+++ b/src/Faker/Provider/en_ZA/Internet.php
@@ -7,12 +7,17 @@ class Internet extends \Faker\Provider\Internet
     protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'webmail.co.za', 'vodamail.co.za'];
 
     /**
+     * An array of South African TLDs.
+     *
      * @see https://en.wikipedia.org/wiki/.za
+     * @see https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#Africa
+     *
+     * @var array
      */
     protected static $tld = [
-        'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'co.za', 'com', 'com', 'com', 'net', 'gov.za',
-        'ac.za', 'edu.za', 'law.za', 'mil.za', 'net.za', 'nom.za', 'org.za', 'school.za', 'ecape.school.za',
-        'fs.school.za', 'gp.school.za', 'kzn.school.za', 'mpm.za', 'ncape.school.za', 'lp.school.za', 'nw.school.za',
-        'wcape.school.za', 'web.za', 'agric.za', 'nis.za', 'grondar.za', 'joburg', 'capetown', 'durban', 'africa',
+        'ac.za', 'africa', 'agric.za', 'capetown', 'co.za', 'co.za', 'co.za', 'co.za', 'com', 'com',
+        'durban', 'ecape.school.za', 'edu.za', 'fs.school.za', 'gov.za', 'gp.school.za', 'grondar.za',
+        'joburg', 'kzn.school.za', 'law.za', 'lp.school.za', 'mil.za', 'mpm.za', 'ncape.school.za',
+        'net.za', 'net', 'nis.za', 'nom.za', 'nw.school.za', 'org.za', 'school.za', 'wcape.school.za', 'web.za',
     ];
 }


### PR DESCRIPTION
### What is the reason for this PR?

Add data to the ZA Internet provider namespace (TLDs).

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] ~~New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)~~ (not applicable)

### Summary of changes

This adds gTLDs, the commonly used .africa, and increases the likelihood of a .co.za or .com being used.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
