### PR TITLE
Enhancement: Configure `trailing_comma_in_multiline` fixer to include `arguments` in `elements` option

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -192,6 +192,7 @@ return $config
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline' => [
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/src/Faker/Calculator/Isbn.php
+++ b/src/Faker/Calculator/Isbn.php
@@ -36,7 +36,7 @@ class Isbn
             $digits,
             static function (&$digit, $position): void {
                 $digit = (10 - $position) * $digit;
-            }
+            },
         );
         $result = (11 - array_sum($digits) % 11) % 11;
 

--- a/src/Faker/Container/Container.php
+++ b/src/Faker/Container/Container.php
@@ -46,7 +46,7 @@ final class Container implements ContainerInterface
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(
                 'First argument of %s::get() must be string',
-                self::class
+                self::class,
             ));
         }
 
@@ -57,7 +57,7 @@ final class Container implements ContainerInterface
         if (!$this->has($id)) {
             throw new NotInContainerException(sprintf(
                 'There is not service with id "%s" in the container.',
-                $id
+                $id,
             ));
         }
 
@@ -69,7 +69,7 @@ final class Container implements ContainerInterface
             throw new \RuntimeException(sprintf(
                 'Service resolved for identifier "%s" does not implement the %s" interface.',
                 $id,
-                Extension::class
+                Extension::class,
             ));
         }
 
@@ -90,7 +90,7 @@ final class Container implements ContainerInterface
                 throw new ContainerException(
                     sprintf('Error while invoking callable for "%s"', $id),
                     0,
-                    $e
+                    $e,
                 );
             }
         } elseif (is_object($definition)) {
@@ -106,12 +106,12 @@ final class Container implements ContainerInterface
 
             throw new ContainerException(sprintf(
                 'Could not instantiate class "%s". Class was not found.',
-                $id
+                $id,
             ));
         } else {
             throw new ContainerException(sprintf(
                 'Invalid type for definition with id "%s"',
-                $id
+                $id,
             ));
         }
     }
@@ -128,7 +128,7 @@ final class Container implements ContainerInterface
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(
                 'First argument of %s::get() must be string',
-                self::class
+                self::class,
             ));
         }
 

--- a/src/Faker/Container/ContainerBuilder.php
+++ b/src/Faker/Container/ContainerBuilder.php
@@ -34,7 +34,7 @@ final class ContainerBuilder
         if (!is_string($value) && !is_callable($value) && !is_object($value)) {
             throw new \InvalidArgumentException(sprintf(
                 'First argument to "%s::add()" must be a string, callable or object.',
-                self::class
+                self::class,
             ));
         }
 
@@ -46,7 +46,7 @@ final class ContainerBuilder
             } else {
                 throw new \InvalidArgumentException(sprintf(
                     'Second argument to "%s::add()" is required not passing a string or object as first argument',
-                    self::class
+                    self::class,
                 ));
             }
         }

--- a/src/Faker/Core/Blood.php
+++ b/src/Faker/Core/Blood.php
@@ -36,7 +36,7 @@ final class Blood implements Extension\BloodExtension
         return sprintf(
             '%s%s',
             $this->bloodType(),
-            $this->bloodRh()
+            $this->bloodRh(),
         );
     }
 }

--- a/src/Faker/Core/Color.php
+++ b/src/Faker/Core/Color.php
@@ -78,7 +78,7 @@ final class Color implements Extension\ColorExtension
             $color[1],
             $color[1],
             $color[2],
-            $color[2]
+            $color[2],
         );
     }
 
@@ -113,7 +113,7 @@ final class Color implements Extension\ColorExtension
     {
         return sprintf(
             'rgb(%s)',
-            $this->rgbColor()
+            $this->rgbColor(),
         );
     }
 
@@ -127,7 +127,7 @@ final class Color implements Extension\ColorExtension
         return sprintf(
             'rgba(%s,%s)',
             $this->rgbColor(),
-            $number->randomFloat(1, 0, 1)
+            $number->randomFloat(1, 0, 1),
         );
     }
 
@@ -158,7 +158,7 @@ final class Color implements Extension\ColorExtension
             '%s,%s,%s',
             $number->numberBetween(0, 360),
             $number->numberBetween(0, 100),
-            $number->numberBetween(0, 100)
+            $number->numberBetween(0, 100),
         );
     }
 

--- a/src/Faker/Core/DateTime.php
+++ b/src/Faker/Core/DateTime.php
@@ -89,7 +89,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
     {
         return $this->setTimezone(
             $this->getTimestampDateTime($this->unixTime($until)),
-            $timezone
+            $timezone,
         );
     }
 
@@ -99,7 +99,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
 
         return $this->setTimezone(
             $this->getTimestampDateTime($this->generator->numberBetween($min, $this->getTimestamp($until))),
-            $timezone
+            $timezone,
         );
     }
 
@@ -116,7 +116,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
 
         return $this->setTimezone(
             $this->getTimestampDateTime($timestamp),
-            $timezone
+            $timezone,
         );
     }
 

