### PR TITLE
Dollar sign outside of curly braces is deprecated

### DIFF
--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -438,8 +438,8 @@ class Person extends \Faker\Provider\Person
             $gender = $this->generator->boolean() ? static::GENDER_MALE : static::GENDER_FEMALE;
         }
 
-        $startTimestamp = strtotime("-${maxAge} year");
-        $endTimestamp = strtotime("-${minAge} year");
+        $startTimestamp = strtotime("-{$maxAge} year");
+        $endTimestamp = strtotime("-{$minAge} year");
         $randTimestamp = self::numberBetween($startTimestamp, $endTimestamp);
 
         $year = intval(date('Y', $randTimestamp));


### PR DESCRIPTION
### What is the reason for this PR?

The ${var} String Interpolation is Deprecated in PHP 8.2

- [ ] A new feature
- [X] Fixed an issue (resolve #ID)

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

cs_CZ Person provider

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
