### PR TITLE
Fix: Command for generating the baseline for `vimeo/psalm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ static: vendor ## Runs static analyzers
 .PHONY: baseline
 baseline: vendor ## Generate baseline files
 	vendor/bin/phpstan --generate-baseline
-	vendor/bin/psalm --update-baseline
+	vendor/bin/psalm --set-baseline=psalm.baseline.xml
 
 .PHONY: clean
 clean:   ## Cleans up build and vendor files


### PR DESCRIPTION
### What is the reason for this PR?

- [x] fixes the command for generating the baseline for `vimeo/psalm`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
