### PR TITLE
Fix: Avoid using deprecated callable declaration

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,16 +6,6 @@ parameters:
 			path: src/Faker/Calculator/Iban.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array\\<int\\|string, string\\>\\)\\: string, array\\{'self', 'alphaToNumberCallba…'\\} given\\.$#"
-			count: 1
-			path: src/Faker/Calculator/Iban.php
-
-		-
-			message: "#^Static method Faker\\\\Calculator\\\\Iban\\:\\:alphaToNumberCallback\\(\\) is unused\\.$#"
-			count: 1
-			path: src/Faker/Calculator/Iban.php
-
-		-
 			message: "#^Binary operation \"\\*\" between int and string results in an error\\.$#"
 			count: 1
 			path: src/Faker/Calculator/Isbn.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     verbose="true"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=605"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=404"/>
     </php>
     <testsuites>
         <testsuite name="Faker Test Suite">

--- a/src/Faker/Calculator/Iban.php
+++ b/src/Faker/Calculator/Iban.php
@@ -17,22 +17,18 @@ class Iban
         $checkString = substr($iban, 4) . substr($iban, 0, 2) . '00';
 
         // Replace all letters with their number equivalents
-        $checkString = preg_replace_callback('/[A-Z]/', ['self', 'alphaToNumberCallback'], $checkString);
+        $checkString = preg_replace_callback(
+            '/[A-Z]/',
+            static function (array $matches): string {
+                return (string) self::alphaToNumber($matches[0]);
+            },
+            $checkString,
+        );
 
         // Perform mod 97 and subtract from 98
         $checksum = 98 - self::mod97($checkString);
 
         return str_pad($checksum, 2, '0', STR_PAD_LEFT);
-    }
-
-    /**
-     * @param string $match
-     *
-     * @return int
-     */
-    private static function alphaToNumberCallback($match)
-    {
-        return self::alphaToNumber($match[0]);
     }
 
     /**


### PR DESCRIPTION
### What is the reason for this PR?

- [x] avoids using a deprecated callable declaration following #528

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
