### PR TITLE
Add image formats to `Faker\Provider\Image`

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -23,6 +23,13 @@ class Image extends Base
     ];
 
     /**
+     * @var array
+     */
+    protected static $imageFormats = [
+        'gif', 'jpg', 'jpeg', 'png',
+    ];
+
+    /**
      * Generate the URL that will return a random image
      *
      * Set randomize to false to remove the random GET parameter at the end of the url.
@@ -35,6 +42,7 @@ class Image extends Base
      * @param bool        $randomize
      * @param string|null $word
      * @param bool        $gray
+     * @param string      $format
      *
      * @return string
      */
@@ -44,9 +52,19 @@ class Image extends Base
         $category = null,
         $randomize = true,
         $word = null,
-        $gray = false
+        $gray = false,
+        $format = 'png'
     ) {
-        $size = sprintf('%dx%d.png', $width, $height);
+        // Validate image format
+        if (!in_array(strtolower($format), static::$imageFormats)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid image format "%s". Allowable formats are: %s',
+                $format,
+                implode(', ', static::$imageFormats)
+            ));
+        }
+
+        $size = sprintf('%dx%d.%s', $width, $height, $format);
 
         $imageParts = [];
 
@@ -90,7 +108,8 @@ class Image extends Base
         $fullPath = true,
         $randomize = true,
         $word = null,
