### PR TITLE
Fix is_IS Address docbock type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -865,16 +865,6 @@ parameters:
 			path: src/Faker/Provider/id_ID/Person.php
 
 		-
-			message: "#^Property Faker\\\\Provider\\\\is_IS\\\\Address\\:\\:\\$postcode has unknown class Faker\\\\Provider\\\\is_IS\\\\Icelandic as its type\\.$#"
-			count: 1
-			path: src/Faker/Provider/is_IS/Address.php
-
-		-
-			message: "#^Static property Faker\\\\Provider\\\\is_IS\\\\Address\\:\\:\\$postcode \\(Faker\\\\Provider\\\\is_IS\\\\Icelandic\\) does not accept default value of type array\\<int, string\\>\\.$#"
-			count: 1
-			path: src/Faker/Provider/is_IS/Address.php
-
-		-
 			message: "#^Binary operation \"\\*\" between string and string results in an error\\.$#"
 			count: 1
 			path: src/Faker/Provider/is_IS/Person.php

--- a/src/Faker/Provider/is_IS/Address.php
+++ b/src/Faker/Provider/is_IS/Address.php
@@ -82,7 +82,7 @@ class Address extends \Faker\Provider\Address
     ];
 
     /**
-     * @var Icelandic zip code.
+     * @var array Icelandic zip code.
      */
     protected static $postcode = [
         '%##',


### PR DESCRIPTION
### What is the reason for this PR?

`is_IS\Address::$postcode` has the nonexistent type `Icelandic`. 

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Fixed the type to array.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
