### PR TITLE
Ensure French department number to be return as string

### DIFF
--- a/src/Faker/Provider/fr_FR/Address.php
+++ b/src/Faker/Provider/fr_FR/Address.php
@@ -53,26 +53,26 @@ class Address extends \Faker\Provider\Address
     ];
 
     private static $departments = [
-        ['01' => 'Ain'], ['02' => 'Aisne'], ['03' => 'Allier'], ['04' => 'Alpes-de-Haute-Provence'], ['05' => 'Hautes-Alpes'],
-        ['06' => 'Alpes-Maritimes'], ['07' => 'Ardèche'], ['08' => 'Ardennes'], ['09' => 'Ariège'], ['10' => 'Aube'],
-        ['11' => 'Aude'], ['12' => 'Aveyron'], ['13' => 'Bouches-du-Rhône'], ['14' => 'Calvados'], ['15' => 'Cantal'],
-        ['16' => 'Charente'], ['17' => 'Charente-Maritime'], ['18' => 'Cher'], ['19' => 'Corrèze'], ['2A' => 'Corse-du-Sud'],
-        ['2B' => 'Haute-Corse'], ['21' => "Côte-d'Or"], ['22' => "Côtes-d'Armor"], ['23' => 'Creuse'], ['24' => 'Dordogne'],
-        ['25' => 'Doubs'], ['26' => 'Drôme'], ['27' => 'Eure'], ['28' => 'Eure-et-Loir'], ['29' => 'Finistère'], ['30' => 'Gard'],
-        ['31' => 'Haute-Garonne'], ['32' => 'Gers'], ['33' => 'Gironde'], ['34' => 'Hérault'], ['35' => 'Ille-et-Vilaine'],
-        ['36' => 'Indre'], ['37' => 'Indre-et-Loire'], ['38' => 'Isère'], ['39' => 'Jura'], ['40' => 'Landes'], ['41' => 'Loir-et-Cher'],
-        ['42' => 'Loire'], ['43' => 'Haute-Loire'], ['44' => 'Loire-Atlantique'], ['45' => 'Loiret'], ['46' => 'Lot'],
-        ['47' => 'Lot-et-Garonne'], ['48' => 'Lozère'], ['49' => 'Maine-et-Loire'], ['50' => 'Manche'], ['51' => 'Marne'],
-        ['52' => 'Haute-Marne'], ['53' => 'Mayenne'], ['54' => 'Meurthe-et-Moselle'], ['55' => 'Meuse'], ['56' => 'Morbihan'],
-        ['57' => 'Moselle'], ['58' => 'Nièvre'], ['59' => 'Nord'], ['60' => 'Oise'], ['61' => 'Orne'], ['62' => 'Pas-de-Calais'],
-        ['63' => 'Puy-de-Dôme'], ['64' => 'Pyrénées-Atlantiques'], ['65' => 'Hautes-Pyrénées'], ['66' => 'Pyrénées-Orientales'],
-        ['67' => 'Bas-Rhin'], ['68' => 'Haut-Rhin'], ['69' => 'Rhône'], ['70' => 'Haute-Saône'], ['71' => 'Saône-et-Loire'],
-        ['72' => 'Sarthe'], ['73' => 'Savoie'], ['74' => 'Haute-Savoie'], ['75' => 'Paris'], ['76' => 'Seine-Maritime'],
-        ['77' => 'Seine-et-Marne'], ['78' => 'Yvelines'], ['79' => 'Deux-Sèvres'], ['80' => 'Somme'], ['81' => 'Tarn'],
-        ['82' => 'Tarn-et-Garonne'], ['83' => 'Var'], ['84' => 'Vaucluse'], ['85' => 'Vendée'], ['86' => 'Vienne'],
-        ['87' => 'Haute-Vienne'], ['88' => 'Vosges'], ['89' => 'Yonne'], ['90' => 'Territoire de Belfort'], ['91' => 'Essonne'],
-        ['92' => 'Hauts-de-Seine'], ['93' => 'Seine-Saint-Denis'], ['94' => 'Val-de-Marne'], ['95' => "Val-d'Oise"],
-        ['971' => 'Guadeloupe'], ['972' => 'Martinique'], ['973' => 'Guyane'], ['974' => 'La Réunion'], ['976' => 'Mayotte'],
+        ['Ain' => '01'], ['Aisne' => '02'], ['Allier' => '03'], ['Alpes-de-Haute-Provence' => '04'], ['Hautes-Alpes' => '05'],
+        ['Alpes-Maritimes' => '06'], ['Ardèche' => '07'], ['Ardennes' => '08'], ['Ariège' => '09'], ['Aube' => '10'],
+        ['Aude' => '11'], ['Aveyron' => '12'], ['Bouches-du-Rhône' => '13'], ['Calvados' => '14'], ['Cantal' => '15'],
+        ['Charente' => '16'], ['Charente-Maritime' => '17'], ['Cher' => '18'], ['Corrèze' => '19'], ['Corse-du-Sud' => '2A'],
+        ['Haute-Corse' => '2B'], ["Côte-d'Or" => '21'], ["Côtes-d'Armor" => '22'], ['Creuse' => '23'], ['Dordogne' => '24'],
+        ['Doubs' => '25'], ['Drôme' => '26'], ['Eure' => '27'], ['Eure-et-Loir' => '28'], ['Finistère' => '29'], ['Gard' => '30'],
+        ['Haute-Garonne' => '31'], ['Gers' => '32'], ['Gironde' => '33'], ['Hérault' => '34'], ['Ille-et-Vilaine' => '35'],
+        ['Indre' => '36'], ['Indre-et-Loire' => '37'], ['Isère' => '38'], ['Jura' => '39'], ['Landes' => '40'], ['Loir-et-Cher' => '41'],
+        ['Loire' => '42'], ['Haute-Loire' => '43'], ['Loire-Atlantique' => '44'], ['Loiret' => '45'], ['Lot' => '46'],
+        ['Lot-et-Garonne' => '47'], ['Lozère' => '48'], ['Maine-et-Loire' => '49'], ['Manche' => '50'], ['Marne' => '51'],
+        ['Haute-Marne' => '52'], ['Mayenne' => '53'], ['Meurthe-et-Moselle' => '54'], ['Meuse' => '55'], ['Morbihan' => '56'],
+        ['Moselle' => '57'], ['Nièvre' => '58'], ['Nord' => '59'], ['Oise' => '60'], ['Orne' => '61'], ['Pas-de-Calais' => '62'],
+        ['Puy-de-Dôme' => '63'], ['Pyrénées-Atlantiques' => '64'], ['Hautes-Pyrénées' => '65'], ['Pyrénées-Orientales' => '66'],
+        ['Bas-Rhin' => '67'], ['Haut-Rhin' => '68'], ['Rhône' => '69'], ['Haute-Saône' => '70'], ['Saône-et-Loire' => '71'],
+        ['Sarthe' => '72'], ['Savoie' => '73'], ['Haute-Savoie' => '74'], ['Paris' => '75'], ['Seine-Maritime' => '76'],
+        ['Seine-et-Marne' => '77'], ['Yvelines' => '78'], ['Deux-Sèvres' => '79'], ['Somme' => '80'], ['Tarn' => '81'],
+        ['Tarn-et-Garonne' => '82'], ['Var' => '83'], ['Vaucluse' => '84'], ['Vendée' => '85'], ['Vienne' => '86'],
+        ['Haute-Vienne' => '87'], ['Vosges' => '88'], ['Yonne' => '89'], ['Territoire de Belfort' => '90'], ['Essonne' => '91'],
+        ['Hauts-de-Seine' => '92'], ['Seine-Saint-Denis' => '93'], ['Val-de-Marne' => '94'], ["Val-d'Oise" => '95'],
+        ['Guadeloupe' => '971'], ['Martinique' => '972'], ['Guyane' => '973'], ['La Réunion' => '974'], ['Mayotte' => '976'],
     ];
 
     protected static $secondaryAddressFormats = ['Apt. ###', 'Suite ###', 'Étage ###', 'Bât. ###', 'Chambre ###'];
