### PR TITLE
Reset formatters when adding a new provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.17.0..main)
 
+- Reset formatters when adding a new provider (#366)
+
 ## [2021-12-05, v1.17.0](https://github.com/FakerPHP/Faker/compare/v1.16.0..v1.17.0)
 
 - Partial PHP 8.1 compatibility (#373)

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -601,6 +601,8 @@ class Generator
     public function addProvider($provider)
     {
         array_unshift($this->providers, $provider);
+
+        $this->formatters = [];
     }
 
     public function getProviders()

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -87,6 +87,24 @@ final class GeneratorTest extends TestCase
         self::assertEquals($expected, $this->faker->getFormatter('fooFormatter'));
     }
 
+    public function testAddProviderClearsPreviousFormatters(): void
+    {
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
+
+        $this->faker->fooFormatter();
+
+        $newProvider = new Fixture\Provider\BarProvider();
+
+        $this->faker->addProvider($newProvider);
+
+        $expected = [
+            $newProvider,
+            'fooFormatter',
+        ];
+
+        self::assertSame($expected, $this->faker->getFormatter('fooFormatter'));
+    }
+
     public function testGetFormatterThrowsExceptionOnIncorrectProvider()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
### What is the reason for this PR?
Fixed bug #366 
This bug occurred when you add new Provider after calling the previous provider formatter with the same function name as the new one. To explain it more clearly read this code:
```php
// Existing behaviour
$faker = Faker\Factory::create(); 
$faker->firstName(); // calling default provider : Faker\Provider\en_US\Person
$faker->addProvider(new Faker\Provider\zh_CN\Person($faker));
$faker->firstName(); // still calling the default provider because of this code https://github.com/FakerPHP/Faker/blob/d3c0752e756a387214c5b942cb7c5231d9bc8b64/src/Faker/Generator.php#L632

// What this PR does
$faker = Faker\Factory::create(); 
$faker->firstName(); // calling default provider : Faker\Provider\en_US\Person
$faker->addProvider(new Faker\Provider\zh_CN\Person($faker));
$faker->firstName(); // calling the new provider formatter
```

- [ ] A new feature
- [x] Fixed an issue (resolve #366 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Remove existing formatters that match the new Provider formatters when calling addProvider function.

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
