### PR TITLE
Rename VAT formatter in it_IT locale for consistency

### DIFF
--- a/src/Faker/Provider/it_IT/Company.php
+++ b/src/Faker/Provider/it_IT/Company.php
@@ -67,16 +67,29 @@ class Company extends \Faker\Provider\Company
     }
 
     /**
-     * Italian VAT number (Partita iva)
+     * Italian VAT number (partita IVA)
      *
      * @see https://it.wikipedia.org/wiki/Partita_IVA
      *
      * @return string
      */
-    public static function vatId()
+    public static function vat()
     {
         $code = sprintf('%s%03d', static::numerify('#######'), self::numberBetween(1, 121));
 
         return sprintf('IT%s%d', $code, Luhn::computeCheckDigit($code));
+    }
+
+    /**
+     * Italian VAT number (partita IVA)
+     *
+     * @return string
+     *
+     * @deprecated use {@link \Faker\Provider\it_IT\Company::vat()} instead
+     * @see \Faker\Provider\it_IT\Company::vat()
+     */
+    public static function vatId()
+    {
+        return self::vat();
     }
 }

--- a/test/Faker/Provider/it_IT/CompanyTest.php
+++ b/test/Faker/Provider/it_IT/CompanyTest.php
@@ -12,8 +12,8 @@ final class CompanyTest extends TestCase
 {
     public function testIfTaxIdCanReturnData()
     {
-        $vatId = $this->faker->vatId();
-        self::assertMatchesRegularExpression('/^IT[0-9]{11}$/', $vatId);
+        $vat = $this->faker->vat();
+        self::assertMatchesRegularExpression('/^IT[0-9]{11}$/', $vat);
     }
 
     protected function getProviders(): iterable


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)
 - I'll be happy to make a pull request to update the docs, if this PR is accepted (or I can do it right now, as you prefer)

### Summary of changes

The VAT number formatter is called `vat()` in `nl_BE/Payment`, `en_GB/Company`, `nl_NL/Company`, `fr_BE/Payment`, `bg_BG/Payment`, `es_ES/Payment`, `de_AT/Payment` and `fr_FR/Payment`, but it is called `vatId()` in `it_IT/Payment`. This pull request harmonize the latter to `vat()`, keeping `vatId()` as an alias.

There is nothing really new, no breaking changes, just a minor change for consistency.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
