### PR TITLE
Add PHPDoc for state, stateAbbr, taxId

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -554,6 +554,18 @@ use Psr\Container\ContainerInterface;
  *
  * @method string linuxPlatformToken()
  *
+ * @property string state
+ *
+ * @method string state()
+ *
+ * @property string stateAbbr
+ *
+ * @method string stateAbbr()
+ *
+ * @property string taxId
+ *
+ * @method string taxId()
+ *
  * @property string $uuid
  *
  * @method string uuid()


### PR DESCRIPTION
### What is the reason for this PR?

I was handling deprecations and I discovered, through static analysis, that `state` `stateAbbr` and `taxId` where not mentioned in the PHPDoc

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
