### PR TITLE
Skip incompatible test cases on 32-bit systems

### DIFF
--- a/test/Faker/Core/DateTimeTest.php
+++ b/test/Faker/Core/DateTimeTest.php
@@ -43,6 +43,8 @@ final class DateTimeTest extends TestCase
 
     public function testDateTimeAD()
     {
+        $this->skipOn32bitSystem();
+
         $dateTime = $this->extension->dateTimeAD('2012-04-12T19:22:23');
 
         self::assertInstanceOf(\DateTime::class, $dateTime);
@@ -122,6 +124,8 @@ final class DateTimeTest extends TestCase
 
     public function testDate()
     {
+        $this->skipOn32bitSystem();
+
         $date = $this->extension->date('Y-m-d', '2102-11-12T14:45:29');
 
         self::assertIsString($date);

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -238,6 +238,8 @@ final class DateTimeTest extends TestCase
 
     public function testFixedSeedWithMaximumTimestamp()
     {
+        $this->skipOn32bitSystem();
+
         $max = '2118-03-01 12:00:00';
 
         mt_srand(1);

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -35,7 +35,7 @@ final class PersonTest extends TestCase
 
     public function testPersonalIdentityNumberGeneratesCompliantNumbers()
     {
-        if (strtotime('1800-01-01 00:00:00')) {
+        if (!$this->is32bitSystem()) {
             $min = '1900';
             $max = '2099';
 

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -18,6 +18,8 @@ final class PersonTest extends TestCase
      */
     public function testIndividualIdentificationNumberIsValid()
     {
+        $this->skipOn32bitSystem();
+
         // 21st century.
         $birthDate = DateTime::dateTimeBetween('2000-01-01', '2099-12-31');
         $individualIdentificationNumber = $this->faker->individualIdentificationNumber($birthDate, Person::GENDER_MALE);

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -13,6 +13,12 @@ final class PersonTest extends TestCase
 {
     public const TEST_CNP_REGEX = '/^[1-9][0-9]{2}(?:0[1-9]|1[012])(?:0[1-9]|[12][0-9]|3[01])(?:0[1-9]|[123][0-9]|4[0-6]|5[12])[0-9]{3}[0-9]$/';
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skipOn32bitSystem();
+    }
+
     public function invalidGenderProvider()
     {
         return [

--- a/test/Faker/TestCase.php
+++ b/test/Faker/TestCase.php
@@ -51,4 +51,16 @@ abstract class TestCase extends BaseTestCase
     {
         return [];
     }
+
+    protected function is32bitSystem(): bool
+    {
+        return PHP_INT_SIZE === 4;
+    }
+
+    protected function skipOn32bitSystem(): void
+    {
+        if ($this->is32bitSystem()) {
+            self::markTestSkipped('Test case is incompatible with 32-bit systems.');
+        }
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [X] Fixed an issue

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Several test cases are incompatible with 32-bit systems due to datetimes that cannot fit in the 32-bit epoch.

    strtotime(): Epoch doesn't fit in a PHP integer

This change skips those test cases.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
