### PR TITLE
Fix bc check

### DIFF
--- a/.github/workflows/bc-check.yaml
+++ b/.github/workflows/bc-check.yaml
@@ -20,5 +20,5 @@ jobs:
         uses: "addnab/docker-run-action@v3"
         with:
           image: "nyholm/roave-bc-check-ga"
-          options: "--volume ${{ github.workspace }}:/app --user 1001 --env GITHUB_REPOSITORY=${{ github.repository }}"
+          options: "--env GITHUB_REPOSITORY=${{ github.repository }} --user 1001 --volume ${{ github.workspace }}:/app"
           run: "/entrypoint.sh"

--- a/.github/workflows/bc-check.yaml
+++ b/.github/workflows/bc-check.yaml
@@ -17,4 +17,8 @@ jobs:
         uses: "actions/checkout@v3"
 
       - name: "Roave BC Check"
-        uses: "docker://nyholm/roave-bc-check-ga"
+        uses: "addnab/docker-run-action@v3"
+        with:
+          image: "nyholm/roave-bc-check-ga"
+          options: "-v ${{ github.workspace }}:/app -u 1001 -e GITHUB_REPOSITORY=${{ github.repository }}"
+          run: "/entrypoint.sh"

--- a/.github/workflows/bc-check.yaml
+++ b/.github/workflows/bc-check.yaml
@@ -20,5 +20,5 @@ jobs:
         uses: "addnab/docker-run-action@v3"
         with:
           image: "nyholm/roave-bc-check-ga"
-          options: "-v ${{ github.workspace }}:/app -u 1001 -e GITHUB_REPOSITORY=${{ github.repository }}"
+          options: "--volume ${{ github.workspace }}:/app --user 1001 --env GITHUB_REPOSITORY=${{ github.repository }}"
           run: "/entrypoint.sh"

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -206,6 +206,6 @@ return $config
                 'property',
             ],
         ],
-        'void_return' => true,
+        'void_return' => false,
         'whitespace_after_comma_in_array' => true,
     ]);

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -597,7 +597,7 @@ class Generator
         return $extension;
     }
 
-    public function addProvider($provider): void
+    public function addProvider($provider)
     {
         array_unshift($this->providers, $provider);
 
@@ -682,7 +682,7 @@ class Generator
         return new ValidGenerator($this, $validator, $maxRetries);
     }
 
-    public function seed($seed = null): void
+    public function seed($seed = null)
     {
         if ($seed === null) {
             mt_srand();
@@ -966,7 +966,7 @@ class Generator
         $this->seed();
     }
 
-    public function __wakeup(): void
+    public function __wakeup()
     {
         $this->formatters = [];
     }

--- a/src/Faker/ORM/CakePHP/EntityPopulator.php
+++ b/src/Faker/ORM/CakePHP/EntityPopulator.php
@@ -27,17 +27,17 @@ class EntityPopulator
     /**
      * @param string $name
      */
-    public function __set($name, $value): void
+    public function __set($name, $value)
     {
         $this->{$name} = $value;
     }
 
-    public function mergeColumnFormattersWith($columnFormatters): void
+    public function mergeColumnFormattersWith($columnFormatters)
     {
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }
 
-    public function mergeModifiersWith($modifiers): void
+    public function mergeModifiersWith($modifiers)
     {
         $this->modifiers = array_merge($this->modifiers, $modifiers);
     }
@@ -155,7 +155,7 @@ class EntityPopulator
         return $entity->{$pk[0]};
     }
 
-    public function setConnection($name): void
+    public function setConnection($name)
     {
         $this->connectionName = $name;
     }

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -38,7 +38,7 @@ class EntityPopulator
         return $this->class->getName();
     }
 
-    public function setColumnFormatters($columnFormatters): void
+    public function setColumnFormatters($columnFormatters)
     {
         $this->columnFormatters = $columnFormatters;
     }
@@ -51,12 +51,12 @@ class EntityPopulator
         return $this->columnFormatters;
     }
 
-    public function mergeColumnFormattersWith($columnFormatters): void
+    public function mergeColumnFormattersWith($columnFormatters)
     {
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }
 
-    public function setModifiers(array $modifiers): void
+    public function setModifiers(array $modifiers)
     {
         $this->modifiers = $modifiers;
     }
