### PR TITLE
Fix PHP 8.2 warning: Use `[static::class, '…']` instead of `'static::…` for callbacks

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -634,6 +634,11 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
+			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array\\<int\\|string, string\\>\\)\\: string, array\\{class\\-string\\<static\\(Faker\\\\Provider\\\\Base\\)\\>, 'randomDigit'\\} given\\.$#"
+			count: 1
+			path: src/Faker/Provider/Base.php
+
+		-
 			message: "#^Parameter \\$validator of method Faker\\\\Provider\\\\Base\\:\\:valid\\(\\) has invalid type Faker\\\\Provider\\\\Closure\\.$#"
 			count: 1
 			path: src/Faker/Provider/Base.php
@@ -732,6 +737,11 @@ parameters:
 			message: "#^Static call to instance method Faker\\\\Provider\\\\cs_CZ\\\\Person\\:\\:birthNumber\\(\\)\\.$#"
 			count: 2
 			path: src/Faker/Provider/cs_CZ/Person.php
+
+		-
+			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array\\<int\\|string, string\\>\\)\\: string, array\\{class\\-string\\<static\\(Faker\\\\Provider\\\\en_CA\\\\Address\\)\\>, 'randomDigit'\\} given\\.$#"
+			count: 1
+			path: src/Faker/Provider/en_CA/Address.php
 
 		-
 			message: "#^Unsafe call to private method Faker\\\\Provider\\\\en_GB\\\\Company\\:\\:generateBranchTraderVatNumber\\(\\) through static\\:\\:\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -654,11 +654,6 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array<int|string, string>\\)\\: string, 'Faker\\\\\\Provider\\\\\\Base…' given\\.$#"
-			count: 1
-			path: src/Faker/Provider/Base.php
-
-		-
 			message: "#^Method Faker\\\\Provider\\\\DateTime\\:\\:resolveTimezone\\(\\) never returns null so it can be removed from the return type\\.$#"
 			count: 1
 			path: src/Faker/Provider/DateTime.php
@@ -737,11 +732,6 @@ parameters:
 			message: "#^Static call to instance method Faker\\\\Provider\\\\cs_CZ\\\\Person\\:\\:birthNumber\\(\\)\\.$#"
 			count: 2
 			path: src/Faker/Provider/cs_CZ/Person.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array<int|string, string>\\)\\: string, 'Faker\\\\\\Provider\\\\\\Base…' given\\.$#"
-			count: 1
-			path: src/Faker/Provider/en_CA/Address.php
 
 		-
 			message: "#^Unsafe call to private method Faker\\\\Provider\\\\en_GB\\\\Company\\:\\:generateBranchTraderVatNumber\\(\\) through static\\:\\:\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -654,6 +654,11 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
+			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array<int|string, string>\\)\\: string, 'Faker\\\\\\Provider\\\\\\Base…' given\\.$#"
+			count: 1
+			path: src/Faker/Provider/Base.php
+
+		-
 			message: "#^Method Faker\\\\Provider\\\\DateTime\\:\\:resolveTimezone\\(\\) never returns null so it can be removed from the return type\\.$#"
 			count: 1
 			path: src/Faker/Provider/DateTime.php
@@ -732,6 +737,11 @@ parameters:
 			message: "#^Static call to instance method Faker\\\\Provider\\\\cs_CZ\\\\Person\\:\\:birthNumber\\(\\)\\.$#"
 			count: 2
 			path: src/Faker/Provider/cs_CZ/Person.php
+
+		-
+			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array<int|string, string>\\)\\: string, 'Faker\\\\\\Provider\\\\\\Base…' given\\.$#"
+			count: 1
+			path: src/Faker/Provider/en_CA/Address.php
 
 		-
 			message: "#^Unsafe call to private method Faker\\\\Provider\\\\en_GB\\\\Company\\:\\:generateBranchTraderVatNumber\\(\\) through static\\:\\:\\.$#"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=404"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
     <testsuites>
         <testsuite name="Faker Test Suite">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -139,10 +139,8 @@
     </UndefinedDocblockClass>
   </file>
   <file src="src/Faker/Provider/Base.php">
-    <InvalidArgument occurrences="3">
-      <code>static::class . '::randomAscii'</code>
-      <code>static::class . '::randomDigit'</code>
-      <code>static::class . '::randomLetter'</code>
+    <InvalidArgument occurrences="1">
+      <code>[static::class, 'randomDigit']</code>
     </InvalidArgument>
     <NoValue occurrences="1">
       <code>$array</code>
@@ -190,12 +188,6 @@
       <code>static::birthNumber(static::GENDER_FEMALE)</code>
       <code>static::birthNumber(static::GENDER_MALE)</code>
     </NonStaticSelfCall>
