### PR TITLE
update `call_user_func()` callables is deprecated

### DIFF
--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -83,7 +83,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
             ['landline', null],
         ]);
 
-        return call_user_func("static::{$options[0]}", $formatted, $options[1]);
+        return call_user_func((static::class . "::{$options[0]}")(...), $formatted, $options[1]);
     }
 
     /**
@@ -135,7 +135,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
         $method = static::randomElement(['cellphoneNumber', 'landlineNumber']);
 
-        return call_user_func("static::$method", true);
+        return call_user_func((static::class . "::$method")(...), true);
     }
 
     /**
@@ -145,6 +145,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
         $method = static::randomElement(['cellphoneNumber', 'landlineNumber']);
 
-        return call_user_func("static::$method", false);
+        return call_user_func((static::class . "::$method")(...), false);
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
