### PR TITLE
Generate a valid BE TAX number

### DIFF
--- a/src/Faker/Provider/nl_BE/Payment.php
+++ b/src/Faker/Provider/nl_BE/Payment.php
@@ -37,6 +37,12 @@ class Payment extends \Faker\Provider\Payment
     {
         $prefix = $spacedNationalPrefix ? 'BE ' : 'BE';
 
-        return sprintf('%s0%d', $prefix, self::randomNumber(9, true));
+        // Generate 7 numbers of vat.
+        $firstEight = self::randomNumber(7, true);
+
+        $checksum = 97 - fmod($firstEight, 97);
+
+        // '0' + 7 numbers + checksum
+        return sprintf('%s0%s%s', $prefix, $firstEight, $checksum);
     }
 }

--- a/src/Faker/Provider/nl_BE/Payment.php
+++ b/src/Faker/Provider/nl_BE/Payment.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\nl_BE;
 class Payment extends \Faker\Provider\Payment
 {
     /**
-     * International Bank Account Number (IBAN)
+     * International Bank Account Number (IBAN).
      *
      * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
      *
@@ -21,7 +21,7 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * Value Added Tax (VAT)
+     * Value Added Tax (VAT).
      *
      * @example 'BE0123456789', ('spaced') 'BE 0123456789'
      *
@@ -38,11 +38,12 @@ class Payment extends \Faker\Provider\Payment
         $prefix = $spacedNationalPrefix ? 'BE ' : 'BE';
 
         // Generate 7 numbers of vat.
-        $firstEight = self::randomNumber(7, true);
+        $firstSeven = self::randomNumber(7, true);
 
-        $checksum = 97 - fmod($firstEight, 97);
+        // Generate checksum for number
+        $checksum = 97 - fmod($firstSeven, 97);
 
         // '0' + 7 numbers + checksum
-        return sprintf('%s0%s%s', $prefix, $firstEight, $checksum);
+        return sprintf('%s0%s%s', $prefix, $firstSeven, $checksum);
     }
 }

--- a/test/Faker/Provider/nl_BE/PaymentTest.php
+++ b/test/Faker/Provider/nl_BE/PaymentTest.php
@@ -31,7 +31,7 @@ final class PaymentTest extends TestCase
         self::assertEquals(10, $len);
         self::assertStringStartsWith('0', $numbers);
 
-        // Mod97 check on last nine digits
+        // Mod97 check on first 8 digits
         $checksum = 97 - fmod(substr($numbers, 0, 8), 97);
 
         self::assertEquals((string) $checksum, substr($numbers, 8, 10));

--- a/test/Faker/Provider/nl_BE/PaymentTest.php
+++ b/test/Faker/Provider/nl_BE/PaymentTest.php
@@ -16,6 +16,25 @@ final class PaymentTest extends TestCase
         $unspacedVat = $this->faker->vat(false);
         self::assertMatchesRegularExpression('/^(BE 0\d{9})$/', $vat);
         self::assertMatchesRegularExpression('/^(BE0\d{9})$/', $unspacedVat);
+
+        $this->validateChecksum($vat);
+        $this->validateChecksum($unspacedVat);
+    }
+
+    private function validateChecksum($vat)
+    {
+        // Remove the "BE " part from the beginning
+        $numbers = trim(substr($vat, 2));
+
+        $len = strlen($numbers);
+
+        self::assertEquals(10, $len);
+        self::assertStringStartsWith('0', $numbers);
+
+        // Mod97 check on last nine digits
+        $checksum = 97 - fmod(substr($numbers, 0, 8), 97);
+
+        self::assertEquals((string) $checksum, substr($numbers, 8, 10));
     }
 
     protected function getProviders(): iterable


### PR DESCRIPTION
According to wikipedia:

> 'BE'+ 8 digits + 2 check digits – e.g. BE09999999XX. At this time no numbers starting with "1" are issued, but this can happen any time. Note that the old numbering schema only had 9 characters, separated with dots (e.g. 999.999.9XX), just adding a zero in front and removing the dots makes it a valid number in the new schema.
> 
> The check digits are calculated as 97 - MOD 97 

This change generates a VAT number according to those rules.