-  </file>
-  <file src="src/Faker/Provider/en_CA/Address.php">
-    <InvalidArgument occurrences="2">
-      <code>static::class . '::randomDigit'</code>
-      <code>static::class . '::randomPostcodeLetter'</code>
-    </InvalidArgument>
   </file>
   <file src="src/Faker/Provider/en_SG/Person.php">
     <InvalidArrayOffset occurrences="1">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -139,6 +139,11 @@
     </UndefinedDocblockClass>
   </file>
   <file src="src/Faker/Provider/Base.php">
+    <InvalidArgument occurrences="3">
+      <code>static::class . '::randomAscii'</code>
+      <code>static::class . '::randomDigit'</code>
+      <code>static::class . '::randomLetter'</code>
+    </InvalidArgument>
     <NoValue occurrences="1">
       <code>$array</code>
     </NoValue>
@@ -185,6 +190,12 @@
       <code>static::birthNumber(static::GENDER_FEMALE)</code>
       <code>static::birthNumber(static::GENDER_MALE)</code>
     </NonStaticSelfCall>
+  </file>
+  <file src="src/Faker/Provider/en_CA/Address.php">
+    <InvalidArgument occurrences="2">
+      <code>static::class . '::randomDigit'</code>
+      <code>static::class . '::randomPostcodeLetter'</code>
+    </InvalidArgument>
   </file>
   <file src="src/Faker/Provider/en_SG/Person.php">
     <InvalidArrayOffset occurrences="1">

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -415,7 +415,7 @@ class Base
                 $string[$toReplace[$i]] = $numbers[$i];
             }
         }
-        $string = self::replaceWildcard($string, '%', static::class . '::randomDigitNotNull');
+        $string = self::replaceWildcard($string, '%', [static::class, 'randomDigitNotNull']);
 
         return $string;
     }
