### PR TITLE
Add DateTimeImmutable extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /vendor-bin/rector/vendor/
 /.php-cs-fixer.cache
 /composer.lock
+
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
-## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.20.0...main)
+## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.21.0...main)
+
+- Added DateTimeImmutable extension with same api as DateTimeExtension
 
 ## [2022-12-13, v1.21.0](https://github.com/FakerPHP/Faker/compare/v1.20.0..v1.21.0)
 

--- a/src/Faker/Container/ContainerBuilder.php
+++ b/src/Faker/Container/ContainerBuilder.php
@@ -9,6 +9,7 @@ use Faker\Extension\BarcodeExtension;
 use Faker\Extension\BloodExtension;
 use Faker\Extension\ColorExtension;
 use Faker\Extension\DateTimeExtension;
+use Faker\Extension\DateTimeImmutableExtension;
 use Faker\Extension\FileExtension;
 use Faker\Extension\NumberExtension;
 use Faker\Extension\UuidExtension;
@@ -72,6 +73,7 @@ final class ContainerBuilder
             BloodExtension::class => Core\Blood::class,
             ColorExtension::class => Core\Color::class,
             DateTimeExtension::class => Core\DateTime::class,
+            DateTimeImmutableExtension::class => Core\DateTimeImmutable::class,
             FileExtension::class => Core\File::class,
             NumberExtension::class => Core\Number::class,
             VersionExtension::class => Core\Version::class,

