### PR TITLE
Fix: Configure `no_trailing_comma_in_singleline` instead of deprecated `no_trailing_comma_in_singleline_array` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -102,7 +102,11 @@ return $config
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => [
+            'elements' => [
+                'array',
+            ],
+        ],
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,


### PR DESCRIPTION
### What is the reason for this PR?

- [x] configures the `no_trailing_comma_in_singleline` instead of deprecated `no_trailing_comma_in_singleline_array` fixer following #551

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