--- a/src/Faker/Core/Uuid.php
+++ b/src/Faker/Core/Uuid.php
@@ -50,7 +50,7 @@ final class Uuid implements UuidExtension
             $byte[12],
             $byte[13],
             $byte[14],
-            $byte[15]
+            $byte[15],
         );
     }
 }

--- a/src/Faker/Core/Version.php
+++ b/src/Faker/Core/Version.php
@@ -26,7 +26,7 @@ final class Version implements VersionExtension
             mt_rand(0, 99),
             mt_rand(0, 99),
             $preRelease && mt_rand(0, 1) ? '-' . $this->semverPreReleaseIdentifier() : '',
-            $build && mt_rand(0, 1) ? '+' . $this->semverBuildIdentifier() : ''
+            $build && mt_rand(0, 1) ? '+' . $this->semverBuildIdentifier() : '',
         );
     }
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -584,7 +584,7 @@ class Generator
         if (!$this->container->has($id)) {
             throw new Extension\ExtensionNotFound(sprintf(
                 'No Faker extension with id "%s" was loaded.',
-                $id
+                $id,
             ));
         }
 
@@ -893,7 +893,7 @@ class Generator
         return $this->ext(Extension\NumberExtension::class)->randomFloat(
             $nbMaxDecimals !== null ? (int) $nbMaxDecimals : null,
             (float) $min,
-            $max !== null ? (float) $max : null
+            $max !== null ? (float) $max : null,
         );
     }
 
@@ -911,7 +911,7 @@ class Generator
     {
         return $this->ext(Extension\NumberExtension::class)->randomNumber(
             $nbDigits !== null ? (int) $nbDigits : null,
-            (bool) $strict
+            (bool) $strict,
         );
     }
 

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -205,7 +205,7 @@ class EntityPopulator
                         'Failed to generate a value for %s::%s: %s',
                         get_class($obj),
                         $field,
-                        $ex->getMessage()
+                        $ex->getMessage(),
                     ));
                 }
                 // Try a standard setter if it's available, otherwise fall back on reflection

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -111,7 +111,7 @@ class Populator
                 $insertedEntities[$class][] = $this->entities[$class]->execute(
                     $entityManager,
                     $insertedEntities,
-                    $generateId
+                    $generateId,
                 );
 
                 if (count($insertedEntities) % $this->batchSize === 0) {

--- a/src/Faker/ORM/Spot/Populator.php
+++ b/src/Faker/ORM/Spot/Populator.php
@@ -79,7 +79,7 @@ class Populator
         foreach ($this->quantities as $entityName => $number) {
             for ($i = 0; $i < $number; ++$i) {
                 $insertedEntities[$entityName][] = $this->entities[$entityName]->execute(
-                    $insertedEntities
+                    $insertedEntities,
                 );
             }
         }

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -138,7 +138,7 @@ class Color extends Base
             '%s,%s,%s',
             self::numberBetween(0, 360),
             self::numberBetween(0, 100),
-            self::numberBetween(0, 100)
+            self::numberBetween(0, 100),
         );
     }
 

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -57,7 +57,7 @@ class DateTime extends Base
     {
         return static::setTimezone(
             new \DateTime('@' . static::unixTime($max)),
-            $timezone
+            $timezone,
         );
     }
 
@@ -80,7 +80,7 @@ class DateTime extends Base
 
         return static::setTimezone(
             new \DateTime('@' . self::numberBetween($min, static::getMaxTimestamp($max))),
-            $timezone
+            $timezone,
         );
     }
 
@@ -156,7 +156,7 @@ class DateTime extends Base
 
         return static::setTimezone(
             new \DateTime('@' . $timestamp),
-            $timezone
+            $timezone,
         );
     }
 
@@ -189,7 +189,7 @@ class DateTime extends Base
         return static::dateTimeBetween(
             $begin,
             $end,
-            $timezone
+            $timezone,
         );
     }
 

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -55,7 +55,7 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead'
+            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
         );
 
         // Validate image format
@@ -65,7 +65,7 @@ class Image extends Base
             throw new \InvalidArgumentException(sprintf(
                 'Invalid image format "%s". Allowable formats are: %s',
                 $format,
-                implode(', ', $imageFormats)
+                implode(', ', $imageFormats),
             ));
         }
 
@@ -92,7 +92,7 @@ class Image extends Base
             self::BASE_URL,
             $size,
             $backgroundColor,
-            count($imageParts) > 0 ? '?text=' . urlencode(implode(' ', $imageParts)) : ''
+            count($imageParts) > 0 ? '?text=' . urlencode(implode(' ', $imageParts)) : '',
         );
     }
 
@@ -119,7 +119,7 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead'
+            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
         );
 
         $dir = null === $dir ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
@@ -172,7 +172,7 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead'
+            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
         );
 
         return array_keys(static::getFormatConstants());
@@ -183,7 +183,7 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead'
+            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
         );
 
         return [

--- a/src/Faker/Provider/Uuid.php
+++ b/src/Faker/Provider/Uuid.php
@@ -53,7 +53,7 @@ class Uuid extends Base
             $byte[12],
             $byte[13],
             $byte[14],
-            $byte[15]
+            $byte[15],
         );
     }
 }

