### PR TITLE
Fix: Reject invalid arguments

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -183,7 +183,8 @@ class Base
      * @param int                $count           Number of elements to take.
      * @param bool               $allowDuplicates Allow elements to be picked several times. Defaults to false
      *
-     * @throws \LengthException When requesting more elements than provided
+     * @throws \InvalidArgumentException
+     * @throws \LengthException          When requesting more elements than provided
      *
      * @return array New array with $count elements from $array
      */
@@ -193,6 +194,14 @@ class Base
 
         if ($array instanceof \Traversable) {
             $elements = \iterator_to_array($array, false);
+        }
+
+        if (!is_array($elements)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+                \Traversable::class,
+                is_object($array) ? get_class($array) : gettype($array),
+            ));
         }
 
         $numberOfElements = count($elements);
@@ -237,6 +246,8 @@ class Base
      * Returns a random element from a passed array
      *
      * @param array|\Traversable $array
+     *
+     * @throws \InvalidArgumentException
      */
     public static function randomElement($array = ['a', 'b', 'c'])
     {
@@ -248,6 +259,14 @@ class Base
 
         if ($elements === []) {
             return null;
+        }
+
+        if (!is_array($elements)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+                \Traversable::class,
+                is_object($array) ? get_class($array) : gettype($array),
+            ));
         }
 
         $randomElements = static::randomElements($elements, 1);

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -548,6 +548,30 @@ final class BaseTest extends TestCase
         BaseProvider::randomElements(['foo'], 2);
     }
 
+    public function testRandomElementsRejectsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+            \Traversable::class,
+            \stdClass::class,
+        ));
+
+        BaseProvider::randomElements(new \stdClass());
+    }
+
+    public function testRandomElementRejectsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Argument for parameter $array needs to be array or an instance of %s, got %s instead.',
+            \Traversable::class,
+            'string',
+        ));
+
+        BaseProvider::randomElement('foo');
+    }
+
     public function testRandomElementsWorksWithoutArgument(): void
     {
         self::assertCount(1, BaseProvider::randomElements(), 'Should work without any input');


### PR DESCRIPTION
### What is the reason for this PR?

This pull request

- [x] rejects invalid arguments passed to `randomElement()` and `randomElements()`

Follows #639.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
