### PR TITLE
Fix: Disable `findUnusedCode` option

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     errorBaseline="psalm.baseline.xml"
     errorLevel="5"
     findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     resolveFromConfigFile="true"
 >
     <projectFiles>


### PR DESCRIPTION
### What is the reason for this PR?

- [x] disables the `findUnusedCode` option

💁‍♂️ Running

```shell
vendor/bin/psalm
```

on current `main` yields

```
Warning: "findUnusedCode" will be defaulted to "true" in Psalm 6. You should explicitly enable or disable this setting.
```

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