--- a/src/Faker/Provider/ar_SA/Person.php
+++ b/src/Faker/Provider/ar_SA/Person.php
@@ -93,7 +93,7 @@ class Person extends \Faker\Provider\Person
     public static function idNumber()
     {
         $partialValue = static::numerify(
-            static::randomElement([1, 2]) . str_repeat('#', 8)
+            static::randomElement([1, 2]) . str_repeat('#', 8),
         );
 
         return Luhn::generateLuhnNumber($partialValue);

--- a/src/Faker/Provider/bg_BG/Payment.php
+++ b/src/Faker/Provider/bg_BG/Payment.php
@@ -40,7 +40,7 @@ class Payment extends \Faker\Provider\Payment
             '%s%d%d',
             $prefix,
             self::randomNumber(5, true), // workaround for mt_getrandmax() limitation
-            self::randomNumber(self::randomElement([4, 5]), true)
+            self::randomNumber(self::randomElement([4, 5]), true),
         );
     }
 }

--- a/src/Faker/Provider/de_DE/PhoneNumber.php
+++ b/src/Faker/Provider/de_DE/PhoneNumber.php
@@ -121,7 +121,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function mobileNumber()
     {
         return ltrim(static::numerify($this->generator->parse(
-            static::randomElement(static::$mobileFormats)
+            static::randomElement(static::$mobileFormats),
         )));
     }
 }

--- a/src/Faker/Provider/el_GR/PhoneNumber.php
+++ b/src/Faker/Provider/el_GR/PhoneNumber.php
@@ -158,7 +158,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public static function areaCode()
     {
         return static::numerify(
-            str_pad(static::randomElement(static::$areaCodes), 4, '#')
+            str_pad(static::randomElement(static::$areaCodes), 4, '#'),
         );
     }
 
@@ -182,7 +182,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function fixedLineNumber()
     {
         return ltrim(static::numerify($this->generator->parse(
-            static::randomElement(static::$fixedLineFormats)
+            static::randomElement(static::$fixedLineFormats),
         )));
     }
 
@@ -211,7 +211,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function mobileNumber()
     {
         return ltrim(static::numerify($this->generator->parse(
-            static::randomElement(static::$mobileFormats)
+            static::randomElement(static::$mobileFormats),
         )));
     }
 
@@ -224,7 +224,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
             strtr(static::randomElement(static::$mobileFormats), [
                 '{{internationalCodePrefix}}' => static::internationalCodePrefix(),
                 '{{mobileCode}}' => static::mobileCode(),
-            ])
+            ]),
         );
     }
 
@@ -241,7 +241,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function personalNumber()
     {
         return ltrim(static::numerify($this->generator->parse(
-            static::randomElement(static::$personalFormats)
+            static::randomElement(static::$personalFormats),
         )));
     }
 
@@ -260,7 +260,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return ltrim(static::numerify(
             strtr(static::randomElement(static::$tollFreeFormats), [
                 '{{internationalCodePrefix}}' => static::internationalCodePrefix(),
-            ])
+            ]),
         ));
     }
 
@@ -289,7 +289,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function sharedCostNumber()
     {
         return ltrim(static::numerify($this->generator->parse(
-            static::randomElement(static::$sharedCostFormats)
+            static::randomElement(static::$sharedCostFormats),
         )));
     }
 
@@ -318,7 +318,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public function premiumRateNumber()
     {
         return ltrim(static::numerify($this->generator->parse(
-            static::randomElement(static::$premiumRateFormats)
+            static::randomElement(static::$premiumRateFormats),
         )));
     }
 }

--- a/src/Faker/Provider/en_GB/Company.php
+++ b/src/Faker/Provider/en_GB/Company.php
@@ -53,7 +53,7 @@ class Company extends \Faker\Provider\Company
             static::VAT_PREFIX,
             $firstBlock,
             $secondBlock,
-            static::calculateModulus97($firstBlock . $secondBlock)
+            static::calculateModulus97($firstBlock . $secondBlock),
         );
     }
 
@@ -66,7 +66,7 @@ class Company extends \Faker\Provider\Company
         return sprintf(
             '%sHA%d',
             static::VAT_PREFIX,
-            static::numberBetween(500, 999)
+            static::numberBetween(500, 999),
         );
     }
 
@@ -79,7 +79,7 @@ class Company extends \Faker\Provider\Company
         return sprintf(
             '%s %d',
             static::generateStandardVatNumber(),
-            static::randomNumber(3, true)
+            static::randomNumber(3, true),
         );
     }
 
@@ -92,7 +92,7 @@ class Company extends \Faker\Provider\Company
         return sprintf(
             '%sGD%s',
             static::VAT_PREFIX,
-            str_pad((string) static::numberBetween(0, 499), 3, '0', STR_PAD_LEFT)
+            str_pad((string) static::numberBetween(0, 499), 3, '0', STR_PAD_LEFT),
         );
     }
 

