### PR TITLE
Only load doctrine/persistence class alias when using Faker\ORM\Doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,7 @@
     "autoload": {
         "psr-4": {
             "Faker\\": "src/Faker/"
-        },
-        "files": [
-            "src/Faker/ORM/Doctrine/backward-compatibility.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,8 @@ includes:
 
 parameters:
     level: 5
+    bootstrapFiles:
+        - src/Faker/ORM/Doctrine/backward-compatibility.php
     paths:
         - src
     tmpDir: .build/phpstan/

--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -5,6 +5,8 @@ namespace Faker\ORM\Doctrine;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Faker\Generator;
 
+require_once 'backward-compatibility.php';
+
 class ColumnTypeGuesser
 {
     protected $generator;

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -5,6 +5,8 @@ namespace Faker\ORM\Doctrine;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 
+require_once 'backward-compatibility.php';
+
 /**
  * Service class for populating a table through a Doctrine Entity class.
  */

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -5,6 +5,8 @@ namespace Faker\ORM\Doctrine;
 use Doctrine\Common\Persistence\ObjectManager;
 use Faker\Generator;
 
+require_once 'backward-compatibility.php';
+
 /**
  * Service class for populating a database using the Doctrine ORM or ODM.
  * A Populator can populate several tables using ActiveRecord classes.

--- a/src/Faker/ORM/Doctrine/backward-compatibility.php
+++ b/src/Faker/ORM/Doctrine/backward-compatibility.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-if (class_exists('\Doctrine\Persistence\Mapping\ClassMetadata') && !class_exists('Doctrine\Common\Persistence\Mapping\ClassMetadata')) {
+if (!class_exists('Doctrine\Common\Persistence\Mapping\ClassMetadata')) {
     class_alias(\Doctrine\Persistence\Mapping\ClassMetadata::class, 'Doctrine\Common\Persistence\Mapping\ClassMetadata');
 }
 
-if (class_exists('\Doctrine\Persistence\ObjectManager') && !class_exists('Doctrine\Common\Persistence\ObjectManager')) {
+if (!class_exists('Doctrine\Common\Persistence\ObjectManager')) {
     class_alias(\Doctrine\Persistence\ObjectManager::class, 'Doctrine\Common\Persistence\ObjectManager');
 }

--- a/src/Faker/ORM/Doctrine/backward-compatibility.php
+++ b/src/Faker/ORM/Doctrine/backward-compatibility.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-if (!class_exists('Doctrine\Common\Persistence\Mapping\ClassMetadata')) {
+if (class_exists('\Doctrine\Persistence\Mapping\ClassMetadata') && !class_exists('Doctrine\Common\Persistence\Mapping\ClassMetadata')) {
     class_alias(\Doctrine\Persistence\Mapping\ClassMetadata::class, 'Doctrine\Common\Persistence\Mapping\ClassMetadata');
 }
 
-if (!class_exists('Doctrine\Common\Persistence\ObjectManager')) {
+if (class_exists('\Doctrine\Persistence\ObjectManager') && !class_exists('Doctrine\Common\Persistence\ObjectManager')) {
     class_alias(\Doctrine\Persistence\ObjectManager::class, 'Doctrine\Common\Persistence\ObjectManager');
 }

--- a/test/Faker/ORM/Doctrine/ColumnTypeGuesserTest.php
+++ b/test/Faker/ORM/Doctrine/ColumnTypeGuesserTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\ORM\Doctrine;
+
+use Faker\ORM\Doctrine\ColumnTypeGuesser;
+use Faker\Test\TestCase;
+
+final class ColumnTypeGuesserTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testClassGenerationWithBackwardCompatibility(): void
+    {
+        $columnTypeGuesser = new ColumnTypeGuesser($this->faker);
+        // Mock ClassMetadata after autoload to test class alias
+        $classMetaData = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetaData->method('getTypeOfField')->with(self::anything())->willReturn('integer');
+
+        $fakerClosure = $columnTypeGuesser->guessFormat('test', $classMetaData);
+        self::assertIsNumeric($fakerClosure());
+    }
+}

--- a/test/Faker/ORM/Doctrine/EntityPopulatorTest.php
+++ b/test/Faker/ORM/Doctrine/EntityPopulatorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\ORM\Doctrine;
+
+use Faker\ORM\Doctrine\EntityPopulator;
+use Faker\Test\TestCase;
+
+final class EntityPopulatorTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testClassGenerationWithBackwardCompatibility(): void
+    {
+        // trigger autoload before using to load backward compatibility fix
+        class_exists(EntityPopulator::class);
+
+        $classMetaData = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetaData->method('getName')->willReturn('test');
+        $entityPopulator = new EntityPopulator($classMetaData);
+
+        self::assertSame('test', $entityPopulator->getClass());
+    }
+}

--- a/test/Faker/ORM/Doctrine/PopulatorTest.php
+++ b/test/Faker/ORM/Doctrine/PopulatorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\ORM\Doctrine;
+
+use Faker\ORM\Doctrine\Populator;
+use Faker\Test\TestCase;
+
+final class PopulatorTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testClassGenerationWithBackwardCompatibility(): void
+    {
+        $populator = new Populator($this->faker);
+        // Mock ObjectManager after autoload to test class alias
+        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+
+        self::assertEmpty($populator->execute($objectManager));
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

This will fix a PHP warning when trying to add a `class_alias` for non existing classes.
This happens if Faker is used while `doctrine/persistence` is not. This problem was introduces with PR #414

- [ ] A new feature
- [x] Fixed an issue (resolve #445)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Only load class aliases if `Faker\ORM\Doctrine` classes are autoloaded.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
