### PR TITLE
Fix: Require and use `phpunit/phpunit`

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -45,11 +45,10 @@ jobs:
       - name: "Download dependencies"
         run: |
           composer update --no-interaction --no-progress --optimize-autoloader
-          vendor/bin/simple-phpunit install
 
       - name: "Collect code coverage with PHPUnit"
         run: |
-          vendor/bin/simple-phpunit --coverage-clover=.build/logs/clover.xml
+          vendor/bin/phpunit --coverage-clover=.build/logs/clover.xml
 
       - name: "Send code coverage report to codecov.io"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
         run: "composer update --no-interaction --no-progress --optimize-autoloader"
 
       - name: "Run tests"
-        run: "./vendor/bin/simple-phpunit"
+        run: "./vendor/bin/phpunit"

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ cs: vendor ## Fixes coding standard issues with php-cs-fixer
 
 .PHONY: coverage
 coverage: vendor ## Collects coverage with phpunit
-	vendor/bin/simple-phpunit --coverage-text --coverage-clover=.build/logs/clover.xml
+	vendor/bin/phpunit --coverage-text --coverage-clover=.build/logs/clover.xml
 
 .PHONY: test
 test: vendor ## Runs tests with phpunit
-	vendor/bin/simple-phpunit
+	vendor/bin/phpunit
 
 .PHONY: static
 static: vendor ## Runs static analyzers
@@ -37,4 +37,3 @@ clean:   ## Cleans up build and vendor files
 vendor: always
 	composer update --no-interaction
 	composer bin all install --no-interaction
-	vendor/bin/simple-phpunit install

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "ext-intl": "*",
         "bamarni/composer-bin-plugin": "^1.4.1",
         "doctrine/persistence": "^1.3 || ^2.0",
+        "phpunit/phpunit": "^9.5.26",
         "symfony/phpunit-bridge": "^5.4.16"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,9 @@
     columns="max"
     verbose="true"
 >
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=404"/>
     </php>


### PR DESCRIPTION
### What is the reason for this PR?

- [ ] requires and uses `phpunit/phpunit` directly

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