@@ -69,7 +69,7 @@ class EntityPopulator
         return $this->modifiers;
     }
 
-    public function mergeModifiersWith(array $modifiers): void
+    public function mergeModifiersWith(array $modifiers)
     {
         $this->modifiers = array_merge($this->modifiers, $modifiers);
     }

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -61,7 +61,7 @@ class Populator
      * @param mixed $entity A Doctrine classname, or a \Faker\ORM\Doctrine\EntityPopulator instance
      * @param int   $number The number of entities to populate
      */
-    public function addEntity($entity, $number, $customColumnFormatters = [], $customModifiers = [], $generateId = false): void
+    public function addEntity($entity, $number, $customColumnFormatters = [], $customModifiers = [], $generateId = false)
     {
         if (!$entity instanceof \Faker\ORM\Doctrine\EntityPopulator) {
             if (null === $this->manager) {

--- a/src/Faker/ORM/Mandango/EntityPopulator.php
+++ b/src/Faker/ORM/Mandango/EntityPopulator.php
@@ -29,7 +29,7 @@ class EntityPopulator
         return $this->class;
     }
 
-    public function setColumnFormatters($columnFormatters): void
+    public function setColumnFormatters($columnFormatters)
     {
         $this->columnFormatters = $columnFormatters;
     }
@@ -42,7 +42,7 @@ class EntityPopulator
         return $this->columnFormatters;
     }
 
-    public function mergeColumnFormattersWith($columnFormatters): void
+    public function mergeColumnFormattersWith($columnFormatters)
     {
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }

--- a/src/Faker/ORM/Mandango/Populator.php
+++ b/src/Faker/ORM/Mandango/Populator.php
@@ -27,7 +27,7 @@ class Populator
      * @param mixed $entity A Propel ActiveRecord classname, or a \Faker\ORM\Propel\EntityPopulator instance
      * @param int   $number The number of entities to populate
      */
-    public function addEntity($entity, $number, $customColumnFormatters = []): void
+    public function addEntity($entity, $number, $customColumnFormatters = [])
     {
         if (!$entity instanceof \Faker\ORM\Mandango\EntityPopulator) {
             $entity = new \Faker\ORM\Mandango\EntityPopulator($entity);

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -29,7 +29,7 @@ class EntityPopulator
         return $this->class;
     }
 
-    public function setColumnFormatters($columnFormatters): void
+    public function setColumnFormatters($columnFormatters)
     {
         $this->columnFormatters = $columnFormatters;
     }
@@ -42,7 +42,7 @@ class EntityPopulator
         return $this->columnFormatters;
     }
 
-    public function mergeColumnFormattersWith($columnFormatters): void
+    public function mergeColumnFormattersWith($columnFormatters)
     {
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }
@@ -126,7 +126,7 @@ class EntityPopulator
         return false;
     }
 
-    public function setModifiers($modifiers): void
+    public function setModifiers($modifiers)
     {
         $this->modifiers = $modifiers;
     }
@@ -139,7 +139,7 @@ class EntityPopulator
         return $this->modifiers;
     }
 
-    public function mergeModifiersWith($modifiers): void
+    public function mergeModifiersWith($modifiers)
     {
         $this->modifiers = array_merge($this->modifiers, $modifiers);
     }

--- a/src/Faker/ORM/Propel/Populator.php
+++ b/src/Faker/ORM/Propel/Populator.php
@@ -23,7 +23,7 @@ class Populator
      * @param mixed $entity A Propel ActiveRecord classname, or a \Faker\ORM\Propel\EntityPopulator instance
      * @param int   $number The number of entities to populate
      */
-    public function addEntity($entity, $number, $customColumnFormatters = [], $customModifiers = []): void
+    public function addEntity($entity, $number, $customColumnFormatters = [], $customModifiers = [])
     {
         if (!$entity instanceof \Faker\ORM\Propel\EntityPopulator) {
             $entity = new \Faker\ORM\Propel\EntityPopulator($entity);

--- a/src/Faker/ORM/Propel2/EntityPopulator.php
+++ b/src/Faker/ORM/Propel2/EntityPopulator.php
@@ -30,7 +30,7 @@ class EntityPopulator
         return $this->class;
     }
 
-    public function setColumnFormatters($columnFormatters): void
+    public function setColumnFormatters($columnFormatters)
     {
         $this->columnFormatters = $columnFormatters;
     }
@@ -43,7 +43,7 @@ class EntityPopulator
         return $this->columnFormatters;
     }
 
