### PR TITLE
Fix: Drop support for PHP 7.1, 7.2, and 7.3

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.4"
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ jobs:
         operating-system:
           - "ubuntu-latest"
         php-version:
-          - "7.1"
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.20.0...main)
 
+- Dropped support for PHP 7.1, 7.2, and 7.3 (#543)
+
 ## [2022-07-20, v1.20.0](https://github.com/FakerPHP/Faker/compare/v1.19.0..v1.20.0)
 
 - Fixed typo in French phone number (#452)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It's heavily inspired by Perl's [Data::Faker](https://metacpan.org/pod/Data::Fak
 
 ### Installation
 
-Faker requires PHP >= 7.1.
+Faker requires PHP >= 7.4.
 
 ```shell
 composer require fakerphp/faker

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },
@@ -50,7 +50,10 @@
             "bamarni/composer-bin-plugin": true,
             "composer/package-versions-deprecated": true
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "7.4.32"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,11 +1,11 @@
 {
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "friendsofphp/php-cs-fixer": "^3.3.0"
     },
     "config": {
         "platform": {
-            "php": "7.1.33"
+            "php": "7.4.32"
         },
         "preferred-install": "dist",
         "sort-packages": true

--- a/vendor-bin/php-cs-fixer/composer.lock
+++ b/vendor-bin/php-cs-fixer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7ed5b5ca7a1a555f6841c04fb41da1d",
+    "content-hash": "5a3d8a39f5b3ca9b528e459bd7271808",
     "packages": [
         {
             "name": "composer/semver",
@@ -1713,11 +1713,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.4.32"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,13 +1,13 @@
 {
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "phpstan/extension-installer": "^1.1.0",
         "phpstan/phpstan": "^0.12.100",
         "phpstan/phpstan-deprecation-rules": "^0.12.6"
     },
     "config": {
         "platform": {
-            "php": "7.1.33"
+            "php": "7.4.32"
         },
         "preferred-install": "dist",
         "sort-packages": true,

--- a/vendor-bin/phpstan/composer.lock
+++ b/vendor-bin/phpstan/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98c8b515ce5fdac0bcbb29369b89f117",
+    "content-hash": "7b6c08f79ca08061f5282b0ca46daf3c",
     "packages": [
         {
             "name": "phpstan/extension-installer",
@@ -170,11 +170,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.4.32"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,11 +1,11 @@
 {
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "vimeo/psalm": "^4.30.0"
     },
     "config": {
         "platform": {
-            "php": "7.1.33"
+            "php": "7.4.32"
         },
         "preferred-install": "dist",
         "sort-packages": true,

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c06b8d5f9750932bd65c549e1674c120",
+    "content-hash": "6440bd3321cecaca3d65a7d334326aab",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1806,11 +1806,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.4.32"
     },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] drop support for outdated PHP versions
- [x] runs `make baseline`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Dropping support for outdated PHP versions, see https://www.php.net/supported-versions.php.

### Review checklist

- [ ] All checks have passed
- [x] Changes are approved by maintainer