--- a/src/Faker/Provider/en_ZA/Company.php
+++ b/src/Faker/Provider/en_ZA/Company.php
@@ -20,7 +20,7 @@ class Company extends \Faker\Provider\Company
             '%s/%s/%s',
             \Faker\Provider\DateTime::dateTimeBetween('-50 years', 'now')->format('Y'),
             static::randomNumber(6, true),
-            static::randomElement(static::$legalEntities)
+            static::randomElement(static::$legalEntities),
         );
     }
 }

--- a/test/Faker/Core/UuidTest.php
+++ b/test/Faker/Core/UuidTest.php
@@ -30,7 +30,7 @@ final class UuidTest extends TestCase
     {
         return is_string($uuid) && (bool) preg_match(
             '/^[a-f0-9]{8,8}-(?:[a-f0-9]{4,4}-){3,3}[a-f0-9]{12,12}$/i',
-            $uuid
+            $uuid,
         );
     }
 }

--- a/test/Faker/Extension/ContainerBuilderTest.php
+++ b/test/Faker/Extension/ContainerBuilderTest.php
@@ -27,7 +27,7 @@ final class ContainerBuilderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
             'First argument to "%s::add()" must be a string, callable or object.',
-            ContainerBuilder::class
+            ContainerBuilder::class,
         ));
 
         $containerBuilder->add($value);
@@ -77,7 +77,7 @@ final class ContainerBuilderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
             'Second argument to "%s::add()" is required not passing a string or object as first argument',
-            ContainerBuilder::class
+            ContainerBuilder::class,
         ));
 
         $containerBuilder->add($value);

--- a/test/Faker/Extension/ContainerTest.php
+++ b/test/Faker/Extension/ContainerTest.php
@@ -58,7 +58,7 @@ final class ContainerTest extends TestCase
         $this->expectExceptionMessage(sprintf(
             'Service resolved for identifier "%s" does not implement the %s" interface.',
             $id,
-            Extension::class
+            Extension::class,
         ));
 
         $container->get($id);

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -312,7 +312,7 @@ final class GeneratorTest extends TestCase
 
         $uniqueGenerator = $generator->unique(
             false,
-            $maxRetries
+            $maxRetries,
         );
 
         $uniqueGenerator->word();
@@ -320,7 +320,7 @@ final class GeneratorTest extends TestCase
         $this->expectException(\OverflowException::class);
         $this->expectExceptionMessage(sprintf(
             'Maximum retries of %d reached without finding a unique value',
-            $maxRetries
+            $maxRetries,
         ));
 
         $uniqueGenerator->word();

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -426,7 +426,7 @@ final class BaseTest extends TestCase
 
         self::assertEquals(
             round(array_sum($valuesOld) / 10000, 2),
-            round(array_sum($valuesNew) / 10000, 2)
+            round(array_sum($valuesNew) / 10000, 2),
         );
     }
 

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -14,7 +14,7 @@ final class ImageTest extends TestCase
     {
         self::assertMatchesRegularExpression(
             '#^https://via.placeholder.com/640x480.png/#',
-            Image::imageUrl()
+            Image::imageUrl(),
         );
     }
 
@@ -22,7 +22,7 @@ final class ImageTest extends TestCase
     {
         self::assertMatchesRegularExpression(
             '#^https://via.placeholder.com/800x400.png/#',
-            Image::imageUrl(800, 400)
+            Image::imageUrl(800, 400),
         );
     }
 
@@ -30,7 +30,7 @@ final class ImageTest extends TestCase
     {
         self::assertMatchesRegularExpression(
             '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+.*#',
-            Image::imageUrl(800, 400, 'nature')
+            Image::imageUrl(800, 400, 'nature'),
         );
     }
 
@@ -38,7 +38,7 @@ final class ImageTest extends TestCase
     {
         self::assertMatchesRegularExpression(
             '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
-            Image::imageUrl(800, 400, 'nature', false, 'Faker')
+            Image::imageUrl(800, 400, 'nature', false, 'Faker'),
         );
     }
 
@@ -50,12 +50,12 @@ final class ImageTest extends TestCase
             'nature',
             false,
             'Faker',
-            false
+            false,
         );
 
         self::assertMatchesRegularExpression(
             '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
-            $imageUrl
+            $imageUrl,
         );
     }
 
@@ -67,12 +67,12 @@ final class ImageTest extends TestCase
             'nature',
             false,
             'Faker',
-            true
+            true,
         );
 
         self::assertMatchesRegularExpression(
             '#^https://via.placeholder.com/800x400.png/CCCCCC\?text=nature\+Faker#',
-            $imageUrl
+            $imageUrl,
         );
     }
 
@@ -95,7 +95,7 @@ final class ImageTest extends TestCase
             false,
             'Faker',
             true,
-            'foo'
+            'foo',
         );
     }
 
@@ -109,12 +109,12 @@ final class ImageTest extends TestCase
                 false,
                 'Faker',
                 true,
-                $format
+                $format,
             );
 
             self::assertMatchesRegularExpression(
                 "#^https://via.placeholder.com/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
-                $imageUrl
+                $imageUrl,
             );
         }
     }
