### PR TITLE
Enhancement: Enable `protected_to_private` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -174,6 +174,7 @@ return $config
         ],
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
+        'protected_to_private' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
         'return_assignment' => true,


### PR DESCRIPTION
### What is the reason for this PR?

- [x] enables the [`protected_to_private`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.13.0/doc/rules/class_notation/protected_to_private.rst) fixer

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
