### PR TITLE
Fix name spelling error in lt_LT locale

### DIFF
--- a/src/Faker/Provider/lt_LT/Person.php
+++ b/src/Faker/Provider/lt_LT/Person.php
@@ -238,7 +238,7 @@ class Person extends \Faker\Provider\Person
      * @see http://www.horoskopai.lt/gaires/populiariausios-pavardes-lietuvoje/
      */
     protected static $lastNameMale = [
-        'Kazlaukas', 'Jankauskas', 'Petrauskas', 'Stankevičius', 'Vasiliauskas', 'Žukauskas', 'Butkus',
+        'Kazlauskas', 'Jankauskas', 'Petrauskas', 'Stankevičius', 'Vasiliauskas', 'Žukauskas', 'Butkus',
         'Kateiva', 'Paulauskas', 'Urbonas', 'Kavaliauskas', 'Baranauskas', 'Pocius', 'Sakalauskas',
     ];
 


### PR DESCRIPTION
### What is the reason for this PR?

- [ ] A new feature
- [x] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR fixes the spelling error pointed out in [issue #521](https://github.com/FakerPHP/Faker/issues/521) for the male surname Kazlauskas in the lt_LT locale. According to [this page](https://surnames.behindthename.com/name/kazlauskas/), it is the most common surname in Lithuania. 

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
