### PR TITLE
Removed UUID from Generator to be able to extend it

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -8,3 +8,5 @@ parameters:
         - '#\[BC\] CHANGED: The parameter \$generator of Faker\\UniqueGenerator\#\_\_construct\(\) changed from Faker\\Generator to no type#'
         - '#\[BC\] CHANGED: The return type of Faker\\Extension\\PersonExtension\#name\(\) changed from no type to string#'
         - '#\[BC\] CHANGED: The parameter \$max of Faker\\Extension\\NumberExtension\#randomFloat\(\) changed from float to float\|null#'
+        - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid\(\) was removed#'
+        - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid3\(\) was removed#'

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -798,34 +798,6 @@ class Generator
     }
 
     /**
-     * Get a random v3 uuid
-     *
-     * @example '7e57d004-2b97-0e7a-b45f-5387367791cd'
-     *
-     * @deprecated call uuid3() instead
-     */
-    public function uuid(): string
-    {
-        trigger_deprecation(
-            'fakerphp/faker',
-            '1.18',
-            'Method uuid() is deprecated, call uuid3() instead'
-        );
-
-        return $this->uuid3();
-    }
-
-    /**
-     * Get a random v3 uuid
-     *
-     * @example '7e57d004-2b97-0e7a-b45f-5387367791cd'
-     */
-    public function uuid3(): string
-    {
-        return $this->ext(Extension\UuidExtension::class)->uuid3();
-    }
-
-    /**
      * Get a random EAN13 barcode.
      *
      * @example '4006381333931'

--- a/test/Faker/Core/UuidTest.php
+++ b/test/Faker/Core/UuidTest.php
@@ -2,28 +2,35 @@
 
 namespace Faker\Test\Core;
 
+use Faker\Core\Uuid;
 use Faker\Test\TestCase;
 
 final class UuidTest extends TestCase
 {
     public function testUuidReturnsUuid()
     {
-        $uuid = $this->faker->uuid3();
+        $instance = new Uuid();
+        $uuid = $instance->uuid3();
         self::assertTrue($this->isUuid($uuid));
     }
 
     public function testUuidExpectedSeed()
     {
+        $instance = new Uuid();
+
         if (pack('L', 0x6162797A) == pack('N', 0x6162797A)) {
             self::markTestSkipped('Big Endian');
         }
         $this->faker->seed(123);
-        self::assertEquals('8e2e0c84-50dd-367c-9e66-f3ab455c78d6', $this->faker->uuid3());
-        self::assertEquals('073eb60a-902c-30ab-93d0-a94db371f6c8', $this->faker->uuid3());
+        self::assertEquals('8e2e0c84-50dd-367c-9e66-f3ab455c78d6', $instance->uuid3());
+        self::assertEquals('073eb60a-902c-30ab-93d0-a94db371f6c8', $instance->uuid3());
     }
 
-    protected function isUuid($uuid)
+    protected function isUuid(string $uuid)
     {
-        return is_string($uuid) && (bool) preg_match('/^[a-f0-9]{8,8}-(?:[a-f0-9]{4,4}-){3,3}[a-f0-9]{12,12}$/i', $uuid);
+        return is_string($uuid) && (bool) preg_match(
+            '/^[a-f0-9]{8,8}-(?:[a-f0-9]{4,4}-){3,3}[a-f0-9]{12,12}$/i',
+            $uuid
+        );
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

Reverts the addition of the UUID method to the generator

- [ ] A new feature
- [x] Fixed an issue (resolve #435)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Since the method exists directly on the generator the `addProvider` method is not able to extend these calls anymore. There we revert it for now and ensure that on v2 these methods used. For v2 we can overwrite it with the container builder however at this moment these are still experimental.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
