### PR TITLE
add Enum generator

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '8.0'
+          - '8.1'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.4]
+        php-version: [8.1]
 
     steps:
       - name: Checkout code

--- a/src/Faker/Core/Enum.php
+++ b/src/Faker/Core/Enum.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Core;
+
+use Faker\Extension;
+
+/**
+ * @experimental This class is experimental and does not fall under our BC promise
+ */
+final class Enum implements Extension\EnumExtension
+{
+    public function enum(string $enumClass): \UnitEnum
+    {
+        if (!enum_exists($enumClass)) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not an enum.', $enumClass));
+        }
+
+        $cases = $enumClass::cases();
+
+        if (0 === count($cases)) {
+            throw new \InvalidArgumentException(sprintf('Enum "%s" does not have any cases', $enumClass));
+        }
+
+        return Extension\Helper::randomElement($cases);
+    }
+}

--- a/src/Faker/Extension/ContainerBuilder.php
+++ b/src/Faker/Extension/ContainerBuilder.php
@@ -60,13 +60,19 @@ final class ContainerBuilder
      */
     public static function defaultExtensions(): array
     {
-        return [
+        $extensions = [
             BarcodeExtension::class => Core\Barcode::class,
             BloodExtension::class => Core\Blood::class,
             FileExtension::class => Core\File::class,
             NumberExtension::class => Core\Number::class,
             VersionExtension::class => Core\Version::class,
         ];
+
+        if (PHP_VERSION_ID >= 80100) {
+            $extensions[EnumExtension::class] = Core\Enum::class;
+        }
+
+        return $extensions;
     }
 
     public static function getDefault(): ContainerInterface

--- a/src/Faker/Extension/EnumExtension.php
+++ b/src/Faker/Extension/EnumExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Faker\Extension;
+
+/**
+ * @experimental This interface is experimental and does not fall under our BC promise
+ */
+interface EnumExtension extends Extension
+{
+    /**
+     * @example 'Gender::Male'
+     *
+     * @template T of UnitEnum
+     *
+     * @param class-string<T> $enumClass
+     *
+     * @return T
+     */
+    public function enum(string $enumClass): \UnitEnum;
+}

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -859,6 +859,22 @@ class Generator
     }
 
     /**
+     * Gets a random enum case.
+     *
+     * @example 'Gender::Male'
+     *
+     * @template T of UnitEnum
+     *
+     * @param class-string<T> $enumClass
+     *
+     * @return T
+     */
+    public function enum(string $enumClass): \UnitEnum
+    {
+        return $this->ext(Extension\EnumExtension::class)->enum($enumClass);
+    }
+
+    /**
      * @deprecated
      */
     protected function callFormatWithMatches($matches)

--- a/test/Faker/Core/EnumTest.php
+++ b/test/Faker/Core/EnumTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\Core;
+
+use Faker\Test\Fixture\Enum\Suit;
+use Faker\Test\TestCase;
+use Faker\UniqueGenerator;
+
+/**
+ * @requires PHP 8.1
+ */
+final class EnumTest extends TestCase
+{
+    public function testBloodRh(): void
+    {
+        $faker = new UniqueGenerator($this->faker);
+        $generated = [];
+        $cases = Suit::cases();
+
+        foreach ($cases as $case) {
+            $generated[] = $faker->enum(Suit::class);
+        }
+
+        self::assertContainsOnlyInstancesOf(Suit::class, $generated);
+        self::assertEqualsCanonicalizing($this->getNames($generated), $this->getNames($cases));
+    }
+
+    /**
+     * @param Suit[] $suits
+     * @return string[]
+     */
+    private function getNames(array $suits): array
+    {
+        return array_map(static function (Suit $suit) {
+            return $suit->name;
+        }, $suits);
+    }
+}

--- a/test/Faker/Provider/EnumTest.php
+++ b/test/Faker/Provider/EnumTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Faker\Test\Provider;
+
+use Faker\Provider\Image;
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class EnumTest extends TestCase
+{
+    public function testImageUrlUses640x680AsTheDefaultSize()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://via.placeholder.com/640x480.png/#',
+            Image::imageUrl()
+        );
+    }
+
+    public function testImageUrlAcceptsCustomWidthAndHeight()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://via.placeholder.com/800x400.png/#',
+            Image::imageUrl(800, 400)
+        );
+    }
+
+    public function testImageUrlAcceptsCustomCategory()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+.*#',
+            Image::imageUrl(800, 400, 'nature')
+        );
+    }
+
+    public function testImageUrlAcceptsCustomText()
+    {
+        self::assertMatchesRegularExpression(
+            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            Image::imageUrl(800, 400, 'nature', false, 'Faker')
+        );
+    }
+
+    public function testImageUrlReturnsLinkToRegularImageWhenGrayIsFalse()
+    {
+        $imageUrl = Image::imageUrl(
+            800,
+            400,
+            'nature',
+            false,
+            'Faker',
+            false
+        );
+
+        self::assertMatchesRegularExpression(
+            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            $imageUrl
+        );
+    }
+
+    public function testImageUrlReturnsLinkToRegularImageWhenGrayIsTrue()
+    {
+        $imageUrl = Image::imageUrl(
+            800,
+            400,
+            'nature',
+            false,
+            'Faker',
+            true
+        );
+
+        self::assertMatchesRegularExpression(
+            '#^https://via.placeholder.com/800x400.png/CCCCCC\?text=nature\+Faker#',
+            $imageUrl
+        );
+    }
+
+    public function testImageUrlAddsARandomGetParameterByDefault()
+    {
+        $url = Image::imageUrl(800, 400);
+        $splitUrl = preg_split('/\?text=/', $url);
+
+        self::assertEquals(count($splitUrl), 2);
+        self::assertMatchesRegularExpression('#\w*#', $splitUrl[1]);
+    }
+
+    public function testDownloadWithDefaults()
+    {
+        $curlPing = curl_init(Image::BASE_URL);
+        curl_setopt($curlPing, CURLOPT_TIMEOUT, 5);
+        curl_setopt($curlPing, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($curlPing, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curlPing, CURLOPT_FOLLOWLOCATION, true);
+        $data = curl_exec($curlPing);
+        $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
+        curl_close($curlPing);
+
+        if ($httpCode < 200 | $httpCode > 300) {
+            self::markTestSkipped('Placeholder.com is offline, skipping image download');
+        }
+
+        $file = Image::image(sys_get_temp_dir());
+        self::assertFileExists($file);
+
+        if (function_exists('getimagesize')) {
+            [$width, $height, $type, $attr] = getimagesize($file);
+            self::assertEquals(640, $width);
+            self::assertEquals(480, $height);
+            self::assertEquals(constant('IMAGETYPE_PNG'), $type);
+        } else {
+            self::assertEquals('png', pathinfo($file, PATHINFO_EXTENSION));
+        }
+
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+}

--- a/test/Fixture/Enum/Suit.php
+++ b/test/Fixture/Enum/Suit.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Faker\Test\Fixture\Enum;
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This change adds `Enum` extension that returns a random enum from the enum FQCN.

Example of use:

```php
enum Suit
{
    case Hearts;
    case Diamonds;
    case Clubs;
    case Spades;
}

$faker->enum(Suit::class); // returns a random instance of the Suit enum
```

The extension is only registered if PHP 8.1+ is used.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