-        $gray = false
+        $gray = false,
+        $format = 'png'
     ) {
         $dir = null === $dir ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
         // Validate directory path
@@ -101,10 +120,10 @@ class Image extends Base
         // Generate a random filename. Use the server address so that a file
         // generated at the same time on a different server won't have a collision.
         $name = md5(uniqid(empty($_SERVER['SERVER_ADDR']) ? '' : $_SERVER['SERVER_ADDR'], true));
-        $filename = $name . '.png';
+        $filename = $name . '.' . $format;
         $filepath = $dir . DIRECTORY_SEPARATOR . $filename;
 
-        $url = static::imageUrl($width, $height, $category, $randomize, $word, $gray);
+        $url = static::imageUrl($width, $height, $category, $randomize, $word, $gray, $format);
 
         // save file
         if (function_exists('curl_exec')) {

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -12,6 +12,10 @@ class Image extends Base
      */
     public const BASE_URL = 'https://via.placeholder.com';
 
+    public const FORMAT_JPG = 'jpg';
+    public const FORMAT_JPEG = 'jpeg';
+    public const FORMAT_PNG = 'png';
+
     /**
      * @var array
      *
@@ -20,13 +24,6 @@ class Image extends Base
     protected static $categories = [
         'abstract', 'animals', 'business', 'cats', 'city', 'food', 'nightlife',
         'fashion', 'people', 'nature', 'sports', 'technics', 'transport',
-    ];
-
-    /**
-     * @var array
-     */
-    public static $imageFormats = [
-        'gif', 'jpg', 'jpeg', 'png',
     ];
 
     /**
@@ -56,11 +53,12 @@ class Image extends Base
         $format = 'png'
     ) {
         // Validate image format
-        if (!in_array(strtolower($format), static::$imageFormats)) {
+        $imageFormats = static::getFormats();
+        if (!in_array(strtolower($format), $imageFormats, true)) {
             throw new \InvalidArgumentException(sprintf(
                 'Invalid image format "%s". Allowable formats are: %s',
                 $format,
-                implode(', ', static::$imageFormats)
+                implode(', ', $imageFormats)
             ));
         }
 
@@ -120,7 +118,7 @@ class Image extends Base
         // Generate a random filename. Use the server address so that a file
         // generated at the same time on a different server won't have a collision.
         $name = md5(uniqid(empty($_SERVER['SERVER_ADDR']) ? '' : $_SERVER['SERVER_ADDR'], true));
-        $filename = $name . '.' . $format;
+        $filename = sprintf('%s.%s', $name, $format);
         $filepath = $dir . DIRECTORY_SEPARATOR . $filename;
 
         $url = static::imageUrl($width, $height, $category, $randomize, $word, $gray, $format);
@@ -154,5 +152,19 @@ class Image extends Base
         }
 
         return $fullPath ? $filepath : $filename;
+    }
+
+    public static function getFormats(): array
+    {
+        return array_keys(static::getFormatConstants());
+    }
+
+    public static function getFormatConstants(): array
+    {
+        return [
+            static::FORMAT_JPG => constant('IMAGETYPE_JPEG'),
+            static::FORMAT_JPEG => constant('IMAGETYPE_JPEG'),
+            static::FORMAT_PNG => constant('IMAGETYPE_PNG')
+        ];
     }
 }

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -25,7 +25,7 @@ class Image extends Base
     /**
      * @var array
      */
-    protected static $imageFormats = [
+    public static $imageFormats = [
         'gif', 'jpg', 'jpeg', 'png',
     ];
 

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -54,6 +54,7 @@ class Image extends Base
     ) {
         // Validate image format
         $imageFormats = static::getFormats();
+
         if (!in_array(strtolower($format), $imageFormats, true)) {
             throw new \InvalidArgumentException(sprintf(
                 'Invalid image format "%s". Allowable formats are: %s',
@@ -164,7 +165,7 @@ class Image extends Base
         return [
             static::FORMAT_JPG => constant('IMAGETYPE_JPEG'),
             static::FORMAT_JPEG => constant('IMAGETYPE_JPEG'),
-            static::FORMAT_PNG => constant('IMAGETYPE_PNG')
+            static::FORMAT_PNG => constant('IMAGETYPE_PNG'),
         ];
     }
 }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -18,6 +18,22 @@ final class ImageTest extends TestCase
         );
     }
 
+    public function testImageUrlAcceptsDifferentImageFormats()
+    {
+        foreach (Image::$imageFormats as $format) {
+            self::assertMatchesRegularExpression(
+                '#^https://via.placeholder.com/640x480.'. $format .'/#',
+                Image::imageUrl(format: $format)
+            );
+        }
+    }
+
+    public function testImageUrlThrowsExceptionOnIllegalImageFormat()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Image::imageUrl(format: 'foo');
+    }
+
     public function testImageUrlAcceptsCustomWidthAndHeight()
     {
         self::assertMatchesRegularExpression(

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -18,22 +18,6 @@ final class ImageTest extends TestCase
         );
     }
 
-    public function testImageUrlAcceptsDifferentImageFormats()
-    {
-        foreach (Image::$imageFormats as $format) {
-            self::assertMatchesRegularExpression(
-                '#^https://via.placeholder.com/640x480.'. $format .'/#',
-                Image::imageUrl(format: $format)
-            );
-        }
-    }
-
-    public function testImageUrlThrowsExceptionOnInvalidImageFormat()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        Image::imageUrl(format: 'foo');
-    }
-
     public function testImageUrlAcceptsCustomWidthAndHeight()
     {
         self::assertMatchesRegularExpression(
@@ -101,9 +85,98 @@ final class ImageTest extends TestCase
         self::assertMatchesRegularExpression('#\w*#', $splitUrl[1]);
     }
 
+    public function testImageUrlThrowsExceptionOnInvalidImageFormat()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Image::imageUrl(
+            800,
+            400,
+            'nature',
+            false,
+            'Faker',
+            true,
+            'foo'
+        );
+    }
+
+    public function testImageUrlAcceptsDifferentImageFormats()
+    {
+        foreach (Image::getFormats() as $format) {
+            $imageUrl = Image::imageUrl(
+                800,
+                400,
+                'nature',
+                false,
+                'Faker',
+                true,
+                $format
+            );
+
+            self::assertMatchesRegularExpression(
+                "#^https://via.placeholder.com/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
+                $imageUrl
+            );
+        }
+    }
+
     public function testDownloadWithDefaults()
     {
-        $curlPing = curl_init(Image::BASE_URL);
+        self::checkUrlConnection(Image::BASE_URL);
+
+        $file = Image::image(sys_get_temp_dir());
+        self::assertFileExists($file);
+
+        self::checkImageProperties($file, 640, 480, 'png');
+    }
+
+    public function testDownloadWithDifferentImageFormats()
+    {
+        self::checkUrlConnection(Image::BASE_URL);
+
+        foreach (Image::getFormats() as $format) {
+            $width = 800;
+            $height = 400;
+            $file = Image::image(
+                sys_get_temp_dir(),
+                $width,
+                $height,
+                'nature',
+                true,
+                false,
+                'Faker',
+                true,
+                $format
+            );
+            self::assertFileExists($file);
+
+            self::checkImageProperties($file, $width, $height, $format);
+        }
+    }
+
+    private static function checkImageProperties(
+        string $file,
+        int $width,
+        int $height,
+        string $format
+    ) {
+        if (function_exists('getimagesize')) {
+            $imageConstants = Image::getFormatConstants();
+            [$actualWidth, $actualHeight, $type, $attr] = getimagesize($file);
+            self::assertEquals($width, $actualWidth);
+            self::assertEquals($height, $actualHeight);
+            self::assertEquals($imageConstants[$format], $type);
+        } else {
+            self::assertEquals($format, pathinfo($file, PATHINFO_EXTENSION));
+        }
+
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+
+    private static function checkUrlConnection(string $url)
+    {
+        $curlPing = curl_init($url);
         curl_setopt($curlPing, CURLOPT_TIMEOUT, 5);
         curl_setopt($curlPing, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($curlPing, CURLOPT_RETURNTRANSFER, true);
@@ -113,23 +186,7 @@ final class ImageTest extends TestCase
         curl_close($curlPing);
 
         if ($httpCode < 200 | $httpCode > 300) {
-            self::markTestSkipped('Placeholder.com is offline, skipping image download');
-        }
-
-        $file = Image::image(sys_get_temp_dir());
-        self::assertFileExists($file);
-
-        if (function_exists('getimagesize')) {
-            [$width, $height, $type, $attr] = getimagesize($file);
-            self::assertEquals(640, $width);
-            self::assertEquals(480, $height);
-            self::assertEquals(constant('IMAGETYPE_PNG'), $type);
-        } else {
-            self::assertEquals('png', pathinfo($file, PATHINFO_EXTENSION));
-        }
-
-        if (file_exists($file)) {
-            unlink($file);
+            self::markTestSkipped(sprintf('"%s" is offline, skipping test', $url));
         }
     }
 }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -28,7 +28,7 @@ final class ImageTest extends TestCase
         }
     }
 
-    public function testImageUrlThrowsExceptionOnIllegalImageFormat()
+    public function testImageUrlThrowsExceptionOnInvalidImageFormat()
     {
         $this->expectException(\InvalidArgumentException::class);
         Image::imageUrl(format: 'foo');


### PR DESCRIPTION
### What is the reason for this PR?
The [placeholder.com](https://placeholder.com/) API allows for a few image formats, whereas `image()` and `imageUrl()` in `Faker\Provider\Image` defaulted to `png`.

- [x] Slight feature extension

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented - PR #66](https://github.com/FakerPHP/fakerphp.github.io/pull/66)

### Summary of changes
Added a static array to `Faker\Provider\Image` which contains allowable image formats (per Placeholder). Appended `$format` argument to both `Image::image()` and `Image::imageUrl()` which defaults to 'png'. Throw an exception in `Image::imageUrl()` if an invalid format is received. Wrote unit tests for all the image formats and `IllegalArgumentException`.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
