### PR TITLE
Fix for support on different Doctrine ORM versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.18.0..main)
+- Fixed usage of `Doctrine\Persistence` dependency
+- Added conflict with `doctrine/persistence` below version `1.4`
 
 ## [2022-01-23, v1.18.0](https://github.com/FakerPHP/Faker/compare/v1.17.0..v1.18.0)
 
@@ -13,7 +15,7 @@
 - Person->name was missing string return type (#424)
 - Generate a valid BE TAX number (#415)
 - Added the UUID extension to Core (#427)
-- 
+
 ## [2021-12-05, v1.17.0](https://github.com/FakerPHP/Faker/compare/v1.16.0..v1.17.0)
 
 - Partial PHP 8.1 compatibility (#373)

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,16 @@
     "require-dev": {
         "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
-        "doctrine/orm": "^2.10",
+        "doctrine/persistence": "^1.3 || ^2.0",
         "symfony/phpunit-bridge": "^4.4 || ^5.2"
     },
     "autoload": {
         "psr-4": {
             "Faker\\": "src/Faker/"
-        }
+        },
+        "files": [
+            "src/Faker/ORM/Doctrine/backward-compatibility.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
@@ -36,8 +39,7 @@
         }
     },
     "conflict": {
-        "fzaninotto/faker": "*",
-        "doctrine/persistence": "<1.4"
+        "fzaninotto/faker": "*"
     },
     "suggest": {
         "ext-curl": "Required by Faker\\Provider\\Image to download images.",
@@ -48,7 +50,8 @@
     },
     "config": {
         "allow-plugins": {
-            "bamarni/composer-bin-plugin": true
+            "bamarni/composer-bin-plugin": true,
+            "composer/package-versions-deprecated": true
         },
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     "require-dev": {
         "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
-        "symfony/phpunit-bridge": "^4.4 || ^5.2",
-        "doctrine/persistence": "^1.4 || ^2.0 || ^3.0"
+        "doctrine/orm": "^2.10",
+        "symfony/phpunit-bridge": "^4.4 || ^5.2"
     },
     "autoload": {
         "psr-4": {
@@ -44,7 +44,7 @@
         "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
         "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
         "ext-mbstring": "Required for multibyte Unicode string functionality.",
-        "doctrine/persistence": "Required to use Faker\\ORM\\Doctrine"
+        "doctrine/orm": "Required to use Faker\\ORM\\Doctrine"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require-dev": {
         "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
-        "symfony/phpunit-bridge": "^4.4 || ^5.2"
+        "symfony/phpunit-bridge": "^4.4 || ^5.2",
+        "doctrine/persistence": "^1.4 || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -35,13 +36,15 @@
         }
     },
     "conflict": {
-        "fzaninotto/faker": "*"
+        "fzaninotto/faker": "*",
+        "doctrine/persistence": "<1.4"
     },
     "suggest": {
         "ext-curl": "Required by Faker\\Provider\\Image to download images.",
         "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
         "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
-        "ext-mbstring": "Required for multibyte Unicode string functionality."
+        "ext-mbstring": "Required for multibyte Unicode string functionality.",
+        "doctrine/persistence": "Required to use Faker\\ORM\\Doctrine"
     },
     "config": {
         "allow-plugins": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Calculator/Iban.php
 
@@ -66,27 +66,7 @@ parameters:
 			path: src/Faker/ORM/CakePHP/Populator.php
 
 		-
-			message: "#^Access to property \\$fieldMappings on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 2
-			path: src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
-
-		-
-			message: "#^Call to method getTypeOfField\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
-
-		-
-			message: "#^Parameter \\$class of method Faker\\\\ORM\\\\Doctrine\\\\ColumnTypeGuesser\\:\\:guessFormat\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
-
-		-
 			message: "#^Access to constant ONE on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Access to constant ONE_TO_ONE on an unknown class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\.$#"
 			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
@@ -96,92 +76,12 @@ parameters:
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
 		-
-			message: "#^Access to property \\$associationMappings on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
 			message: "#^Access to property \\$associationMappings on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\.$#"
 			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
 		-
-			message: "#^Access to property \\$fieldMappings on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Access to property \\$reflFields on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 2
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method createQueryBuilder\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getAssociationMappings\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getAssociationMappings\\(\\) on an unknown class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getAssociationNames\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getAssociationTargetClass\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getFieldNames\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getIdentifier\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getName\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method getRepository\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method hasField\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method isCollectionValuedAssociation\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method isIdentifier\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method newInstance\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method persist\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\<object\\>\\:\\:createQueryBuilder\\(\\)\\.$#"
 			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
@@ -189,71 +89,6 @@ parameters:
 			message: "#^Class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata not found\\.$#"
 			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata not found\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Method Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:generateId\\(\\) never returns null so it can be removed from the return typehint\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$repository contains unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Parameter \\$class of method Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:__construct\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Parameter \\$manager of method Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:execute\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Parameter \\$manager of method Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:generateId\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Property Faker\\\\ORM\\\\Doctrine\\\\EntityPopulator\\:\\:\\$class has unknown class Doctrine\\\\Common\\\\Persistence\\\\Mapping\\\\ClassMetadata as its type\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/EntityPopulator.php
-
-		-
-			message: "#^Call to method flush\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 2
-			path: src/Faker/ORM/Doctrine/Populator.php
-
-		-
-			message: "#^Call to method flush\\(\\) on an unknown class Faker\\\\ORM\\\\Doctrine\\\\EntityManager\\.$#"
-			count: 2
-			path: src/Faker/ORM/Doctrine/Populator.php
-
-		-
-			message: "#^Call to method getClassMetadata\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/Populator.php
-
-		-
-			message: "#^Parameter \\$entityManager of method Faker\\\\ORM\\\\Doctrine\\\\Populator\\:\\:execute\\(\\) has invalid typehint type Faker\\\\ORM\\\\Doctrine\\\\EntityManager\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/Populator.php
-
-		-
-			message: "#^Parameter \\$manager of method Faker\\\\ORM\\\\Doctrine\\\\Populator\\:\\:__construct\\(\\) has invalid typehint type Doctrine\\\\Common\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/Populator.php
-
-		-
-			message: "#^Property Faker\\\\ORM\\\\Doctrine\\\\Populator\\:\\:\\$manager has unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectManager as its type\\.$#"
-			count: 1
-			path: src/Faker/ORM/Doctrine/Populator.php
 
 		-
 			message: "#^Call to method create\\(\\) on an unknown class Mandango\\\\Mandango\\.$#"
@@ -765,7 +600,7 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Base.php
 
@@ -795,12 +630,12 @@ parameters:
 			path: src/Faker/Provider/File.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function md5 expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function md5 expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Miscellaneous.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function sha1 expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function sha1 expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Miscellaneous.php
 
@@ -835,7 +670,7 @@ parameters:
 			path: src/Faker/Provider/cs_CZ/Person.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/en_ZA/Person.php
 
@@ -910,7 +745,7 @@ parameters:
 			path: src/Faker/Provider/ro_RO/Person.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/ru_RU/Company.php
 
@@ -920,7 +755,7 @@ parameters:
 			path: src/Faker/Provider/sl_SI/Person.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/zh_CN/Address.php
 
@@ -930,7 +765,7 @@ parameters:
 			path: src/Faker/Provider/zh_CN/Address.php
 
 		-
-			message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, Closure\\(mixed\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function spl_autoload_register expects \\(callable\\(string\\)\\: void\\)\\|null, Closure\\(mixed\\)\\: bool given\\.$#"
 			count: 1
 			path: src/autoload.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,7 +66,27 @@ parameters:
 			path: src/Faker/ORM/CakePHP/Populator.php
 
 		-
+			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$fieldMappings\\.$#"
+			count: 2
+			path: src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+
+		-
+			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$fieldMappings\\.$#"
+			count: 1
+			path: src/Faker/ORM/Doctrine/EntityPopulator.php
+
+		-
+			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$reflFields\\.$#"
+			count: 2
+			path: src/Faker/ORM/Doctrine/EntityPopulator.php
+
+		-
 			message: "#^Access to constant ONE on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\.$#"
+			count: 1
+			path: src/Faker/ORM/Doctrine/EntityPopulator.php
+
+		-
+			message: "#^Access to constant ONE_TO_ONE on an unknown class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\.$#"
 			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
@@ -81,12 +101,27 @@ parameters:
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
 		-
+			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:newInstance\\(\\)\\.$#"
+			count: 1
+			path: src/Faker/ORM/Doctrine/EntityPopulator.php
+
+		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\<object\\>\\:\\:createQueryBuilder\\(\\)\\.$#"
 			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 
 		-
+			message: "#^Call to method getAssociationMappings\\(\\) on an unknown class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\.$#"
+			count: 1
+			path: src/Faker/ORM/Doctrine/EntityPopulator.php
+
+		-
 			message: "#^Class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata not found\\.$#"
+			count: 1
+			path: src/Faker/ORM/Doctrine/EntityPopulator.php
+
+		-
+			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata not found\\.$#"
 			count: 1
 			path: src/Faker/ORM/Doctrine/EntityPopulator.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Calculator/Iban.php
 
@@ -600,7 +600,7 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Base.php
 
@@ -630,12 +630,12 @@ parameters:
 			path: src/Faker/Provider/File.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function md5 expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Miscellaneous.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function sha1 expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$str of function sha1 expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Miscellaneous.php
 
@@ -670,7 +670,7 @@ parameters:
 			path: src/Faker/Provider/cs_CZ/Person.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/en_ZA/Person.php
 
@@ -745,7 +745,7 @@ parameters:
 			path: src/Faker/Provider/ro_RO/Person.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/ru_RU/Company.php
 
@@ -755,7 +755,7 @@ parameters:
 			path: src/Faker/Provider/sl_SI/Person.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/zh_CN/Address.php
 
@@ -765,7 +765,7 @@ parameters:
 			path: src/Faker/Provider/zh_CN/Address.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function spl_autoload_register expects \\(callable\\(string\\)\\: void\\)\\|null, Closure\\(mixed\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, Closure\\(mixed\\)\\: bool given\\.$#"
 			count: 1
 			path: src/autoload.php
 

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -19,49 +19,26 @@
       <code>self</code>
       <code>self</code>
     </InvalidReturnType>
-    </file>
+  </file>
   <file src="src/Faker/ORM/CakePHP/EntityPopulator.php">
     <UndefinedClass occurrences="1">
       <code>TableRegistry</code>
     </UndefinedClass>
   </file>
-  <file src="src/Faker/ORM/Doctrine/ColumnTypeGuesser.php">
-    <UndefinedClass occurrences="1">
-      <code>ClassMetadata</code>
-    </UndefinedClass>
-  </file>
   <file src="src/Faker/ORM/Doctrine/EntityPopulator.php">
-    <UndefinedClass occurrences="13">
+    <UndefinedClass occurrences="6">
       <code>$this-&gt;class</code>
-      <code>$this-&gt;class</code>
-      <code>$this-&gt;class</code>
-      <code>$this-&gt;class-&gt;associationMappings</code>
-      <code>$this-&gt;class-&gt;fieldMappings</code>
-      <code>ClassMetadata</code>
-      <code>ObjectManager</code>
-      <code>ObjectManager</code>
       <code>\Doctrine\ODM\MongoDB\Mapping\ClassMetadata</code>
       <code>\Doctrine\ODM\MongoDB\Mapping\ClassMetadata</code>
       <code>\Doctrine\ODM\MongoDB\Mapping\ClassMetadata</code>
       <code>\Doctrine\ORM\Mapping\ClassMetadata</code>
       <code>\Doctrine\ORM\Mapping\ClassMetadata</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="7">
-      <code>$this-&gt;class</code>
-      <code>$this-&gt;class</code>
-      <code>$this-&gt;class</code>
-      <code>$this-&gt;class</code>
-      <code>$this-&gt;class</code>
-      <code>$this-&gt;class-&gt;reflFields</code>
-      <code>ClassMetadata</code>
-    </UndefinedDocblockClass>
-  </file>
-  <file src="src/Faker/ORM/Doctrine/Populator.php">
-    <UndefinedClass occurrences="1"/>
-    <UndefinedDocblockClass occurrences="3">
-      <code>$this-&gt;manager</code>
-      <code>ObjectManager|null</code>
-    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>createQueryBuilder</code>
+      <code>getAssociationMappings</code>
+      <code>newInstance</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="src/Faker/ORM/Mandango/EntityPopulator.php">
     <UndefinedClass occurrences="2">
@@ -76,7 +53,9 @@
     </UndefinedClass>
   </file>
   <file src="src/Faker/ORM/Propel/ColumnTypeGuesser.php">
-    <UndefinedClass occurrences="1"/>
+    <UndefinedClass occurrences="1">
+      <code>\ColumnMap</code>
+    </UndefinedClass>
   </file>
   <file src="src/Faker/ORM/Propel/EntityPopulator.php">
     <UndefinedClass occurrences="9">
@@ -88,6 +67,7 @@
       <code>$columnMap</code>
       <code>$columnMap</code>
       <code>$columnMap</code>
+      <code>\ColumnMap</code>
     </UndefinedClass>
   </file>
   <file src="src/Faker/ORM/Propel/Populator.php">
@@ -152,6 +132,7 @@
   <file src="src/Faker/ORM/Spot/Populator.php">
     <UndefinedClass occurrences="2">
       <code>$this-&gt;locator</code>
+      <code>Locator</code>
     </UndefinedClass>
     <UndefinedDocblockClass occurrences="1">
       <code>Locator</code>
@@ -191,33 +172,15 @@
       <code>$checksumArr[$checksum % 11]</code>
     </InvalidArrayOffset>
   </file>
-  <file src="src/Faker/Provider/is_IS/Address.php">
-    <InvalidPropertyAssignmentValue occurrences="1"/>
-    <UndefinedDocblockClass occurrences="2">
-      <code>Icelandic</code>
-    </UndefinedDocblockClass>
-  </file>
   <file src="src/Faker/Provider/is_IS/Person.php">
-    <InvalidArgument occurrences="1">
-      <code>static::$middleName</code>
-    </InvalidArgument>
     <InvalidArrayOffset occurrences="1">
       <code>$ref[$i]</code>
     </InvalidArrayOffset>
-    <InvalidPropertyAssignmentValue occurrences="3"/>
   </file>
   <file src="src/Faker/Provider/ja_JP/Text.php">
     <UndefinedMethod occurrences="1">
       <code>static::split($text)</code>
     </UndefinedMethod>
-  </file>
-  <file src="src/Faker/Provider/pl_PL/Company.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>implode('', $result)</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>14</code>
-    </InvalidReturnType>
   </file>
   <file src="src/Faker/Provider/pl_PL/Person.php">
     <UndefinedDocblockClass occurrences="1">

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -2,7 +2,7 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Faker\Generator;
 
 class ColumnTypeGuesser

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -2,7 +2,7 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Faker\Generator;
 
 class ColumnTypeGuesser
@@ -17,7 +17,7 @@ class ColumnTypeGuesser
     /**
      * @return \Closure|null
      */
-    public function guessFormat($fieldName, ClassMetadata $class)
+    public function guessFormat($fieldName, ClassMetadataInfo $class)
     {
         $generator = $this->generator;
         $type = $class->getTypeOfField($fieldName);

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -2,7 +2,7 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Faker\Generator;
 
 class ColumnTypeGuesser
@@ -17,7 +17,7 @@ class ColumnTypeGuesser
     /**
      * @return \Closure|null
      */
-    public function guessFormat($fieldName, ClassMetadataInfo $class)
+    public function guessFormat($fieldName, ClassMetadata $class)
     {
         $generator = $this->generator;
         $type = $class->getTypeOfField($fieldName);

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -2,8 +2,8 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 
 /**
  * Service class for populating a table through a Doctrine Entity class.

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -2,7 +2,7 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\ObjectManager;
 
 /**
@@ -11,7 +11,7 @@ use Doctrine\Persistence\ObjectManager;
 class EntityPopulator
 {
     /**
-     * @var ClassMetadata
+     * @var ClassMetadataInfo
      */
     protected $class;
     /**
@@ -23,7 +23,10 @@ class EntityPopulator
      */
     protected $modifiers = [];
 
-    public function __construct(ClassMetadata $class)
+    /**
+     * @param ClassMetadataInfo<object> $class
+     */
+    public function __construct(ClassMetadataInfo $class)
     {
         $this->class = $class;
     }
@@ -226,19 +229,16 @@ class EntityPopulator
     }
 
     /**
-     * @return int|null
+     * @return int
      */
     private function generateId($obj, $column, ObjectManager $manager)
     {
-        /** @var \Doctrine\Common\Persistence\ObjectRepository $repository */
         $repository = $manager->getRepository(get_class($obj));
         $result = $repository->createQueryBuilder('e')
                 ->select(sprintf('e.%s', $column))
                 ->getQuery()
                 ->execute();
         $ids = array_map('current', $result->toArray());
-
-        $id = null;
 
         do {
             $id = mt_rand();

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -2,8 +2,8 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\ObjectManager;
 
 /**
  * Service class for populating a table through a Doctrine Entity class.
@@ -11,7 +11,7 @@ use Doctrine\Persistence\ObjectManager;
 class EntityPopulator
 {
     /**
-     * @var ClassMetadataInfo
+     * @var ClassMetadata
      */
     protected $class;
     /**
@@ -23,10 +23,7 @@ class EntityPopulator
      */
     protected $modifiers = [];
 
-    /**
-     * @param ClassMetadataInfo<object> $class
-     */
-    public function __construct(ClassMetadataInfo $class)
+    public function __construct(ClassMetadata $class)
     {
         $this->class = $class;
     }

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -2,7 +2,7 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Faker\Generator;
 
 /**

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -86,7 +86,7 @@ class Populator
      * Please note that large amounts of data will result in more memory usage since the the Populator will return
      * all newly created primary keys after executing.
      *
-     * @param EntityManager|null $entityManager A Doctrine connection object
+     * @param ObjectManager|null $entityManager A Doctrine connection object
      *
      * @return array A list of the inserted PKs
      */

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -2,7 +2,7 @@
 
 namespace Faker\ORM\Doctrine;
 
-use Doctrine\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use Faker\Generator;
 
 /**

--- a/src/Faker/ORM/Doctrine/backward-compatibility.php
+++ b/src/Faker/ORM/Doctrine/backward-compatibility.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+if (!class_exists('Doctrine\Common\Persistence\Mapping\ClassMetadata')) {
+    class_alias(\Doctrine\Persistence\Mapping\ClassMetadata::class, 'Doctrine\Common\Persistence\Mapping\ClassMetadata');
+}
+
+if (!class_exists('Doctrine\Common\Persistence\ObjectManager')) {
+    class_alias(\Doctrine\Persistence\ObjectManager::class, 'Doctrine\Common\Persistence\ObjectManager');
+}

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -10,6 +10,9 @@
             "php": "7.1.33"
         },
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -8,6 +8,9 @@
             "php": "7.1.33"
         },
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     }
 }


### PR DESCRIPTION
Add conflict to doctrine/persistence below 1.4 and use correct persistence classes

### What is the reason for this PR?

Fix an issue with `doctrine/persistnce`
- [x] Fixed an issue (resolve #413 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

- ~Add a conflict into `composer.json` for `doctrine/persistence` below version 1.4~
- Add suggest into `composer.json` for `doctrine/orm`
- ~Add `doctrine/orm` as dev requirement to avoid static analysis baseline entries~
- ~Use new classes of `doctrine/orm` and `doctrine/persistence` for `Faker\ORM\Doctrine` namespace~
- Add `class_alias` for `ClassMetadata` and `ObjectManager`

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer