### PR TITLE
allows passing an `enum` to `randomElement()` or `randomElements()`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,9 @@ $finder = PhpCsFixer\Finder::create()
         '.github/',
         'vendor-bin/',
     ])
+    ->notPath([
+        'test/Fixture/Enum/BackedEnum.php',
+    ])
     ->ignoreDotFiles(false)
     ->in(__DIR__);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -611,6 +611,11 @@ parameters:
 			path: src/Faker/ORM/Spot/Populator.php
 
 		-
+			message: "#^Class UnitEnum not found\\.$#"
+			count: 2
+			path: src/Faker/Provider/Base.php
+
+		-
 			message: """
 				#^Instantiation of deprecated class Faker\\\\DefaultGenerator\\:
 				Use ChanceGenerator instead$#

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -145,6 +145,10 @@
     <UndefinedDocblockClass>
       <code>Closure</code>
     </UndefinedDocblockClass>
+    <UndefinedFunction>
+      <code>enum_exists($array)</code>
+      <code>enum_exists($array)</code>
+    </UndefinedFunction>
   </file>
   <file src="src/Faker/Provider/Biased.php">
     <InvalidParamDefault>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -142,6 +142,10 @@
     <InvalidArgument>
       <code>[static::class, 'randomDigit']</code>
     </InvalidArgument>
+    <UndefinedClass>
+      <code>\UnitEnum</code>
+      <code>\UnitEnum</code>
+    </UndefinedClass>
     <UndefinedDocblockClass>
       <code>Closure</code>
     </UndefinedDocblockClass>

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -192,8 +192,8 @@ class Base
     {
         $elements = $array;
 
-        if (is_string($array) && function_exists('enum_exists') && enum_exists($array)) {
-            $elements = [$array, 'cases']();
+        if (is_string($array) && function_exists('enum_exists') && \enum_exists($array)) {
+            $array = [$array, 'cases']();
         }
 
         if ($array instanceof \Traversable) {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -180,8 +180,8 @@ class Base
      * Returns randomly ordered subsequence of $count elements from a provided array
      *
      * @param array|class-string<\UnitEnum>|\Traversable $array           Array to take elements from. Defaults to a-c
-     * @param int                       $count           Number of elements to take.
-     * @param bool                      $allowDuplicates Allow elements to be picked several times. Defaults to false
+     * @param int                                        $count           Number of elements to take.
+     * @param bool                                       $allowDuplicates Allow elements to be picked several times. Defaults to false
      *
      * @throws \InvalidArgumentException
      * @throws \LengthException          When requesting more elements than provided
@@ -193,7 +193,7 @@ class Base
         $elements = $array;
 
         if (is_string($array) && function_exists('enum_exists') && \enum_exists($array)) {
-            $traversables = [$array, 'cases']();
+            $elements = $array::cases();
         }
 
         if ($array instanceof \Traversable) {
@@ -259,7 +259,7 @@ class Base
         $elements = $array;
 
         if (is_string($array) && function_exists('enum_exists') && enum_exists($array)) {
-            $elements = [$array, 'cases']();
+            $elements = $array::cases();
         }
 
         if ($array instanceof \Traversable) {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -179,7 +179,7 @@ class Base
     /**
      * Returns randomly ordered subsequence of $count elements from a provided array
      *
-     * @param array|string|\Traversable $array           Array to take elements from. Defaults to a-c
+     * @param array|class-string<\UnitEnum>|\Traversable $array           Array to take elements from. Defaults to a-c
      * @param int                       $count           Number of elements to take.
      * @param bool                      $allowDuplicates Allow elements to be picked several times. Defaults to false
      *
@@ -250,8 +250,7 @@ class Base
     /**
      * Returns a random element from a passed array
      *
-     * @param array|string|\Traversable $array
-     * @param array|\Traversable $array
+     * @param array|class-string<\UnitEnum>|\Traversable $array
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -192,7 +192,7 @@ class Base
     {
         $elements = $array;
 
-        if (is_string($array) && function_exists('enum_exists') && \enum_exists($array)) {
+        if (is_string($array) && function_exists('enum_exists') && enum_exists($array)) {
             $elements = $array::cases();
         }
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -179,9 +179,9 @@ class Base
     /**
      * Returns randomly ordered subsequence of $count elements from a provided array
      *
-     * @param array|\Traversable $array           Array to take elements from. Defaults to a-c
-     * @param int                $count           Number of elements to take.
-     * @param bool               $allowDuplicates Allow elements to be picked several times. Defaults to false
+     * @param array|string|\Traversable $array           Array to take elements from. Defaults to a-c
+     * @param int                       $count           Number of elements to take.
+     * @param bool                      $allowDuplicates Allow elements to be picked several times. Defaults to false
      *
      * @throws \InvalidArgumentException
      * @throws \LengthException          When requesting more elements than provided
@@ -192,13 +192,18 @@ class Base
     {
         $elements = $array;
 
+        if (is_string($array) && function_exists('enum_exists') && enum_exists($array)) {
+            $elements = [$array, 'cases']();
+        }
+
         if ($array instanceof \Traversable) {
             $elements = \iterator_to_array($array, false);
         }
 
         if (!is_array($elements)) {
             throw new \InvalidArgumentException(sprintf(
-                'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+                'Argument for parameter $array needs to be array, an instance of %s, or an instance of %s, got %s instead.',
+                \UnitEnum::class,
                 \Traversable::class,
                 is_object($array) ? get_class($array) : gettype($array),
             ));
@@ -245,6 +250,7 @@ class Base
     /**
      * Returns a random element from a passed array
      *
+     * @param array|string|\Traversable $array
      * @param array|\Traversable $array
      *
      * @throws \InvalidArgumentException
@@ -252,6 +258,10 @@ class Base
     public static function randomElement($array = ['a', 'b', 'c'])
     {
         $elements = $array;
+
+        if (is_string($array) && function_exists('enum_exists') && enum_exists($array)) {
+            $elements = [$array, 'cases']();
+        }
 
         if ($array instanceof \Traversable) {
             $elements = iterator_to_array($array, false);
@@ -263,7 +273,8 @@ class Base
 
         if (!is_array($elements)) {
             throw new \InvalidArgumentException(sprintf(
-                'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+                'Argument for parameter $array needs to be array, an instance of %s, or an instance of %s, got %s instead.',
+                \UnitEnum::class,
                 \Traversable::class,
                 is_object($array) ? get_class($array) : gettype($array),
             ));

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -179,9 +179,9 @@ class Base
     /**
      * Returns randomly ordered subsequence of $count elements from a provided array
      *
-     * @param array|class-string<\UnitEnum>|\Traversable $array           Array to take elements from. Defaults to a-c
-     * @param int                                        $count           Number of elements to take.
-     * @param bool                                       $allowDuplicates Allow elements to be picked several times. Defaults to false
+     * @param array|class-string|\Traversable $array           Array to take elements from. Defaults to a-c
+     * @param int                             $count           Number of elements to take.
+     * @param bool                            $allowDuplicates Allow elements to be picked several times. Defaults to false
      *
      * @throws \InvalidArgumentException
      * @throws \LengthException          When requesting more elements than provided
@@ -250,7 +250,7 @@ class Base
     /**
      * Returns a random element from a passed array
      *
-     * @param array|class-string<\UnitEnum>|\Traversable $array
+     * @param array|class-string|\Traversable $array
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -193,7 +193,7 @@ class Base
         $elements = $array;
 
         if (is_string($array) && function_exists('enum_exists') && \enum_exists($array)) {
-            $array = [$array, 'cases']();
+            $traversables = [$array, 'cases']();
         }
 
         if ($array instanceof \Traversable) {

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -616,8 +616,6 @@ final class BaseTest extends TestCase
      */
     public function testRandomElementWithEnum(): void
     {
-        require_once __DIR__ . '/../../Fixture/Enum/BackedEnum.php';
-
         self::assertCount(2, $cases = BaseProvider::randomElements(BackedEnum::class, 2));
         self::assertInstanceOf(BackedEnum::class, $cases[0]);
         self::assertInstanceOf(BackedEnum::class, $cases[1]);

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -553,7 +553,8 @@ final class BaseTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
-            'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+            'Argument for parameter $array needs to be array, an instance of %s, or an instance of %s, got %s instead.',
+            \UnitEnum::class,
             \Traversable::class,
             \stdClass::class,
         ));
@@ -565,7 +566,8 @@ final class BaseTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
-            'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+            'Argument for parameter $array needs to be array, an instance of %s, or an instance of %s, got %s instead.',
+            \UnitEnum::class,
             \Traversable::class,
             'string',
         ));

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -611,12 +611,11 @@ final class BaseTest extends TestCase
         self::assertContainsOnly('string', $randomElements);
     }
 
+    /**
+     * @requires PHP 8.1
+     */
     public function testRandomElementWithEnum(): void
     {
-        if (!function_exists('enum_exists')) {
-            self::markTestSkipped('Enums were not implemented until 8.1');
-        }
-
         require_once __DIR__ . '/../../Fixture/Enum/BackedEnum.php';
 
         self::assertCount(2, $cases = BaseProvider::randomElements(BackedEnum::class, 2));

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -617,7 +617,7 @@ final class BaseTest extends TestCase
     public function testRandomElementsWithEnum(): void
     {
         $count = 2;
-        
+
         $randomElements = BaseProvider::randomElements(BackedEnum::class, $count);
 
         self::assertCount($count, $randomElements);

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -3,6 +3,7 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\Base as BaseProvider;
+use Faker\Test\Fixture\Enum\BackedEnum;
 use Faker\Test\TestCase;
 
 /**
@@ -608,6 +609,21 @@ final class BaseTest extends TestCase
 
         self::assertCount(3, $randomElements);
         self::assertContainsOnly('string', $randomElements);
+    }
+
+    public function testRandomElementWithEnum(): void
+    {
+        if (!function_exists('enum_exists')) {
+            self::markTestSkipped('Enums were not implemented until 8.1');
+        }
+
+        require_once __DIR__ . '/../../Fixture/Enum/BackedEnum.php';
+
+        self::assertCount(2, $cases = BaseProvider::randomElements(BackedEnum::class, 2));
+        self::assertInstanceOf(BackedEnum::class, $cases[0]);
+        self::assertInstanceOf(BackedEnum::class, $cases[1]);
+
+        self::assertInstanceOf(BackedEnum::class, BaseProvider::randomElement(BackedEnum::class));
     }
 }
 

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -614,13 +614,24 @@ final class BaseTest extends TestCase
     /**
      * @requires PHP 8.1
      */
+    public function testRandomElementsWithEnum(): void
+    {
+        $count = 2;
+        
+        $randomElements = BaseProvider::randomElements(BackedEnum::class, $count);
+
+        self::assertCount($count, $randomElements);
+        self::assertContainsOnlyInstancesOf(BackedEnum::class, $randomElements);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
     public function testRandomElementWithEnum(): void
     {
-        self::assertCount(2, $cases = BaseProvider::randomElements(BackedEnum::class, 2));
-        self::assertInstanceOf(BackedEnum::class, $cases[0]);
-        self::assertInstanceOf(BackedEnum::class, $cases[1]);
+        $randomElement = BaseProvider::randomElement(BackedEnum::class);
 
-        self::assertInstanceOf(BackedEnum::class, BaseProvider::randomElement(BackedEnum::class));
+        self::assertInstanceOf(BackedEnum::class, $randomElement);
     }
 }
 

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -3,7 +3,7 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\Base as BaseProvider;
-use Faker\Test\Fixture\Enum\BackedEnum;
+use Faker\Test\Fixture;
 use Faker\Test\TestCase;
 
 /**
@@ -618,10 +618,10 @@ final class BaseTest extends TestCase
     {
         $count = 2;
 
-        $randomElements = BaseProvider::randomElements(BackedEnum::class, $count);
+        $randomElements = BaseProvider::randomElements(Fixture\Enum\BackedEnum::class, $count);
 
         self::assertCount($count, $randomElements);
-        self::assertContainsOnlyInstancesOf(BackedEnum::class, $randomElements);
+        self::assertContainsOnlyInstancesOf(Fixture\Enum\BackedEnum::class, $randomElements);
     }
 
     /**
@@ -629,9 +629,9 @@ final class BaseTest extends TestCase
      */
     public function testRandomElementWithEnum(): void
     {
-        $randomElement = BaseProvider::randomElement(BackedEnum::class);
+        $randomElement = BaseProvider::randomElement(Fixture\Enum\BackedEnum::class);
 
-        self::assertInstanceOf(BackedEnum::class, $randomElement);
+        self::assertInstanceOf(Fixture\Enum\BackedEnum::class, $randomElement);
     }
 }
 

--- a/test/Fixture/Enum/BackedEnum.php
+++ b/test/Fixture/Enum/BackedEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Faker\Test\Fixture\Enum;
+
+enum BackedEnum: string
+{
+    case Assigned = 'assigned';
+
+    case Pending = 'unassigned';
+
+    case Deleted = 'removed';
+}


### PR DESCRIPTION
### What is the reason for this PR?
```php
faker()->randomElement(SomeEnum::cases())
```
is fine, but I think it would be even nicer to have
```php
faker()->randomElement(SomeEnum::class);
```
- [x] A new feature

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io) in https://github.com/FakerPHP/fakerphp.github.io/pull/85

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
