### PR TITLE
Fix: rename UserAgent edge to msedge

### DIFF
--- a/src/Faker/Provider/UserAgent.php
+++ b/src/Faker/Provider/UserAgent.php
@@ -4,7 +4,7 @@ namespace Faker\Provider;
 
 class UserAgent extends Base
 {
-    protected static $userAgents = ['firefox', 'chrome', 'internetExplorer', 'opera', 'safari', 'edge'];
+    protected static $userAgents = ['firefox', 'chrome', 'internetExplorer', 'opera', 'safari', 'msedge'];
 
     protected static $windowsPlatformTokens = [
         'Windows NT 6.2', 'Windows NT 6.1', 'Windows NT 6.0', 'Windows NT 5.2', 'Windows NT 5.1',
@@ -88,7 +88,7 @@ class UserAgent extends Base
      *
      * @return string
      */
-    public static function edge()
+    public static function msedge()
     {
         $saf = self::numberBetween(531, 537) . '.' . self::numberBetween(0, 2);
         $chrv = self::numberBetween(79, 99) . '.0';

--- a/src/Faker/Provider/UserAgent.php
+++ b/src/Faker/Provider/UserAgent.php
@@ -88,7 +88,7 @@ class UserAgent extends Base
      *
      * @return string
      */
-    public static function msedge()
+    public static function edge()
     {
         $saf = self::numberBetween(531, 537) . '.' . self::numberBetween(0, 2);
         $chrv = self::numberBetween(79, 99) . '.0';

--- a/test/Faker/Provider/UserAgentTest.php
+++ b/test/Faker/Provider/UserAgentTest.php
@@ -4,7 +4,6 @@ namespace Faker\Test\Provider;
 
 use Faker\Provider\UserAgent;
 use Faker\Test\TestCase;
-use ReflectionClass;
 
 /**
  * @group legacy
@@ -14,7 +13,7 @@ final class UserAgentTest extends TestCase
     public function testAllAgents()
     {
         $agent = new UserAgent($this->faker);
-        $reflection = new ReflectionClass($agent);
+        $reflection = new \ReflectionClass($agent);
         $agents = $reflection->getProperty('userAgents');
         $agents->setAccessible(true);
 

--- a/test/Faker/Provider/UserAgentTest.php
+++ b/test/Faker/Provider/UserAgentTest.php
@@ -4,12 +4,25 @@ namespace Faker\Test\Provider;
 
 use Faker\Provider\UserAgent;
 use Faker\Test\TestCase;
+use ReflectionClass;
 
 /**
  * @group legacy
  */
 final class UserAgentTest extends TestCase
 {
+    public function testAllAgents()
+    {
+        $agent = new UserAgent($this->faker);
+        $reflection = new ReflectionClass($agent);
+        $agents = $reflection->getProperty('userAgents');
+        $agents->setAccessible(true);
+
+        foreach ($agents->getValue() as $method) {
+            self::assertNotNull(UserAgent::$method());
+        }
+    }
+
     public function testRandomUserAgent()
     {
         self::assertNotNull(UserAgent::userAgent());


### PR DESCRIPTION
### What is the reason for this PR?
The useragent is called ['edge'](https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/UserAgent.php#L7), when calling a random userAgent via [`userAgent()`](https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/UserAgent.php#L57) it tries to call `userAgent->edge()` but the function is currently called [`msedge()`](https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/UserAgent.php#L91). This PR renames that static `edge` into `msedge`.

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [X] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

tl;dr - rename `edge` to `msedge`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