--- a/src/Faker/Core/DateTimeImmutable.php
+++ b/src/Faker/Core/DateTimeImmutable.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Faker\Core;
+
+use Faker\Extension\DateTimeImmutableExtension;
+use Faker\Extension\GeneratorAwareExtension;
+use Faker\Extension\GeneratorAwareExtensionTrait;
+use Faker\Extension\Helper;
+
+/**
+ * @experimental
+ *
+ * @since 1.22.0
+ */
+final class DateTimeImmutable implements DateTimeImmutableExtension, GeneratorAwareExtension
+{
+    use GeneratorAwareExtensionTrait;
+
+    /**
+     * @var string[]
+     */
+    private $centuries = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X', 'XI', 'XII', 'XIII', 'XIV', 'XV', 'XVI', 'XVII', 'XVIII', 'XIX', 'XX', 'XXI'];
+
+    /**
+     * @var string
+     */
+    private $defaultTimezone = null;
+
+    /**
+     * Get the POSIX-timestamp of a DateTime, int or string.
+     *
+     * @param \DateTimeImmutable|float|int|string $until
+     *
+     * @return false|int
+     */
+    protected function getTimestamp($until = 'now')
+    {
+        if (is_numeric($until)) {
+            return (int) $until;
+        }
+
+        if ($until instanceof \DateTimeImmutable) {
+            return $until->getTimestamp();
+        }
+
+        return strtotime(empty($until) ? 'now' : $until);
+    }
+
+    /**
+     * Get a DateTime created based on a POSIX-timestamp.
+     *
+     * @param int $timestamp the UNIX / POSIX-compatible timestamp
+     */
+    protected function getTimestampDateTime(int $timestamp): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('@' . $timestamp);
+    }
+
+    protected function setDefaultTimezone(string $timezone = null): void
+    {
+        $this->defaultTimezone = $timezone;
+    }
+
+    protected function getDefaultTimezone(): ?string
+    {
+        return $this->defaultTimezone;
+    }
+
+    protected function resolveTimezone(?string $timezone): string
+    {
+        if ($timezone !== null) {
+            return $timezone;
+        }
+
+        return null === $this->defaultTimezone ? date_default_timezone_get() : $this->defaultTimezone;
+    }
+
+    /**
+     * Internal method to set the timezone on a DateTime object.
+     */
+    protected function setTimezone(\DateTimeImmutable $dateTime, ?string $timezone): \DateTimeImmutable
+    {
+        $timezone = $this->resolveTimezone($timezone);
+
+        return $dateTime->setTimezone(new \DateTimeZone($timezone));
+    }
+
+    public function dateTime($until = 'now', string $timezone = null): \DateTimeImmutable
+    {
+        return $this->setTimezone(
+            $this->getTimestampDateTime($this->unixTime($until)),
+            $timezone,
+        );
+    }
+
+    public function dateTimeAD($until = 'now', string $timezone = null): \DateTimeImmutable
+    {
+        $min = (PHP_INT_SIZE > 4) ? -62135597361 : -PHP_INT_MAX;
+
+        return $this->setTimezone(
+            $this->getTimestampDateTime($this->generator->numberBetween($min, $this->getTimestamp($until))),
+            $timezone,
+        );
+    }
+
+    public function dateTimeBetween($from = '-30 years', $until = 'now', string $timezone = null): \DateTimeImmutable
+    {
+        $start = $this->getTimestamp($from);
+        $end = $this->getTimestamp($until);
+
+        if ($start > $end) {
+            throw new \InvalidArgumentException('"$from" must be anterior to "$until".');
+        }
+
+        $timestamp = $this->generator->numberBetween($start, $end);
+
+        return $this->setTimezone(
+            $this->getTimestampDateTime($timestamp),
+            $timezone,
+        );
+    }
+
+    public function dateTimeInInterval($from = '-30 years', string $interval = '+5 days', string $timezone = null): \DateTimeImmutable
+    {
+        $intervalObject = \DateInterval::createFromDateString($interval);
+        $datetime = $from instanceof \DateTimeImmutable ? $from : new \DateTimeImmutable($from);
+
+        $other = (clone $datetime)->add($intervalObject);
+
+        $begin = min($datetime, $other);
+        $end = $datetime === $begin ? $other : $datetime;
+
+        return $this->dateTimeBetween($begin, $end, $timezone);
+    }
+
+    public function dateTimeThisWeek($until = 'sunday this week', string $timezone = null): \DateTimeImmutable
+    {
+        return $this->dateTimeBetween('monday this week', $until, $timezone);
+    }
+
+    public function dateTimeThisMonth($until = 'last day of this month', string $timezone = null): \DateTimeImmutable
+    {
+        return $this->dateTimeBetween('first day of this month', $until, $timezone);
+    }
+
+    public function dateTimeThisYear($until = 'last day of december', string $timezone = null): \DateTimeImmutable
+    {
+        return $this->dateTimeBetween('first day of january', $until, $timezone);
+    }
+
+    public function dateTimeThisDecade($until = 'now', string $timezone = null): \DateTimeImmutable
+    {
+        $year = floor(date('Y') / 10) * 10;
+
+        return $this->dateTimeBetween("first day of january $year", $until, $timezone);
+    }
+
+    public function dateTimeThisCentury($until = 'now', string $timezone = null): \DateTimeImmutable
+    {
+        $year = floor(date('Y') / 100) * 100;
+
+        return $this->dateTimeBetween("first day of january $year", $until, $timezone);
+    }
+
+    public function date(string $format = 'Y-m-d', $until = 'now'): string
+    {
+        return $this->dateTime($until)->format($format);
+    }
+
+    public function time(string $format = 'H:i:s', $until = 'now'): string
+    {
+        return $this->date($format, $until);
+    }
+
+    public function unixTime($until = 'now'): int
+    {
+        return $this->generator->numberBetween(0, $this->getTimestamp($until));
+    }
+
+    public function iso8601($until = 'now'): string
+    {
+        return $this->date(\DateTimeImmutable::ISO8601, $until);
+    }
+
+    public function amPm($until = 'now'): string
+    {
+        return $this->date('a', $until);
+    }
+
+    public function dayOfMonth($until = 'now'): string
+    {
+        return $this->date('d', $until);
+    }
+
+    public function dayOfWeek($until = 'now'): string
+    {
+        return $this->date('l', $until);
+    }
+
+    public function month($until = 'now'): string
+    {
+        return $this->date('m', $until);
+    }
+
+    public function monthName($until = 'now'): string
+    {
+        return $this->date('F', $until);
+    }
+
+    public function year($until = 'now'): string
+    {
+        return $this->date('Y', $until);
+    }
+
+    public function century(): string
+    {
+        return Helper::randomElement($this->centuries);
+    }
+
+    public function timezone(string $countryCode = null): string
+    {
+        if ($countryCode) {
+            $timezones = \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, $countryCode);
+        } else {
+            $timezones = \DateTimeZone::listIdentifiers();
+        }
+
+        return Helper::randomElement($timezones);
+    }
+}