@@ -145,7 +145,7 @@ final class ImageTest extends TestCase
                 false,
                 'Faker',
                 true,
-                $format
+                $format,
             );
             self::assertFileExists($file);
 

--- a/test/Faker/Provider/el_GR/PhoneNumberTest.php
+++ b/test/Faker/Provider/el_GR/PhoneNumberTest.php
@@ -16,7 +16,7 @@ final class PhoneNumberTest extends TestCase
         self::assertNotSame(' ', $fixedLineNumber[0]);
         self::assertMatchesRegularExpression(
             '/^(\+30)?2(?:1\d\d|2(?:2[1-46-9]|[36][1-8]|4[1-7]|5[1-4]|7[1-5]|[89][1-9])|3(?:1\d|2[1-57]|[35][1-3]|4[13]|7[1-7]|8[124-6]|9[1-79])|4(?:1\d|2[1-8]|3[1-4]|4[13-5]|6[1-578]|9[1-5])|5(?:1\d|[29][1-4]|3[1-5]|4[124]|5[1-6])|6(?:1\d|[269][1-6]|3[1245]|4[1-7]|5[13-9]|7[14]|8[1-5])|7(?:1\d|2[1-5]|3[1-6]|4[1-7]|5[1-57]|6[135]|9[125-7])|8(?:1\d|2[1-5]|[34][1-4]|9[1-57]))\d{6}$/',
-            str_replace(' ', '', $fixedLineNumber)
+            str_replace(' ', '', $fixedLineNumber),
         );
     }
 
@@ -26,7 +26,7 @@ final class PhoneNumberTest extends TestCase
         self::assertNotSame(' ', $mobileNumber[0]);
         self::assertMatchesRegularExpression(
             '/^(\+30)?68[57-9]\d{7}|(?:69|94)\d{8}$/',
-            str_replace(' ', '', $mobileNumber)
+            str_replace(' ', '', $mobileNumber),
         );
     }
 
@@ -36,7 +36,7 @@ final class PhoneNumberTest extends TestCase
         self::assertNotSame(' ', $personalNumber[0]);
         self::assertMatchesRegularExpression(
             '/^(\+30)?70\d{8}$/',
-            str_replace(' ', '', $personalNumber)
+            str_replace(' ', '', $personalNumber),
         );
     }
 
@@ -46,7 +46,7 @@ final class PhoneNumberTest extends TestCase
         self::assertNotSame(' ', $tollFreeNumber[0]);
         self::assertMatchesRegularExpression(
             '/^(\+30)?800\d{7}$/',
-            str_replace(' ', '', $tollFreeNumber)
+            str_replace(' ', '', $tollFreeNumber),
         );
     }
 
@@ -56,7 +56,7 @@ final class PhoneNumberTest extends TestCase
         self::assertNotSame(' ', $sharedCostNumber[0]);
         self::assertMatchesRegularExpression(
             '/^(\+30)?8(?:0[16]|12|[27]5|50)\d{7}$/',
-            str_replace(' ', '', $sharedCostNumber)
+            str_replace(' ', '', $sharedCostNumber),
         );
     }
 
@@ -66,7 +66,7 @@ final class PhoneNumberTest extends TestCase
         self::assertNotSame(' ', $premiumRateNumber[0]);
         self::assertMatchesRegularExpression(
             '/^(\+30)?90[19]\d{7}$/',
-            str_replace(' ', '', $premiumRateNumber)
+            str_replace(' ', '', $premiumRateNumber),
         );
     }
 

--- a/test/Faker/Provider/el_GR/TextTest.php
+++ b/test/Faker/Provider/el_GR/TextTest.php
@@ -29,32 +29,32 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             'Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ ']),
         );
 
         self::assertSame(
             'Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ—'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ—']),
         );
 
         self::assertSame(
             'Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ,'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ,']),
         );
 
         self::assertSame(
             'Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ!.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ! '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ! ']),
         );
 
         self::assertSame(
             'Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ; '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ; ']),
         );
 
         self::assertSame(
             'Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ: '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Και δεν άκουσες το κλοπακλόπ, κλοπακλόπ, κλοπακλόπ: ']),
         );
     }
 }

--- a/test/Faker/Provider/en_NZ/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NZ/PhoneNumberTest.php
@@ -21,7 +21,7 @@ final class PhoneNumberTest extends TestCase
         $number = $this->faker->phoneNumber;
         self::assertMatchesRegularExpression(
             '/(^\([0]\d{1}\))(\d{7}$)|(^\([0][2]\d{1}\))(\d{6,8}$)|([0][8][0][0])([\s])(\d{5,8}$)/',
-            $number
+            $number,
         );
     }
 

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -55,7 +55,7 @@ final class PhoneNumberTest extends TestCase
 
             self::assertMatchesRegularExpression(
                 '/^(\+27|27)?(\()?0?([6][0-4]|[7][1-9]|[8][1-9])(\))?( |-|\.|_)?(\d{3})( |-|\.|_)?(\d{4})/',
-                $number
+                $number,
             );
         }
     }