@@ -429,7 +429,7 @@ class Base
      */
     public static function lexify($string = '????')
     {
-        return self::replaceWildcard($string, '?', static::class . '::randomLetter');
+        return self::replaceWildcard($string, '?', [static::class,  'randomLetter']);
     }
 
     /**
@@ -460,7 +460,7 @@ class Base
      */
     public static function asciify($string = '****')
     {
-        return preg_replace_callback('/\*/u', static::class . '::randomAscii', $string);
+        return preg_replace_callback('/\*/u', [static::class, 'randomAscii'], $string);
     }
 
     /**
@@ -532,8 +532,8 @@ class Base
             return str_replace('.', '\.', $randomElement);
         }, $regex);
         // replace \d with number and \w with letter and . with ascii
-        $regex = preg_replace_callback('/\\\w/', static::class . '::randomLetter', $regex);
-        $regex = preg_replace_callback('/\\\d/', static::class . '::randomDigit', $regex);
+        $regex = preg_replace_callback('/\\\w/', [static::class, 'randomLetter'], $regex);
+        $regex = preg_replace_callback('/\\\d/', [static::class, 'randomDigit'], $regex);
         //replace . with ascii except backslash
         $regex = preg_replace_callback('/(?<!\\\)\./', static function () {
             $chr = static::asciify('*');

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -363,7 +363,7 @@ class Base
         return implode('', static::shuffleArray($array));
     }
 
-    private static function replaceWildcard($string, $wildcard = '#', $callback = static::class . '::randomDigit')
+    private static function replaceWildcard($string, $wildcard, $callback)
     {
         if (($pos = strpos($string, $wildcard)) === false) {
             return $string;

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -363,7 +363,7 @@ class Base
         return implode('', static::shuffleArray($array));
     }
 
-    private static function replaceWildcard($string, $wildcard = '#', $callback = 'static::randomDigit')
+    private static function replaceWildcard($string, $wildcard = '#', $callback = self::class . '::randomDigit')
     {
         if (($pos = strpos($string, $wildcard)) === false) {
             return $string;
@@ -415,7 +415,7 @@ class Base
                 $string[$toReplace[$i]] = $numbers[$i];
             }
         }
-        $string = self::replaceWildcard($string, '%', 'static::randomDigitNotNull');
+        $string = self::replaceWildcard($string, '%', self::class . '::randomDigitNotNull');
 
         return $string;
     }
@@ -429,7 +429,7 @@ class Base
      */
     public static function lexify($string = '????')
     {
-        return self::replaceWildcard($string, '?', 'static::randomLetter');
+        return self::replaceWildcard($string, '?', self::class . '::randomLetter');
     }
 
     /**
@@ -460,7 +460,7 @@ class Base
      */
     public static function asciify($string = '****')
     {
-        return preg_replace_callback('/\*/u', 'static::randomAscii', $string);
+        return preg_replace_callback('/\*/u', self::class . '::randomAscii', $string);
     }
 
     /**
@@ -532,8 +532,8 @@ class Base
             return str_replace('.', '\.', $randomElement);
         }, $regex);
         // replace \d with number and \w with letter and . with ascii
-        $regex = preg_replace_callback('/\\\w/', 'static::randomLetter', $regex);
-        $regex = preg_replace_callback('/\\\d/', 'static::randomDigit', $regex);
+        $regex = preg_replace_callback('/\\\w/', self::class . '::randomLetter', $regex);
+        $regex = preg_replace_callback('/\\\d/', self::class . '::randomDigit', $regex);
         //replace . with ascii except backslash
         $regex = preg_replace_callback('/(?<!\\\)\./', static function () {
             $chr = static::asciify('*');

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -363,7 +363,7 @@ class Base
         return implode('', static::shuffleArray($array));
     }
 
-    private static function replaceWildcard($string, $wildcard = '#', $callback = self::class . '::randomDigit')
+    private static function replaceWildcard($string, $wildcard = '#', $callback = static::class . '::randomDigit')
     {
         if (($pos = strpos($string, $wildcard)) === false) {
             return $string;
@@ -415,7 +415,7 @@ class Base
                 $string[$toReplace[$i]] = $numbers[$i];
             }
         }
-        $string = self::replaceWildcard($string, '%', self::class . '::randomDigitNotNull');
+        $string = self::replaceWildcard($string, '%', static::class . '::randomDigitNotNull');
 
         return $string;
     }
@@ -429,7 +429,7 @@ class Base
      */
     public static function lexify($string = '????')
     {
-        return self::replaceWildcard($string, '?', self::class . '::randomLetter');
+        return self::replaceWildcard($string, '?', static::class . '::randomLetter');
     }
 
     /**
@@ -460,7 +460,7 @@ class Base
      */
     public static function asciify($string = '****')
     {
-        return preg_replace_callback('/\*/u', self::class . '::randomAscii', $string);
+        return preg_replace_callback('/\*/u', static::class . '::randomAscii', $string);
     }
 
     /**
@@ -532,8 +532,8 @@ class Base
             return str_replace('.', '\.', $randomElement);
         }, $regex);
         // replace \d with number and \w with letter and . with ascii
-        $regex = preg_replace_callback('/\\\w/', self::class . '::randomLetter', $regex);
-        $regex = preg_replace_callback('/\\\d/', self::class . '::randomDigit', $regex);
+        $regex = preg_replace_callback('/\\\w/', static::class . '::randomLetter', $regex);
+        $regex = preg_replace_callback('/\\\d/', static::class . '::randomDigit', $regex);
         //replace . with ascii except backslash
         $regex = preg_replace_callback('/(?<!\\\)\./', static function () {
             $chr = static::asciify('*');

--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -64,8 +64,8 @@ class Address extends \Faker\Provider\en_US\Address
     {
         $string = static::randomElement(static::$postcode);
 
-        $string = preg_replace_callback('/\#/u', static::class . '::randomDigit', $string);
-        $string = preg_replace_callback('/\?/u', static::class . '::randomPostcodeLetter', $string);
+        $string = preg_replace_callback('/\#/u', [static::class,  'randomDigit'], $string);
+        $string = preg_replace_callback('/\?/u', [static::class, 'randomPostcodeLetter'], $string);
 
         return static::toUpper($string);
     }

--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -64,8 +64,8 @@ class Address extends \Faker\Provider\en_US\Address
     {
         $string = static::randomElement(static::$postcode);
 
-        $string = preg_replace_callback('/\#/u', 'static::randomDigit', $string);
-        $string = preg_replace_callback('/\?/u', 'static::randomPostcodeLetter', $string);
+        $string = preg_replace_callback('/\#/u', self::class . '::randomDigit', $string);
+        $string = preg_replace_callback('/\?/u', self::class . '::randomPostcodeLetter', $string);
 
         return static::toUpper($string);
     }

--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -64,8 +64,8 @@ class Address extends \Faker\Provider\en_US\Address
     {
         $string = static::randomElement(static::$postcode);
 
-        $string = preg_replace_callback('/\#/u', self::class . '::randomDigit', $string);
-        $string = preg_replace_callback('/\?/u', self::class . '::randomPostcodeLetter', $string);
+        $string = preg_replace_callback('/\#/u', static::class . '::randomDigit', $string);
+        $string = preg_replace_callback('/\?/u', static::class . '::randomPostcodeLetter', $string);
 
         return static::toUpper($string);
     }


### PR DESCRIPTION
### What is the reason for this PR?

This implements remaining changes for #479 (Use of "static" in callables is deprecated in PHP 8.2) and is an extension of #528 (Ensure php 8.2 compatibility)

- [x] Fixed PHP 8.2 warnings (should resolve the #479 issue?)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io) (there are none)

### Summary of changes
Use self::class . '::[…]' instead of 'static::[…]' on callbacks which triggered a PHP 8.2 warning. Implementation analogous to [php.watch](https://php.watch/versions/8.2/partially-supported-callable-deprecation#deprecated-patterns).

The phpstan "errors" can be ignored as that functionality still works for PHP 7.4 and is thus added to ignoreErrors.

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
