### PR TITLE
Fix: Assemble cache key from branch name

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -52,9 +52,10 @@ jobs:
         uses: "actions/cache@v3"
         with:
           path: ".php_cs.cache"
-          key: "composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}"
+          key: "composer-${{ runner.os }}-${{ matrix.php-version }}-${{ github.ref_name }}"
           restore-keys: |
-            composer-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-main
+            composer-${{ runner.os }}-${{ matrix.php-version }}
             composer-${{ runner.os }}-
             composer-
 


### PR DESCRIPTION
### What is the reason for this PR?

- [x] assembles the cache key for caching the cache file for `friendsofphp/php-cs-fixer` from the branch name

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