--- a/test/Faker/Provider/fr_FR/TextTest.php
+++ b/test/Faker/Provider/fr_FR/TextTest.php
@@ -29,32 +29,32 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             'Que faisaient-elles maintenant? À.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À ']),
         );
 
         self::assertSame(
             'Que faisaient-elles maintenant? À.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À—   '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À—   ']),
         );
 
         self::assertSame(
             'Que faisaient-elles maintenant? À.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À,'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À,']),
         );
 
         self::assertSame(
             'Que faisaient-elles maintenant? À!.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À! '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À! ']),
         );
 
         self::assertSame(
             'Que faisaient-elles maintenant? À.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À: '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À: ']),
         );
 
         self::assertSame(
             'Que faisaient-elles maintenant? À.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À; '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Que faisaient-elles maintenant? À; ']),
         );
     }
 }

--- a/test/Faker/Provider/ka_GE/TextTest.php
+++ b/test/Faker/Provider/ka_GE/TextTest.php
@@ -29,32 +29,32 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             'ჭეშმარიტია. ჩვენც ისე.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე ']),
         );
 
         self::assertSame(
             'ჭეშმარიტია. ჩვენც ისე.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე— '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე— ']),
         );
 
         self::assertSame(
             'ჭეშმარიტია. ჩვენც ისე.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე,  '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე,  ']),
         );
 
         self::assertSame(
             'ჭეშმარიტია. ჩვენც ისე!.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე! '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე! ']),
         );
 
         self::assertSame(
             'ჭეშმარიტია. ჩვენც ისე.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე; '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე; ']),
         );
 
         self::assertSame(
             'ჭეშმარიტია. ჩვენც ისე.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე: '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['ჭეშმარიტია. ჩვენც ისე: ']),
         );
     }
 }

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -18,7 +18,7 @@ final class CompanyTest extends TestCase
 
         self::assertMatchesRegularExpression(
             '/^(' . $registrationDateAsString . ')([4-6]{1})([0-3]{1})(\\d{6})$/',
-            $businessIdentificationNumber
+            $businessIdentificationNumber,
         );
     }
 

--- a/test/Faker/Provider/kk_KZ/TextTest.php
+++ b/test/Faker/Provider/kk_KZ/TextTest.php
@@ -29,32 +29,32 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             'Арыстан баб кесенесі - көне Отырар.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар ']),
         );
 
         self::assertSame(
             'Арыстан баб кесенесі - көне Отырар.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар— '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар— ']),
         );
 
         self::assertSame(
             'Арыстан баб кесенесі - көне Отырар.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар,  '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар,  ']),
         );
 
         self::assertSame(
             'Арыстан баб кесенесі - көне Отырар!.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар! '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар! ']),
         );
 
         self::assertSame(
             'Арыстан баб кесенесі - көне Отырар.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар: '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар: ']),
         );
 
         self::assertSame(
             'Арыстан баб кесенесі - көне Отырар.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар; '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Арыстан баб кесенесі - көне Отырар; ']),
         );
     }
 }

--- a/test/Faker/Provider/ko_KR/TextTest.php
+++ b/test/Faker/Provider/ko_KR/TextTest.php
@@ -29,32 +29,32 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             '최석(崔晳)으로부터 최후의 편지가.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가 '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가 ']),
         );
 
         self::assertSame(
             '최석(崔晳)으로부터 최후의 편지가.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가—'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가—']),
         );
 
         self::assertSame(
             '최석(崔晳)으로부터 최후의 편지가.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가,'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가,']),
         );
 
         self::assertSame(
             '최석(崔晳)으로부터 최후의 편지가!.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가! '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가! ']),
         );
 
         self::assertSame(
             '최석(崔晳)으로부터 최후의 편지가.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가: '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가: ']),
         );
 
         self::assertSame(
             '최석(崔晳)으로부터 최후의 편지가.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가; '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['최석(崔晳)으로부터 최후의 편지가; ']),
         );
     }
 }

