### PR TITLE
Fix CZ Person birthNumber docblock return type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -830,16 +830,6 @@ parameters:
 			path: src/Faker/Provider/cs_CZ/DateTime.php
 
 		-
-			message: "#^Method Faker\\\\Provider\\\\cs_CZ\\\\Person\\:\\:birthNumber\\(\\) should return Faker\\\\Provider\\\\cs_CZ\\\\czech but returns string\\.$#"
-			count: 1
-			path: src/Faker/Provider/cs_CZ/Person.php
-
-		-
-			message: "#^Return typehint of method Faker\\\\Provider\\\\cs_CZ\\\\Person\\:\\:birthNumber\\(\\) has invalid type Faker\\\\Provider\\\\cs_CZ\\\\czech\\.$#"
-			count: 1
-			path: src/Faker/Provider/cs_CZ/Person.php
-
-		-
 			message: "#^Static call to instance method Faker\\\\Provider\\\\cs_CZ\\\\Person\\:\\:birthNumber\\(\\)\\.$#"
 			count: 2
 			path: src/Faker/Provider/cs_CZ/Person.php

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -181,19 +181,10 @@
     </UndefinedPropertyFetch>
   </file>
   <file src="src/Faker/Provider/cs_CZ/Person.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>$birthNumber</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>czech</code>
-    </InvalidReturnType>
     <NonStaticSelfCall occurrences="2">
       <code>static::birthNumber(static::GENDER_FEMALE)</code>
       <code>static::birthNumber(static::GENDER_MALE)</code>
     </NonStaticSelfCall>
-    <UndefinedDocblockClass occurrences="1">
-      <code>czech</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/Faker/Provider/en_SG/Person.php">
     <InvalidArrayOffset occurrences="1">

--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -430,7 +430,7 @@ class Person extends \Faker\Provider\Person
      * @param int         $minAge minimal age of "generated person" in years
      * @param int         $maxAge maximal age of "generated person" in years
      *
-     * @return string birth number
+     * @return string czech birth number
      */
     public function birthNumber($gender = null, $minAge = 0, $maxAge = 100, $slashProbability = 50)
     {

--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -430,7 +430,7 @@ class Person extends \Faker\Provider\Person
      * @param int         $minAge minimal age of "generated person" in years
      * @param int         $maxAge maximal age of "generated person" in years
      *
-     * @return czech birth number
+     * @return string birth number
      */
     public function birthNumber($gender = null, $minAge = 0, $maxAge = 100, $slashProbability = 50)
     {


### PR DESCRIPTION
### What is the reason for this PR?

The docblock of `cs_CZ\Person::birthNumber()` has a non existing return type czech.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Fixed the docblock return type.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
