### PR TITLE
fix: Empty `Traversable` in `randomElements()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -649,11 +649,6 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
-			message: "#^Ternary operator condition is always false\\.$#"
-			count: 1
-			path: src/Faker/Provider/Base.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/Faker/Provider/Base.php

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -190,14 +190,14 @@ class Base
     public static function randomElements($array = ['a', 'b', 'c'], $count = 1, $allowDuplicates = false)
     {
         $traversables = [];
+        $arr = $array;
 
         if ($array instanceof \Traversable) {
             foreach ($array as $element) {
                 $traversables[] = $element;
             }
+            $arr = $traversables;
         }
-
-        $arr = count($traversables) ? $traversables : $array;
 
         $allKeys = array_keys($arr);
         $numKeys = count($allKeys);

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -556,6 +556,10 @@ final class BaseTest extends TestCase
         self::assertIsArray($empty);
         self::assertCount(0, $empty);
 
+        $emptyTraversable = BaseProvider::randomElements(new \ArrayIterator(), 0);
+        self::assertIsArray($emptyTraversable);
+        self::assertCount(0, $emptyTraversable);
+
         $shuffled = BaseProvider::randomElements(['foo', 'bar', 'baz'], 3);
         self::assertContains('foo', $shuffled);
         self::assertContains('bar', $shuffled);


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue (resolve #604  )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
