### PR TITLE
Fix: Use `Xdebug` instead of `pcov` for collecting code coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Install PHP with extensions"
         uses: "shivammathur/setup-php@v2"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "intl"
           php-version: "${{ matrix.php-version }}"
 


### PR DESCRIPTION
### What is the reason for this PR?

- [x] use `Xdebug` instead of `pcov` for collecting code coverage

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
