### PR TITLE
allow deprecation-contracts v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "psr/container": "^1.0 || ^2.0",
-        "symfony/deprecation-contracts": "^2.2"
+        "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },
     "require-dev": {
         "ext-intl": "*",


### PR DESCRIPTION
### What is the reason for this PR?

Allow using faker with Symfony 6 projects that utilize `symfony/deprecation-contracts` `^v3.0.0`

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

No code based changes required. Allows `symfony/deprecation-contracts` v2.2 || v3.0

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
