### PR TITLE
Remove uuid method from Generator

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -801,24 +801,6 @@ class Generator
      * Get a random v3 uuid
      *
      * @example '7e57d004-2b97-0e7a-b45f-5387367791cd'
-     *
-     * @deprecated call uuid3() instead
-     */
-    public function uuid(): string
-    {
-        trigger_deprecation(
-            'fakerphp/faker',
-            '1.18',
-            'Method uuid() is deprecated, call uuid3() instead'
-        );
-
-        return $this->uuid3();
-    }
-
-    /**
-     * Get a random v3 uuid
-     *
-     * @example '7e57d004-2b97-0e7a-b45f-5387367791cd'
      */
     public function uuid3(): string
     {


### PR DESCRIPTION
### What is the reason for this PR?

This method added in https://github.com/FakerPHP/Faker/pull/427 is a BC break. I had a Provider with `uuid` function but this added a new Formatter with name `uuid` which has a precedence over Providers.

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