@@ -106,9 +106,9 @@ class Address extends \Faker\Provider\Address
     }
 
     /**
-     * Randomly returns a french department ('departmentNumber' => 'departmentName').
+     * Randomly returns a french department ('departmentName' => 'departmentNumber').
      *
-     * @example array('2B' => 'Haute-Corse')
+     * @example array('Haute-Corse' => '2B')
      *
      * @return array
      */
@@ -126,7 +126,7 @@ class Address extends \Faker\Provider\Address
      */
     public static function departmentName()
     {
-        $randomDepartmentName = array_values(static::department());
+        $randomDepartmentName = array_keys(static::department());
 
         return $randomDepartmentName[0];
     }
@@ -140,7 +140,7 @@ class Address extends \Faker\Provider\Address
      */
     public static function departmentNumber()
     {
-        $randomDepartmentNumber = array_keys(static::department());
+        $randomDepartmentNumber = array_values(static::department());
 
         return $randomDepartmentNumber[0];
     }

--- a/src/Faker/Provider/fr_FR/Person.php
+++ b/src/Faker/Provider/fr_FR/Person.php
@@ -93,7 +93,7 @@ class Person extends \Faker\Provider\Person
             sprintf('%02d', $this->numberBetween(1, 12));
 
         // Department
-        $department = key(Address::department());
+        $department = current(Address::department());
         $nir .= $department;
 
         // Town number, depends on department length

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -12,14 +12,36 @@ final class AddressTest extends TestCase
 {
     public function testSecondaryAddress(): void
     {
-        self::assertEquals('Étage 007', $this->faker->secondaryAddress());
-        self::assertEquals('Bât. 932', $this->faker->secondaryAddress());
+        self::assertSame('Étage 007', $this->faker->secondaryAddress());
+        self::assertSame('Bât. 932', $this->faker->secondaryAddress());
+    }
+
+    public function testStreetPrefix()
+    {
+        self::assertSame('boulevard', $this->faker->streetPrefix());
+        self::assertSame('rue', $this->faker->streetPrefix());
     }
 
     public function testRegion(): void
     {
-        self::assertEquals('Occitanie', $this->faker->region());
-        self::assertEquals('Auvergne-Rhône-Alpes', $this->faker->region());
+        self::assertSame('Occitanie', $this->faker->region());
+        self::assertSame('Auvergne-Rhône-Alpes', $this->faker->region());
+    }
+
+    public function testDepartment()
+    {
+        self::assertSame(['Nièvre' => '58'], $this->faker->department());
+        self::assertSame(['Ain' => '01'], $this->faker->department());
+    }
+
+    public function testDepartmentName()
+    {
+        self::assertSame('Nièvre', $this->faker->departmentName());
+    }
+
+    public function testDepartmentNumber()
+    {
+        self::assertSame('58', $this->faker->departmentNumber());
     }
 
     protected function getProviders(): iterable


### PR DESCRIPTION
### What is the reason for this PR?

- [ ] A new feature
- [x] Fixed an issue (resolve #391 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Reversal of the department name and number so that the latter is always returned as a string

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
