### PR TITLE
Feature: Generate only HTTPS URLs

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -327,7 +327,7 @@ use Faker\Container\ContainerInterface;
  *
  * @property string $url
  *
- * @method string url()
+ * @method string url($isHttpsOnly = false)
  *
  * @property string $slug
  *

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -190,11 +190,17 @@ class Internet extends Base
      *
      * @return string
      */
-    public function url()
+    public function url($isHttpsOnly = false)
     {
         $format = static::randomElement(static::$urlFormats);
 
-        return $this->generator->parse($format);
+        $url = $this->generator->parse($format);
+
+        if ($isHttpsOnly) {
+            return str_ireplace('http://', 'https://', $url);
+        }
+
+        return $url;
     }
 
     /**

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -98,6 +98,13 @@ final class InternetTest extends TestCase
         self::assertNotFalse(filter_var($this->faker->url(), FILTER_VALIDATE_URL));
     }
 
+    public function testUrlIsHttpsValid(): void
+    {
+        $url = $this->faker->url(true);
+        self::assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
+        self::assertNotFalse(stripos($url, 'https://'));
+    }
+
     public function testLocalIpv4(): void
     {
         self::assertNotFalse(filter_var($this->faker->localIpv4(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));


### PR DESCRIPTION
### What is the reason for this PR?

Related issue was also created - https://github.com/FakerPHP/Faker/issues/593
Extend Internet provider url method to provide only HTTPS URLs

- [x] A new feature (resolve #593)
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Extend url method with $isHttpsOnly flag, default value is false. If it's true 

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