-    public function mergeColumnFormattersWith($columnFormatters): void
+    public function mergeColumnFormattersWith($columnFormatters)
     {
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }
@@ -129,7 +129,7 @@ class EntityPopulator
         return false;
     }
 
-    public function setModifiers($modifiers): void
+    public function setModifiers($modifiers)
     {
         $this->modifiers = $modifiers;
     }
@@ -142,7 +142,7 @@ class EntityPopulator
         return $this->modifiers;
     }
 
-    public function mergeModifiersWith($modifiers): void
+    public function mergeModifiersWith($modifiers)
     {
         $this->modifiers = array_merge($this->modifiers, $modifiers);
     }

--- a/src/Faker/ORM/Propel2/Populator.php
+++ b/src/Faker/ORM/Propel2/Populator.php
@@ -26,7 +26,7 @@ class Populator
      * @param mixed $entity A Propel ActiveRecord classname, or a \Faker\ORM\Propel2\EntityPopulator instance
      * @param int   $number The number of entities to populate
      */
-    public function addEntity($entity, $number, $customColumnFormatters = [], $customModifiers = []): void
+    public function addEntity($entity, $number, $customColumnFormatters = [], $customModifiers = [])
     {
         if (!$entity instanceof \Faker\ORM\Propel2\EntityPopulator) {
             $entity = new \Faker\ORM\Propel2\EntityPopulator($entity);

--- a/src/Faker/ORM/Spot/EntityPopulator.php
+++ b/src/Faker/ORM/Spot/EntityPopulator.php
@@ -60,7 +60,7 @@ class EntityPopulator
         return $this->mapper;
     }
 
-    public function setColumnFormatters($columnFormatters): void
+    public function setColumnFormatters($columnFormatters)
     {
         $this->columnFormatters = $columnFormatters;
     }
@@ -73,12 +73,12 @@ class EntityPopulator
         return $this->columnFormatters;
     }
 
-    public function mergeColumnFormattersWith($columnFormatters): void
+    public function mergeColumnFormattersWith($columnFormatters)
     {
         $this->columnFormatters = array_merge($this->columnFormatters, $columnFormatters);
     }
 
-    public function setModifiers(array $modifiers): void
+    public function setModifiers(array $modifiers)
     {
         $this->modifiers = $modifiers;
     }
@@ -91,7 +91,7 @@ class EntityPopulator
         return $this->modifiers;
     }
 
-    public function mergeModifiersWith(array $modifiers): void
+    public function mergeModifiersWith(array $modifiers)
     {
         $this->modifiers = array_merge($this->modifiers, $modifiers);
     }

--- a/src/Faker/ORM/Spot/Populator.php
+++ b/src/Faker/ORM/Spot/Populator.php
@@ -38,7 +38,7 @@ class Populator
         $customColumnFormatters = [],
         $customModifiers = [],
         $useExistingData = false
-    ): void {
+    ) {
         $mapper = $this->locator->mapper($entityName);
 
         if (null === $mapper) {

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -356,7 +356,7 @@ class DateTime extends Base
      *
      * @param string $timezone
      */
-    public static function setDefaultTimezone($timezone = null): void
+    public static function setDefaultTimezone($timezone = null)
     {
         static::$defaultTimezone = $timezone;
     }


### PR DESCRIPTION
### What is the reason for this PR?

The bc check is currently not working.

- [x] Use [addnab/docker-run-action@v3](https://github.com/addnab/docker-run-action) action to run as checkout user (uid `1001`)
- [x] reverts backward-incompatible changes applied in #554

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io) (there are none)

### Summary of changes

At the moment the code gets checked out by a user with the uid `1001` but the `nyholm/roave-bc-check-ga` runs as root which triggers the `fatal: detected dubious ownership in repository at '/github/workspace'` error.
Running the commands in that container as a user with the user id 1001 is, to my understanding, not possible using default GitHub Actions config so the workaround of using `addnab/docker-run-action@v3` is used to allow for defining the user id uding `-u 1001` (and setting then not available, `GITHUB_REPOSITORY` variable).

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
