### PR TITLE
Person->name was missing string return type

### DIFF
--- a/src/Faker/Extension/PersonExtension.php
+++ b/src/Faker/Extension/PersonExtension.php
@@ -13,11 +13,9 @@ interface PersonExtension extends Extension
     /**
      * @param string|null $gender 'male', 'female' or null for any
      *
-     * @return string
-     *
      * @example 'John Doe'
      */
-    public function name(?string $gender = null);
+    public function name(?string $gender = null): string;
 
     /**
      * @param string|null $gender 'male', 'female' or null for any


### PR DESCRIPTION
### What is the reason for this PR?

Missing return type for PersonExtension::name

- [ ] A new feature
- [x] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

added return type

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