--- a/test/Faker/Provider/pl_PL/LicensePlateTest.php
+++ b/test/Faker/Provider/pl_PL/LicensePlateTest.php
@@ -29,7 +29,7 @@ final class LicensePlateTest extends TestCase
     {
         for ($i = 0; $i < 40; ++$i) {
             $licensePlate = $this->faker->licensePlate(
-                false
+                false,
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -44,7 +44,7 @@ final class LicensePlateTest extends TestCase
     {
         for ($i = 0; $i < 5; ++$i) {
             $licensePlate = $this->faker->licensePlate(
-                true
+                true,
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -60,7 +60,7 @@ final class LicensePlateTest extends TestCase
         for ($i = 0; $i < 5; ++$i) {
             $licensePlate = $this->faker->licensePlate(
                 false,
-                ['podkarpackie']
+                ['podkarpackie'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -76,7 +76,7 @@ final class LicensePlateTest extends TestCase
         for ($i = 0; $i < 5; ++$i) {
             $licensePlate = $this->faker->licensePlate(
                 true,
-                ['łódzkie', 'army']
+                ['łódzkie', 'army'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -92,7 +92,7 @@ final class LicensePlateTest extends TestCase
         for ($i = 0; $i < 5; ++$i) {
             $licensePlate = $this->faker->licensePlate(
                 false,
-                ['łódzkie', 'army']
+                ['łódzkie', 'army'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -108,7 +108,7 @@ final class LicensePlateTest extends TestCase
         for ($i = 0; $i < 5; ++$i) {
             $licensePlate = $this->faker->licensePlate(
                 true,
-                ['fake voivodeship', 'fake voivodeship2']
+                ['fake voivodeship', 'fake voivodeship2'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -124,7 +124,7 @@ final class LicensePlateTest extends TestCase
         for ($i = 0; $i < 5; ++$i) {
             $licensePlate = $this->faker->licensePlate(
                 true,
-                []
+                [],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -141,7 +141,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 true,
                 [],
-                []
+                [],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -158,7 +158,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 true,
                 ['mazowieckie', 'services'],
-                ['Straż Graniczna', 'warszawski zachodni', 'radomski']
+                ['Straż Graniczna', 'warszawski zachodni', 'radomski'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -175,7 +175,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 true,
                 ['mazowieckie', 'services'],
-                ['fake county']
+                ['fake county'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -192,7 +192,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 true,
                 ['fake voivodeship'],
-                ['Straż Graniczna', 'warszawski zachodni', 'radomski']
+                ['Straż Graniczna', 'warszawski zachodni', 'radomski'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -209,7 +209,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 true,
                 null,
-                ['Straż Graniczna', 'warszawski zachodni', 'radomski']
+                ['Straż Graniczna', 'warszawski zachodni', 'radomski'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -226,7 +226,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 true,
                 [null],
-                ['Straż Graniczna', 'warszawski zachodni', 'radomski']
+                ['Straż Graniczna', 'warszawski zachodni', 'radomski'],
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -243,7 +243,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 false,
                 ['mazowieckie', 'services'],
-                null
+                null,
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);
@@ -260,7 +260,7 @@ final class LicensePlateTest extends TestCase
             $licensePlate = $this->faker->licensePlate(
                 true,
                 ['services'],
-                null
+                null,
             );
             self::assertNotEmpty($licensePlate);
             self::assertIsString($licensePlate);

--- a/test/Faker/Provider/pt_BR/TextTest.php
+++ b/test/Faker/Provider/pt_BR/TextTest.php
@@ -29,32 +29,32 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             'Uma noite destas.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas, '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas, ']),
         );
 
         self::assertSame(
             'Uma noite destas.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas—   '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas—   ']),
         );
 
         self::assertSame(
             'Uma noite destas.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas,'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas,']),
         );
 
         self::assertSame(
             'Uma noite destas!.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas! '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas! ']),
         );
 
         self::assertSame(
             'Uma noite destas.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas: '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas: ']),
         );
 
         self::assertSame(
             'Uma noite destas.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas; '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['Uma noite destas; ']),
         );
     }
 }

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -81,7 +81,7 @@ final class PersonTest extends TestCase
         $cnp = $this->faker->cnp;
         self::assertTrue(
             $this->isValidCnp($cnp),
-            sprintf("Invalid CNP '%' generated", $cnp)
+            sprintf("Invalid CNP '%' generated", $cnp),
         );
     }
 
@@ -90,13 +90,13 @@ final class PersonTest extends TestCase
         $cnp = $this->faker->cnp(Person::GENDER_MALE);
         self::assertTrue(
             $this->isValidMaleCnp($cnp),
-            sprintf("Invalid CNP '%' generated for '%s' gender", $cnp, Person::GENDER_MALE)
+            sprintf("Invalid CNP '%' generated for '%s' gender", $cnp, Person::GENDER_MALE),
         );
 
         $cnp = $this->faker->cnp(Person::GENDER_FEMALE);
         self::assertTrue(
             $this->isValidFemaleCnp($cnp),
-            sprintf("Invalid CNP '%' generated for '%s' gender", $cnp, Person::GENDER_FEMALE)
+            sprintf("Invalid CNP '%' generated for '%s' gender", $cnp, Person::GENDER_FEMALE),
         );
     }
 
@@ -121,7 +121,7 @@ final class PersonTest extends TestCase
         $cnp = $this->faker->cnp(null, $value);
         self::assertTrue(
             $this->isValidCnp($cnp),
-            sprintf("Invalid CNP '%' generated for valid year '%s'", $cnp, $value)
+            sprintf("Invalid CNP '%' generated for valid year '%s'", $cnp, $value),
         );
     }
 
@@ -146,7 +146,7 @@ final class PersonTest extends TestCase
         $cnp = $this->faker->cnp(null, null, $value);
         self::assertTrue(
             $this->isValidCnp($cnp),
-            sprintf("Invalid CNP '%' generated for valid year '%s'", $cnp, $value)
+            sprintf("Invalid CNP '%' generated for valid year '%s'", $cnp, $value),
         );
     }
 
@@ -166,12 +166,12 @@ final class PersonTest extends TestCase
         $cnp = $this->faker->cnp(null, null, null, false);
         self::assertTrue(
             $this->isValidCnp($cnp),
-            sprintf("Invalid CNP '%' generated for non resident", $cnp)
+            sprintf("Invalid CNP '%' generated for non resident", $cnp),
         );
         self::assertStringStartsWith(
             '9',
             $cnp,
-            sprintf("Invalid CNP '%' generated for non resident (should start with 9)", $cnp)
+            sprintf("Invalid CNP '%' generated for non resident (should start with 9)", $cnp),
         );
     }
 
@@ -190,7 +190,7 @@ final class PersonTest extends TestCase
         self::assertStringStartsWith(
             $expectedCnpStart,
             $cnp,
-            sprintf("Invalid CNP '%' generated for non valid data", $cnp)
+            sprintf("Invalid CNP '%' generated for non valid data", $cnp),
         );
     }
 

--- a/test/Faker/Provider/ru_RU/CompanyTest.php
+++ b/test/Faker/Provider/ru_RU/CompanyTest.php
@@ -32,7 +32,7 @@ final class CompanyTest extends TestCase
         self::assertGreaterThanOrEqual(
             3,
             count(explode(' ', $this->faker->catchPhrase)),
-            "'$phrase' - should be contain 3 word"
+            "'$phrase' - should be contain 3 word",
         );
     }
 

--- a/test/Faker/Provider/ru_RU/TextTest.php
+++ b/test/Faker/Provider/ru_RU/TextTest.php
@@ -29,32 +29,32 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер ']),
         );
 
         self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер—'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер—']),
         );
 
         self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер,'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер,']),
         );
 
         self::assertSame(
             'На другой день Чичиков отправился на обед и вечер!.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер! '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер! ']),
         );
 
         self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер; '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер; ']),
         );
 
         self::assertSame(
             'На другой день Чичиков отправился на обед и вечер.',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер: '])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['На другой день Чичиков отправился на обед и вечер: ']),
         );
     }
 }

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -31,7 +31,7 @@ final class AddressTest extends TestCase
         self::assertSame(
             preg_match($pattern, $streetName),
             1,
-            'Street name ' . $streetName . ' is wrong!'
+            'Street name ' . $streetName . ' is wrong!',
         );
     }
 
