### PR TITLE
fix: typo in french phone number

### DIFF
--- a/src/Faker/Provider/fr_FR/PhoneNumber.php
+++ b/src/Faker/Provider/fr_FR/PhoneNumber.php
@@ -70,7 +70,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     ];
 
     protected static $e164Formats = [
-        '+33##########',
+        '+33#########',
     ];
 
     public function phoneNumber07()


### PR DESCRIPTION
### What is the reason for this PR?

The goal here is to generate as much as possible valid phone numbers.

The original code was one number too long. French phone numbers contains 10 numbers, starting by 0. But this was not generating always 0 for the first number.

In addition, when it comes to e164, the first 0 number is usually not specified (specifying it seems to be valid, but useless and it's not a usage of french people). The quick fix here is to remove this useless (wrong most part of the time!) number.

- [ ] A new feature
- [x] Fixed an issue (resolve #ID)

### Summary of changes

Fix: Removed a number in french e164 format

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
