### PR TITLE
Fix: Do not install project dependencies for running `friendsofphp/php-cs-fixer`

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -44,9 +44,7 @@ jobs:
             composer-
 
       - name: Download dependencies
-        run: |
-          composer update --no-interaction --no-progress --optimize-autoloader
-          composer bin php-cs-fixer install --no-interaction --no-progress --optimize-autoloader
+        run: composer bin php-cs-fixer install --no-interaction --no-progress --optimize-autoloader
 
       - name: Cache cache file for php-cs-fixer
         uses: actions/cache@v3


### PR DESCRIPTION
### What is the reason for this PR?

- [x] stop installing project dependencies for running `friendsofphp/php-cs-fixer`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
