### PR TITLE
Fix regexify escape backslash in character class

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -526,8 +526,8 @@ class Base
         // All [ABC] become B (or A or C)
         $regex = preg_replace_callback('/\[([^\]]+)\]/', static function ($matches) {
             // remove backslashes (that are not followed by another backslash) because they are escape characters
-            $matches = preg_replace('/\\\(?!\\\)/', '', $matches[1]);
-            $randomElement = Base::randomElement(str_split($matches));
+            $match = preg_replace('/\\\(?!\\\)/', '', $matches[1]);
+            $randomElement = Base::randomElement(str_split($match));
             //[.] should not be a random character, but a literal .
             return str_replace('.', '\.', $randomElement);
         }, $regex);

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -525,7 +525,7 @@ class Base
         }, $regex);
         // All [ABC] become B (or A or C)
         $regex = preg_replace_callback('/\[([^\]]+)\]/', static function ($matches) {
-            // remove single backslash
+            // remove backslashes (that are not followed by another backslash) because they are escape characters
             $matches = preg_replace('/\\\(?!\\\)/', '', $matches[1]);
             $randomElement = Base::randomElement(str_split($matches));
             //[.] should not be a random character, but a literal .

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -525,7 +525,9 @@ class Base
         }, $regex);
         // All [ABC] become B (or A or C)
         $regex = preg_replace_callback('/\[([^\]]+)\]/', static function ($matches) {
-            $randomElement = Base::randomElement(str_split($matches[1]));
+            // remove single backslash
+            $matches = preg_replace('/\\\(?!\\\)/', '', $matches[1]);
+            $randomElement = Base::randomElement(str_split($matches));
             //[.] should not be a random character, but a literal .
             return str_replace('.', '\.', $randomElement);
         }, $regex);

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -333,6 +333,7 @@ final class BaseTest extends TestCase
             ['[aeiou]', 'basic character class'],
             ['[a-z]', 'character class range'],
             ['[a-z1-9]', 'multiple character class range'],
+            ['[a-z\-]{4}', 'character class range with quantifier and escaped character'],
             ['a*b+c?', 'single character quantifiers'],
             ['a{2}', 'brackets quantifiers'],
             ['a{2,3}', 'min-max brackets quantifiers'],


### PR DESCRIPTION
### What is the reason for this PR?

This PR removes single escape backslashes from character classes in `regexify()`.

- [ ] A new feature
- [x] Fixed an issue (resolve #382)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Besides the `regexify()` change I've added a test that covers the respective issue (note that without the code changes in `regexify()` this added test fails).

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
