### PR TITLE
Update French regions list, remove TOM

### DIFF
--- a/src/Faker/Provider/fr_FR/Address.php
+++ b/src/Faker/Provider/fr_FR/Address.php
@@ -43,13 +43,13 @@ class Address extends \Faker\Provider\Address
         'Territoire britannique de l\'océan Indien', 'Territoires français du sud', 'Thailande', 'Timor', 'Togo', 'Tokelau', 'Tonga', 'Trinité et Tobago', 'Tunisie', 'Turkménistan', 'Turks et Caïques (Îles)', 'Turquie', 'Tuvalu', 'Ukraine', 'Uruguay', 'Vanuatu', 'Vatican (Etat du)', 'Venezuela', 'Vierges (Îles)', 'Vierges britanniques (Îles)', 'Vietnam', 'Wallis et Futuna (Îles)', 'Yemen', 'Yougoslavie', 'Zambie', 'Zaïre', 'Zimbabwe',
     ];
 
+    /**
+     * @see https://en.wikipedia.org/wiki/Regions_of_France
+     */
     private static $regions = [
-        'Alsace', 'Aquitaine', 'Auvergne', 'Bourgogne', 'Bretagne', 'Centre', 'Champagne-Ardenne',
-        'Corse', 'Franche-Comté', 'Île-de-France', 'Languedoc-Roussillon', 'Limousin',
-        'Lorraine', 'Midi-Pyrénées', 'Nord-Pas-de-Calais', 'Basse-Normandie', 'Haute-Normandie',
-        'Pays-de-Loire', 'Picardie', 'Poitou-Charentes', "Provence-Alpes-Côte d'Azur", 'Rhone-Alpes',
-        'Guadeloupe', 'Martinique', 'Guyane', 'Réunion', 'Saint-Pierre-et-Miquelon', 'Mayotte',
-        'Saint-Barthélémy', 'Saint-Martin', 'Wallis-et-Futuna', 'Polynésie française', 'Nouvelle-Calédonie',
+        'Auvergne-Rhône-Alpes', 'Bourgogne-Franche-Comté', 'Bretagne', 'Centre-Val de Loire', 'Corse', 'Grand Est', 'Hauts-de-France',
+        'Île-de-France', 'Normandie', 'Nouvelle-Aquitaine', 'Occitanie', 'Pays de la Loire', "Provence-Alpes-Côte d'Azur",
+        'Guadeloupe', 'Martinique', 'Guyane', 'La Réunion', 'Mayotte',
     ];
 
     private static $departments = [

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -12,9 +12,14 @@ final class AddressTest extends TestCase
 {
     public function testSecondaryAddress()
     {
-        $secondaryAdress = $this->faker->secondaryAddress();
-        self::assertNotEmpty($secondaryAdress);
-        self::assertIsString($secondaryAdress);
+        self::assertEquals('Étage 007', $this->faker->secondaryAddress());
+        self::assertEquals('Bât. 932', $this->faker->secondaryAddress());
+    }
+
+    public function testRegion()
+    {
+        self::assertEquals('Occitanie', $this->faker->region());
+        self::assertEquals('Auvergne-Rhône-Alpes', $this->faker->region());
     }
 
     protected function getProviders(): iterable


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Since 2015 and the NOTRe law, French regions have been merged. Moreover, Saint-Pierre-et-Miquelon, Saint-Barthélémy, Saint-Martin, Wallis-et-Futuna, Polynésie française and the Nouvelle-Calédonie are TOM, not ROM.

https://en.wikipedia.org/wiki/Regions_of_France

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
