### PR TITLE
Fix: Clean up `randomElements()` and `randomElement()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -644,11 +644,6 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/Faker/Provider/Base.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/Faker/Provider/Base.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -612,7 +612,7 @@ parameters:
 
 		-
 			message: "#^Instanceof between array and Traversable will always evaluate to false\\.$#"
-			count: 2
+			count: 1
 			path: src/Faker/Provider/Base.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -611,11 +611,6 @@ parameters:
 			path: src/Faker/ORM/Spot/Populator.php
 
 		-
-			message: "#^Instanceof between array and Traversable will always evaluate to false\\.$#"
-			count: 1
-			path: src/Faker/Provider/Base.php
-
-		-
 			message: """
 				#^Instantiation of deprecated class Faker\\\\DefaultGenerator\\:
 				Use ChanceGenerator instead$#

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.7.7@e028ba46ba0d7f9a78bc3201c251e137383e145f">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/Faker/Calculator/Luhn.php">
     <InvalidReturnStatement>
       <code>0</code>
@@ -140,11 +140,8 @@
   </file>
   <file src="src/Faker/Provider/Base.php">
     <InvalidArgument>
-      <code><![CDATA[[static::class, 'randomDigit']]]></code>
+      <code>[static::class, 'randomDigit']</code>
     </InvalidArgument>
-    <NoValue>
-      <code>$array</code>
-    </NoValue>
     <UndefinedDocblockClass>
       <code>Closure</code>
     </UndefinedDocblockClass>

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -212,17 +212,17 @@ class Base
         $numberOfRandomElements = 0;
 
         while ($numberOfRandomElements < $count) {
-            $num = mt_rand(0, $highKey);
+            $index = mt_rand(0, $highKey);
 
             if (!$allowDuplicates) {
-                if (isset($keys[$num])) {
+                if (isset($keys[$index])) {
                     continue;
                 }
 
-                $keys[$num] = true;
+                $keys[$index] = true;
             }
 
-            $key = $allKeys[$num];
+            $key = $allKeys[$index];
 
             $randomElements[] = $elements[$key];
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -206,13 +206,13 @@ class Base
         }
 
         $keys = array_keys($elements);
-        $highKey = $numberOfElements - 1;
+        $maxIndex = $numberOfElements - 1;
         $elementHasBeenSelectedAlready = [];
         $randomElements = [];
         $numberOfRandomElements = 0;
 
         while ($numberOfRandomElements < $count) {
-            $index = mt_rand(0, $highKey);
+            $index = mt_rand(0, $maxIndex);
 
             if (!$allowDuplicates) {
                 if (isset($elementHasBeenSelectedAlready[$index])) {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -195,18 +195,18 @@ class Base
             $elements = \iterator_to_array($array, false);
         }
 
-        $numKeys = count($elements);
+        $numberOfElements = count($elements);
 
-        if (!$allowDuplicates && $numKeys < $count) {
+        if (!$allowDuplicates && $numberOfElements < $count) {
             throw new \LengthException(sprintf(
                 'Cannot get %d elements, only %d in array',
                 $count,
-                $numKeys,
+                $numberOfElements,
             ));
         }
 
         $allKeys = array_keys($elements);
-        $highKey = $numKeys - 1;
+        $highKey = $numberOfElements - 1;
         $keys = [];
         $randomElements = [];
         $numberOfRandomElements = 0;

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -243,6 +243,7 @@ class Base
         if (!$array || ($array instanceof \Traversable && !count($array))) {
             return null;
         }
+
         $elements = static::randomElements($array, 1);
 
         return $elements[0];

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -244,9 +244,9 @@ class Base
             return null;
         }
 
-        $elements = static::randomElements($array, 1);
+        $randomElements = static::randomElements($array, 1);
 
-        return $elements[0];
+        return $randomElements[0];
     }
 
     /**

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -189,14 +189,10 @@ class Base
      */
     public static function randomElements($array = ['a', 'b', 'c'], $count = 1, $allowDuplicates = false)
     {
-        $traversables = [];
         $arr = $array;
 
         if ($array instanceof \Traversable) {
-            foreach ($array as $element) {
-                $traversables[] = $element;
-            }
-            $arr = $traversables;
+            $arr = \iterator_to_array($array, false);
         }
 
         $allKeys = array_keys($arr);

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -240,11 +240,11 @@ class Base
      */
     public static function randomElement($array = ['a', 'b', 'c'])
     {
-        if ($array === []) {
-            return null;
+        if ($array instanceof \Traversable) {
+            $array = iterator_to_array($array, false);
         }
 
-        if ($array instanceof \Traversable && !count($array)) {
+        if ($array === []) {
             return null;
         }
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -222,7 +222,9 @@ class Base
                 $keys[$num] = true;
             }
 
-            $randomElements[] = $elements[$allKeys[$num]];
+            $key = $allKeys[$num];
+
+            $randomElements[] = $elements[$key];
 
             ++$numberOfRandomElements;
         }

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -195,7 +195,6 @@ class Base
             $elements = \iterator_to_array($array, false);
         }
 
-        $allKeys = array_keys($elements);
         $numKeys = count($elements);
 
         if (!$allowDuplicates && $numKeys < $count) {
@@ -206,6 +205,7 @@ class Base
             ));
         }
 
+        $allKeys = array_keys($elements);
         $highKey = $numKeys - 1;
         $keys = [];
         $randomElements = [];

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -240,7 +240,11 @@ class Base
      */
     public static function randomElement($array = ['a', 'b', 'c'])
     {
-        if (!$array || ($array instanceof \Traversable && !count($array))) {
+        if ($array === []) {
+            return null;
+        }
+
+        if ($array instanceof \Traversable && !count($array)) {
             return null;
         }
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -236,7 +236,7 @@ class Base
     /**
      * Returns a random element from a passed array
      *
-     * @param array $array
+     * @param array|\Traversable $array
      */
     public static function randomElement($array = ['a', 'b', 'c'])
     {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -199,7 +199,11 @@ class Base
         $numKeys = count($allKeys);
 
         if (!$allowDuplicates && $numKeys < $count) {
-            throw new \LengthException(sprintf('Cannot get %d elements, only %d in array', $count, $numKeys));
+            throw new \LengthException(sprintf(
+                'Cannot get %d elements, only %d in array',
+                $count,
+                $numKeys,
+            ));
         }
 
         $highKey = $numKeys - 1;
@@ -214,10 +218,12 @@ class Base
                 if (isset($keys[$num])) {
                     continue;
                 }
+
                 $keys[$num] = true;
             }
 
             $elements[] = $arr[$allKeys[$num]];
+
             ++$numElements;
         }
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -209,9 +209,9 @@ class Base
         $highKey = $numKeys - 1;
         $keys = [];
         $randomElements = [];
-        $numElements = 0;
+        $numberOfRandomElements = 0;
 
-        while ($numElements < $count) {
+        while ($numberOfRandomElements < $count) {
             $num = mt_rand(0, $highKey);
 
             if (!$allowDuplicates) {
@@ -224,7 +224,7 @@ class Base
 
             $randomElements[] = $elements[$allKeys[$num]];
 
-            ++$numElements;
+            ++$numberOfRandomElements;
         }
 
         return $randomElements;

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -205,10 +205,11 @@ class Base
             ));
         }
 
+        $randomElements = [];
+
         $keys = array_keys($elements);
         $maxIndex = $numberOfElements - 1;
         $elementHasBeenSelectedAlready = [];
-        $randomElements = [];
         $numberOfRandomElements = 0;
 
         while ($numberOfRandomElements < $count) {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -189,13 +189,13 @@ class Base
      */
     public static function randomElements($array = ['a', 'b', 'c'], $count = 1, $allowDuplicates = false)
     {
-        $arr = $array;
+        $elements = $array;
 
         if ($array instanceof \Traversable) {
-            $arr = \iterator_to_array($array, false);
+            $elements = \iterator_to_array($array, false);
         }
 
-        $allKeys = array_keys($arr);
+        $allKeys = array_keys($elements);
         $numKeys = count($allKeys);
 
         if (!$allowDuplicates && $numKeys < $count) {
@@ -222,7 +222,7 @@ class Base
                 $keys[$num] = true;
             }
 
-            $randomElements[] = $arr[$allKeys[$num]];
+            $randomElements[] = $elements[$allKeys[$num]];
 
             ++$numElements;
         }

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -196,7 +196,7 @@ class Base
         }
 
         $allKeys = array_keys($elements);
-        $numKeys = count($allKeys);
+        $numKeys = count($elements);
 
         if (!$allowDuplicates && $numKeys < $count) {
             throw new \LengthException(sprintf(

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -203,7 +203,8 @@ class Base
         }
 
         $highKey = $numKeys - 1;
-        $keys = $elements = [];
+        $keys = [];
+        $elements = [];
         $numElements = 0;
 
         while ($numElements < $count) {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -205,7 +205,7 @@ class Base
             ));
         }
 
-        $allKeys = array_keys($elements);
+        $keys = array_keys($elements);
         $highKey = $numberOfElements - 1;
         $elementHasBeenSelectedAlready = [];
         $randomElements = [];
@@ -222,7 +222,7 @@ class Base
                 $elementHasBeenSelectedAlready[$index] = true;
             }
 
-            $key = $allKeys[$index];
+            $key = $keys[$index];
 
             $randomElements[] = $elements[$key];
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -179,9 +179,9 @@ class Base
     /**
      * Returns randomly ordered subsequence of $count elements from a provided array
      *
-     * @param array $array           Array to take elements from. Defaults to a-c
-     * @param int   $count           Number of elements to take.
-     * @param bool  $allowDuplicates Allow elements to be picked several times. Defaults to false
+     * @param array|\Traversable $array           Array to take elements from. Defaults to a-c
+     * @param int                $count           Number of elements to take.
+     * @param bool               $allowDuplicates Allow elements to be picked several times. Defaults to false
      *
      * @throws \LengthException When requesting more elements than provided
      *

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -207,7 +207,7 @@ class Base
 
         $allKeys = array_keys($elements);
         $highKey = $numberOfElements - 1;
-        $keys = [];
+        $elementHasBeenSelectedAlready = [];
         $randomElements = [];
         $numberOfRandomElements = 0;
 
@@ -215,11 +215,11 @@ class Base
             $index = mt_rand(0, $highKey);
 
             if (!$allowDuplicates) {
-                if (isset($keys[$index])) {
+                if (isset($elementHasBeenSelectedAlready[$index])) {
                     continue;
                 }
 
-                $keys[$index] = true;
+                $elementHasBeenSelectedAlready[$index] = true;
             }
 
             $key = $allKeys[$index];

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -240,15 +240,17 @@ class Base
      */
     public static function randomElement($array = ['a', 'b', 'c'])
     {
+        $elements = $array;
+
         if ($array instanceof \Traversable) {
-            $array = iterator_to_array($array, false);
+            $elements = iterator_to_array($array, false);
         }
 
-        if ($array === []) {
+        if ($elements === []) {
             return null;
         }
 
-        $randomElements = static::randomElements($array, 1);
+        $randomElements = static::randomElements($elements, 1);
 
         return $randomElements[0];
     }

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -208,7 +208,7 @@ class Base
 
         $highKey = $numKeys - 1;
         $keys = [];
-        $elements = [];
+        $randomElements = [];
         $numElements = 0;
 
         while ($numElements < $count) {
@@ -222,12 +222,12 @@ class Base
                 $keys[$num] = true;
             }
 
-            $elements[] = $arr[$allKeys[$num]];
+            $randomElements[] = $arr[$allKeys[$num]];
 
             ++$numElements;
         }
 
-        return $elements;
+        return $randomElements;
     }
 
     /**


### PR DESCRIPTION
### What is the reason for this PR?

- [x] cleans up `randomElements()` and `randomElement()`

Blocks #620.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
