### PR TITLE
Set allow-plugins for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
         "ext-mbstring": "Required for multibyte Unicode string functionality."
     },
     "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        },
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
### What is the reason for this PR?

A new configuration **allow-plugins** has been introduced with Composer 2.2: https://github.com/composer/composer/releases/tag/2.2.0-RC1

Quote from Composer's documentation:

    Defaults to null (allow all plugins implicitly) for backwards compatibility until July 2022. At that point the default will become {} and plugins will not load anymore unless allowed.
    
    As of Composer 2.2.0, the allow-plugins option adds a layer of security allowing you to restrict which Composer plugins are able to execute code during a Composer run.
    
    When a new plugin is first activated, which is not yet listed in the config option, Composer will print a warning. If you run Composer interactively it will prompt you to decide if you want to execute the plugin or not.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)
- [x] UX improvement

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

I've set **allow-plugins** with the only composer plugin used (*bamarni/composer-bin-plugin*).

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