@@ -42,7 +42,7 @@ final class AddressTest extends TestCase
         self::assertSame(
             preg_match($pattern, $city),
             1,
-            'City name ' . $city . ' is wrong!'
+            'City name ' . $city . ' is wrong!',
         );
     }
 
@@ -53,7 +53,7 @@ final class AddressTest extends TestCase
         self::assertSame(
             preg_match($pattern, $regionName),
             1,
-            'Region name ' . $regionName . ' is wrong!'
+            'Region name ' . $regionName . ' is wrong!',
         );
     }
 
@@ -64,7 +64,7 @@ final class AddressTest extends TestCase
         self::assertSame(
             preg_match($pattern, $country),
             1,
-            'Country name ' . $country . ' is wrong!'
+            'Country name ' . $country . ' is wrong!',
         );
     }
 

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -17,7 +17,7 @@ final class PhoneNumberTest extends TestCase
         self::assertSame(
             preg_match($pattern, $phoneNumber),
             1,
-            'Phone number format ' . $phoneNumber . ' is wrong!'
+            'Phone number format ' . $phoneNumber . ' is wrong!',
         );
     }
 
@@ -28,7 +28,7 @@ final class PhoneNumberTest extends TestCase
         self::assertSame(
             preg_match($pattern, $phoneNumber),
             1,
-            'Phone number format ' . $phoneNumber . ' is wrong!'
+            'Phone number format ' . $phoneNumber . ' is wrong!',
         );
     }
 

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -29,12 +29,12 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             ['中', '文', '測', '試', '真', '有', '趣'],
-            $this->getMethod('explode')->invokeArgs(null, ['中文測試真有趣'])
+            $this->getMethod('explode')->invokeArgs(null, ['中文測試真有趣']),
         );
 
         self::assertSame(
             ['標', '點', '，', '符', '號', '！'],
-            $this->getMethod('explode')->invokeArgs(null, ['標點，符號！'])
+            $this->getMethod('explode')->invokeArgs(null, ['標點，符號！']),
         );
     }
 
@@ -42,7 +42,7 @@ final class TextTest extends TestCase
     {
         self::assertContains(
             $this->getMethod('strlen')->invokeArgs(null, ['中文測試真有趣']),
-            [7, 21]
+            [7, 21],
         );
     }
 
@@ -63,17 +63,17 @@ final class TextTest extends TestCase
     {
         self::assertSame(
             '中文測試真有趣。',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣']),
         );
 
         self::assertSame(
             '中文測試真有趣。',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣，'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣，']),
         );
 
         self::assertSame(
             '中文測試真有趣！',
-            $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣！'])
+            $this->getMethod('appendEnd')->invokeArgs(null, ['中文測試真有趣！']),
         );
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] configures the  [`trailing_comma_in_multiline`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.13.0/doc/rules/control_structure/trailing_comma_in_multiline.rst) fixer to include `arguments` in `elements` option
- [x] runs `make cs`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
