### PR TITLE
Remove invalid config reference in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,18 @@ to run `rector/rector`.
 
 *Note:* do not forget to replace `src/` with the path to your source directory.
 
-Another way is to use it in your `rector.php` file:
+Alternatively, import the configuration in your `rector.php` file:
 
 ```php
-$rectorConfig->import('vendor/fakerphp/faker/rector-migrate.php');
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->import('vendor/fakerphp/faker/rector-migrate.php');
+};
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Another way is to use it in your `rector.php` file:
 
 ```php
 $rectorConfig->import('vendor/fakerphp/faker/rector-migrate.php');
-$faker($rectorConfig);
 ```
 
 ## License


### PR DESCRIPTION
### What is the reason for this PR?

Fix the Rector config in the README by removing an invalid closure call

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