--- a/src/Faker/Extension/DateTimeImmutableExtension.php
+++ b/src/Faker/Extension/DateTimeImmutableExtension.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Faker\Extension;
+
+/**
+ * FakerPHP extension for Date-related randomization.
+ *
+ * Functions accepting a date string use the `strtotime()` function internally.
+ *
+ * @experimental
+ *
+ * @since 1.22.0
+ */
+interface DateTimeImmutableExtension
+{
+    /**
+     * Get a DateTime object between January 1, 1970, and `$until` (defaults to "now").
+     *
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone zone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     *
+     * @example DateTime('2005-08-16 20:39:21')
+     */
+    public function dateTime($until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a DateTime object for a date between January 1, 0001, and now.
+     *
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone zone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @example DateTime('1265-03-22 21:15:52')
+     *
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeAD($until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a DateTime object a random date between `$from` and `$until`.
+     * Accepts date strings that can be recognized by `strtotime()`.
+     *
+     * @param \DateTimeImmutable|string     $from     defaults to 30 years ago
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone zone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeBetween($from = '-30 years', $until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a DateTime object based on a random date between `$from` and an interval.
+     * Accepts date string that can be recognized by `strtotime()`.
+     *
+     * @param \DateTimeImmutable|int|string $from     defaults to 30 years ago
+     * @param string               $interval defaults to 5 days after
+     * @param string|null          $timezone zone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeInInterval($from = '-30 years', string $interval = '+5 days', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a date time object somewhere inside the current week.
+     *
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone zone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeThisWeek($until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a date time object somewhere inside the current month.
+     *
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeThisMonth($until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a date time object somewhere inside the current year.
+     *
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeThisYear($until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a date time object somewhere inside the current decade.
+     *
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeThisDecade($until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a date time object somewhere inside the current century.
+     *
+     * @param \DateTimeImmutable|int|string $until    maximum timestamp, defaults to "now"
+     * @param string|null          $timezone timezone for generated date, fallback to `DateTime::$defaultTimezone` and `date_default_timezone_get()`.
+     *
+     * @see \DateTimeZone
+     * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
+     */
+    public function dateTimeThisCentury($until = 'now', string $timezone = null): \DateTimeImmutable;
+
+    /**
+     * Get a date string between January 1, 1970, and `$until`.
+     *
+     * @param string               $format DateTime format
+     * @param \DateTimeImmutable|int|string $until  maximum timestamp, defaults to "now"
+     *
+     * @see https://www.php.net/manual/en/datetime.format.php
+     */
+    public function date(string $format = 'Y-m-d', $until = 'now'): string;
+
+    /**
+     * Get a time string (24h format by default).
+     *
+     * @param string               $format DateTime format
+     * @param \DateTimeImmutable|int|string $until  maximum timestamp, defaults to "now"
+     *
+     * @see https://www.php.net/manual/en/datetime.format.php
+     */
+    public function time(string $format = 'H:i:s', $until = 'now'): string;
+
+    /**
+     * Get a UNIX (POSIX-compatible) timestamp between January 1, 1970, and `$until`.
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     */
+    public function unixTime($until = 'now'): int;
+
+    /**
+     * Get a date string according to the ISO-8601 standard.
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     */
+    public function iso8601($until = 'now'): string;
+
+    /**
+     * Get a string containing either "am" or "pm".
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     *
+     * @example 'am'
+     */
+    public function amPm($until = 'now'): string;
+
+    /**
+     * Get a localized random day of the month.
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     *
+     * @example '16'
+     */
+    public function dayOfMonth($until = 'now'): string;
+
+    /**
+     * Get a localized random day of the week.
+     *
+     * Uses internal DateTime formatting, hence PHP's internal locale will be used (change using `setlocale()`).
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     *
+     * @example 'Tuesday'
+     *
+     * @see setlocale
+     * @see https://www.php.net/manual/en/function.setlocale.php Set a different output language
+     */
+    public function dayOfWeek($until = 'now'): string;
+
+    /**
+     * Get a random month (numbered).
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     *
+     * @example '7'
+     */
+    public function month($until = 'now'): string;
+
+    /**
+     * Get a random month.
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     *
+     * @see setlocale
+     * @see https://www.php.net/manual/en/function.setlocale.php Set a different output language
+     *
+     * @example 'September'
+     */
+    public function monthName($until = 'now'): string;
+
+    /**
+     * Get a random year between 1970 and `$until`.
+     *
+     * @param \DateTimeImmutable|int|string $until maximum timestamp, defaults to "now"
+     *
+     * @example '1987'
+     */
+    public function year($until = 'now'): string;
+
+    /**
+     * Get a random century, formatted as Roman numerals.
+     *
+     * @example 'XVII'
+     */
+    public function century(): string;
+
+    /**
+     * Get a random timezone, uses `\DateTimeZone::listIdentifiers()` internally.
+     *
+     * @param string|null $countryCode two-letter ISO 3166-1 compatible country code
+     *
+     * @example 'Europe/Rome'
+     */
+    public function timezone(string $countryCode = null): string;
+}

--- a/test/Faker/Core/DateTimeImmutableTest.php
+++ b/test/Faker/Core/DateTimeImmutableTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\Core;
+
+use Faker\Extension\DateTimeExtension;
+use Faker\Extension\DateTimeImmutableExtension;
+use Faker\Test\TestCase;
+
+/**
+ * @covers \Faker\Core\DateTimeImmutable
+ */
+final class DateTimeImmutableTest extends TestCase
+{
+    /**
+     * @var DateTimeExtension
+     */
+    protected $extension;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension = $this->faker->ext(DateTimeImmutableExtension::class);
+    }
+
+    public function testDateTime(): void
+    {
+        $dateTime = $this->extension->dateTime('2005-10-19T14:12:00');
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertEquals(new \DateTimeImmutable('1990-09-29T12:12:53'), $dateTime);
+    }
+
+    public function testDateTimeWithTimezone(): void
+    {
+        $dateTime = $this->extension->dateTime('2021-09-05T15:10:00', 'America/Los_Angeles');
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertEquals(new \DateTimeImmutable('1999-12-11T22:41:46.000000-0800'), $dateTime);
+        self::assertEquals(new \DateTimeZone('America/Los_Angeles'), $dateTime->getTimezone());
+    }
+
+    public function testDateTimeAD(): void
+    {
+        $dateTime = $this->extension->dateTimeAD('2012-04-12T19:22:23');
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertEquals(new \DateTimeImmutable('1166-06-01T17:43:42'), $dateTime);
+    }
+
+    public function testDateTimeBetween(): void
+    {
+        $dateTime = $this->extension->dateTimeBetween('1998-12-18T11:23:40', '2004-09-15T22:10:45');
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertEquals(new \DateTimeImmutable('2002-04-17T09:33:38'), $dateTime);
+    }
+
+    public function testDateTimeBetweenShouldThrowIfFromIsNotAnteriorToUntil(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        $this->extension->dateTimeBetween('2004-09-15T22:10:45', '1998-12-18T11:23:40');
+    }
+
+    public function testDateTimeInInterval(): void
+    {
+        $dateTime = $this->extension->dateTimeInInterval('1999-07-16T17:30:12', '+2 years');
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertEquals(new \DateTimeImmutable('2000-09-12T07:10:58'), $dateTime);
+    }
+
+    public function testDateTimeThisWeek(): void
+    {
+        $dateTime = $this->extension->dateTimeThisWeek();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertGreaterThanOrEqual(new \DateTimeImmutable('monday this week'), $dateTime);
+        self::assertLessThanOrEqual(new \DateTimeImmutable('sunday this week'), $dateTime);
+    }
+
+    public function testDateTimeThisMonth(): void
+    {
+        $dateTime = $this->extension->dateTimeThisMonth();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertGreaterThanOrEqual(new \DateTimeImmutable('first day of this month'), $dateTime);
+        self::assertLessThanOrEqual(new \DateTimeImmutable('last day of this month'), $dateTime);
+    }
+
+    public function testDateTimeThisYear(): void
+    {
+        $dateTime = $this->extension->dateTimeThisYear();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertGreaterThanOrEqual(new \DateTimeImmutable('first day of january'), $dateTime);
+        self::assertLessThanOrEqual(new \DateTimeImmutable('last day of december'), $dateTime);
+    }
+
+    public function testDateTimeThisDecade(): void
+    {
+        $dateTime = $this->extension->dateTimeThisDecade();
+
+        $year = floor(date('Y') / 10) * 10;
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertGreaterThanOrEqual(new \DateTimeImmutable("first day of january $year"), $dateTime);
+        self::assertLessThanOrEqual(new \DateTimeImmutable('now'), $dateTime);
+    }
+
+    public function testDateTimeThisCentury(): void
+    {
+        $dateTime = $this->extension->dateTimeThisCentury();
+
+        $year = floor(date('Y') / 100) * 100;
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        self::assertGreaterThanOrEqual(new \DateTimeImmutable("first day of january $year"), $dateTime);
+        self::assertLessThanOrEqual(new \DateTimeImmutable('now'), $dateTime);
+    }
+
+    public function testDate(): void
+    {
+        $date = $this->extension->date('Y-m-d', '2102-11-12T14:45:29');
+
+        self::assertIsString($date);
+        self::assertEquals('2046-12-26', $date);
+    }
+
+    public function testTime(): void
+    {
+        $time = $this->extension->time('H:i:s', '1978-06-27T09:43:21');
+
+        self::assertIsString($time);
+        self::assertEquals('21:59:44', $time);
+    }
+
+    public function testUnixTime(): void
+    {
+        $unixTime = $this->extension->unixTime('1993-08-29T15:10:00');
+
+        self::assertIsInt($unixTime);
+        self::assertEquals(432630664, $unixTime);
+    }
+
+    public function testUnitTimeWithNumericUntil(): void
+    {
+        $unixTime = $this->extension->unixTime(1643830258);
+
+        self::assertIsInt($unixTime);
+        self::assertEquals(952499510, $unixTime);
+    }
+
+    public function testIso8601(): void
+    {
+        $iso8601 = $this->extension->iso8601('1993-07-11T15:10:00');
+
+        self::assertIsString($iso8601);
+        self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}$/', $iso8601);
+        self::assertEquals('1983-08-19T21:45:51+0000', $iso8601);
+    }
+
+    public function testAmPm(): void
+    {
+        $amPm = $this->extension->amPm('1929-04-14T15:10:23');
+
+        self::assertIsString($amPm);
+        self::assertEquals('pm', $amPm);
+        self::assertContains($amPm, ['am', 'pm']);
+    }
+
+    public function testDayOfMonth(): void
+    {
+        $dayOfMonth = $this->extension->dayOfMonth('2001-04-29T15:10:12');
+
+        self::assertIsString($dayOfMonth);
+        self::assertEquals('25', $dayOfMonth);
+    }
+
+    public function testDayOfWeek(): void
+    {
+        $dayOfWeek = $this->extension->dayOfWeek('2021-12-12T15:10:00');
+
+        self::assertIsString($dayOfWeek);
+        self::assertEquals('Monday', $dayOfWeek);
+    }
+
+    public function testMonth(): void
+    {
+        $month = $this->extension->month('2021-05-23T15:10:00');
+
+        self::assertIsString($month);
+        self::assertEquals('10', $month);
+    }
+
+    public function testMonthName(): void
+    {
+        $monthName = $this->extension->monthName('2021-06-06T15:10:00');
+
+        self::assertIsString($monthName);
+        self::assertEquals('October', $monthName);
+    }
+
+    public function testYear(): void
+    {
+        $year = $this->extension->year('2021-09-12T15:10:00');
+
+        self::assertIsString($year);
+        self::assertEquals('1999', $year);
+    }
+
+    public function testCentury(): void
+    {
+        $century = $this->extension->century();
+
+        self::assertIsString($century);
+        self::assertEquals('XIX', $century);
+    }
+
+    public function testTimezone(): void
+    {
+        $timezone = $this->extension->timezone();
+        $countryTimezone = $this->extension->timezone('US');
+
+        self::assertIsString($timezone);
+        self::assertContains($timezone, \DateTimeZone::listIdentifiers());
+        self::assertIsString($countryTimezone);
+        self::assertContains($countryTimezone, \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, 'US'));
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

We have a extension for generating `DateTime`s but no native way for `DateTimeImmutable` even though they have clear advantages in most sitations. Therefore this PR creates an extension for `DateTimeImmutable` with the same API as for `DateTime`.

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Basically copy & paste from `DateTime`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
