### PR TITLE
Fix: Require `symfony/phpunit-bridge:^5.4.16`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
         "doctrine/persistence": "^1.3 || ^2.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.2"
+        "symfony/phpunit-bridge": "^5.4.16"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### What is the reason for this PR?

- [x] requires `symfony/phpunit-bridge:^5.4.16` following #543 

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
