### PR TITLE
timezone() respects countrycode

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -330,7 +330,6 @@ class DateTime extends Base
     }
 
     /**
-     * @param string|null $countryCode
      * @return string
      *
      * @example 'Europe/Paris'

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -330,13 +330,20 @@ class DateTime extends Base
     }
 
     /**
+     * @param string|null $countryCode
      * @return string
      *
      * @example 'Europe/Paris'
      */
-    public static function timezone()
+    public static function timezone(string $countryCode = null)
     {
-        return static::randomElement(\DateTimeZone::listIdentifiers());
+        if ($countryCode) {
+            $timezones = \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, $countryCode);
+        } else {
+            $timezones = \DateTimeZone::listIdentifiers();
+        }
+
+        return static::randomElement($timezones);
     }
 
     /**

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -281,4 +281,15 @@ final class DateTimeTest extends TestCase
         self::assertEquals($dateTimeThisYear, DateTimeProvider::dateTimeThisYear($max));
         mt_srand();
     }
+
+    public function testTimezone(): void
+    {
+        $timezone = DateTimeProvider::timezone();
+        $countryTimezone = DateTimeProvider::timezone('US');
+
+        self::assertIsString($timezone);
+        self::assertContains($timezone, \DateTimeZone::listIdentifiers());
+        self::assertIsString($countryTimezone);
+        self::assertContains($countryTimezone, \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, 'US'));
+    }
 }


### PR DESCRIPTION
https://github.com/FakerPHP/Faker/pull/480/files added optional countryCode parameter, to Core and Extension classes, but not the Provider class.

### What is the reason for this PR?

Duplicate existing functionality into Provider\DateTime class

- [ ] A new feature
- [X] Fixed an issue (resolve #606)

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ NA] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->
Duplicate existing functionality into other class.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
