### PR TITLE
run 'mkdir' only if the directory doesn't exist yet

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,8 +13,10 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config('faker');
 
-if( !file_exists('.build/php-cs-fixer'))
+if (!file_exists('.build/php-cs-fixer')) {
     mkdir('.build/php-cs-fixer', 0755, true);
+}
+
 return $config
     ->setCacheFile('.build/php-cs-fixer/cache')
     ->setFinder($finder)

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,7 +13,7 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config('faker');
 
-if (!file_exists('.build/php-cs-fixer')) {
+if (!is_dir('.build/php-cs-fixer')) {
     mkdir('.build/php-cs-fixer', 0755, true);
 }
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,7 +13,8 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config('faker');
 
-mkdir('.build/php-cs-fixer', 0755, true);
+if( !file_exists('.build/php-cs-fixer'))
+    mkdir('.build/php-cs-fixer', 0755, true);
 return $config
     ->setCacheFile('.build/php-cs-fixer/cache')
     ->setFinder($finder)


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [X] Fixed an issue (resolve #ID)

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes
When we run the `make cs` command twice, this error occurs:
```bash
In .php-cs-fixer.dist.php line 16:
                        
  [ErrorException]      
  mkdir(): File exists  
                        

Exception trace:
  at /home/fgaroby/workspace/Faker/.php-cs-fixer.dist.php:16
 {closure}() at n/a:n/a
 mkdir() at /home/fgaroby/workspace/Faker/.php-cs-fixer.dist.php:16
 include() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/src/Console/ConfigurationResolver.php:946
 PhpCsFixer\Console\ConfigurationResolver::separatedContextLessInclude() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/src/Console/ConfigurationResolver.php:267
 PhpCsFixer\Console\ConfigurationResolver->getConfig() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/src/Console/ConfigurationResolver.php:598
 PhpCsFixer\Console\ConfigurationResolver->getFormat() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/src/Console/ConfigurationResolver.php:444
 PhpCsFixer\Console\ConfigurationResolver->getReporter() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/src/Console/Command/FixCommand.php:261
 PhpCsFixer\Console\Command\FixCommand->execute() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/symfony/console/Application.php:1009
 Symfony\Component\Console\Application->doRunCommand() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/symfony/console/Application.php:273
 Symfony\Component\Console\Application->doRun() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/src/Console/Application.php:97
 PhpCsFixer\Console\Application->doRun() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/symfony/console/Application.php:149
 Symfony\Component\Console\Application->run() at /home/fgaroby/workspace/Faker/vendor-bin/php-cs-fixer/vendor/friendsofphp/php-cs-fixer/php-cs-fixer:115

fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--cache-file CACHE-FILE] [--diff] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--] [<path>...]

make: *** [Makefile:13 : cs] Error 1
```
This PR checks if the directory doesn't exit yet.

### Review checklist

- [X] All checks have passed
- [ ] Changes are approved by maintainer
