### PR TITLE
Remove unnecesary docblock magic method definition uuid()

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -540,10 +540,6 @@ use Psr\Container\ContainerInterface;
  * @property string $linuxPlatformToken
  *
  * @method string linuxPlatformToken()
- *
- * @property string $uuid
- *
- * @method string uuid()
  */
 class Generator
 {


### PR DESCRIPTION
### What is the reason for this PR?

The `uuid()` was defined as magic `@method` in the `Generator` docblock. In 69dbadac5f6bec0bb7d9718efc9a5e5cbc192927 the `uuid()` method was added to the `Generator`, making the definition of this method in the docblock unnecessary.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Removed `uuid()` from Generator docblock.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
