### PR TITLE
Add Address::localCoordinates for de_DE provider

### DIFF
--- a/src/Faker/Provider/de_DE/Address.php
+++ b/src/Faker/Provider/de_DE/Address.php
@@ -126,7 +126,7 @@ class Address extends \Faker\Provider\Address
     
     /**
      * Coordinates inside the border of Germany.
-     * Reference: https://de.wikipedia.org/wiki/Liste_der_Extrempunkte_Deutschlands
+     * @see https://de.wikipedia.org/wiki/Liste_der_Extrempunkte_Deutschlands
      *
      * @example array('51.48239', '11.96994')
      *

--- a/src/Faker/Provider/de_DE/Address.php
+++ b/src/Faker/Provider/de_DE/Address.php
@@ -126,11 +126,12 @@ class Address extends \Faker\Provider\Address
     
     /**
      * Coordinates inside the border of Germany.
+     *
+     * @return array<string, float>
+     *
      * @see https://de.wikipedia.org/wiki/Liste_der_Extrempunkte_Deutschlands
      *
      * @example array('51.48239', '11.96994')
-     *
-     * @return array<string, float>
      */
     public static function localCoordinates()
     {

--- a/src/Faker/Provider/de_DE/Address.php
+++ b/src/Faker/Provider/de_DE/Address.php
@@ -123,7 +123,7 @@ class Address extends \Faker\Provider\Address
     {
         return static::regexify(self::numerify(static::randomElement(static::$buildingNumber)));
     }
-    
+
     /**
      * Coordinates inside the border of Germany.
      *

--- a/src/Faker/Provider/de_DE/Address.php
+++ b/src/Faker/Provider/de_DE/Address.php
@@ -130,7 +130,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example array('51.48239', '11.96994')
      *
-     * @return array | latitude, longitude
+     * @return array<string, float>
      */
     public static function localCoordinates()
     {

--- a/src/Faker/Provider/de_DE/Address.php
+++ b/src/Faker/Provider/de_DE/Address.php
@@ -123,4 +123,20 @@ class Address extends \Faker\Provider\Address
     {
         return static::regexify(self::numerify(static::randomElement(static::$buildingNumber)));
     }
+    
+    /**
+     * Coordinates inside the border of Germany.
+     * Reference: https://de.wikipedia.org/wiki/Liste_der_Extrempunkte_Deutschlands
+     *
+     * @example array('51.48239', '11.96994')
+     *
+     * @return array | latitude, longitude
+     */
+    public static function localCoordinates()
+    {
+        return [
+            'latitude' => static::latitude(47.271679, 54.91131),
+            'longitude' => static::longitude(5.866944, 15.04193),
+        ];
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

As a developer, I want to generate random coordinates within the borders of Germany, so that I can quickly test location-related features.

This PR implements `Address::localCoordinates` for the `de_DE` provider.

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR implements the `localCoordinates` method on the de_DE `Address` provider. Reference for the coordinate min/max is https://de.wikipedia.org/wiki/Liste_der_Extrempunkte_Deutschlands. As there are multiple northern extreme points, I picked the north-most point on main land (Rodenäs, Südtondern, Nordfriesland, Schleswig-Holstein), to reduce the amount of random coordinates that place you in the sea ;-)

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
