### PR TITLE
Update `randomElements` to return random number of elements when no count is provided

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -179,8 +179,10 @@ class Base
     /**
      * Returns randomly ordered subsequence of $count elements from a provided array
      *
+     * @todo update default $count to `null` (BC) for next major version
+     *
      * @param array|class-string|\Traversable $array           Array to take elements from. Defaults to a-c
-     * @param int                             $count           Number of elements to take.
+     * @param int|null                        $count           Number of elements to take. If `null` then returns random number of elements
      * @param bool                            $allowDuplicates Allow elements to be picked several times. Defaults to false
      *
      * @throws \InvalidArgumentException
@@ -211,12 +213,16 @@ class Base
 
         $numberOfElements = count($elements);
 
-        if (!$allowDuplicates && $numberOfElements < $count) {
+        if (!$allowDuplicates && null !== $count && $numberOfElements < $count) {
             throw new \LengthException(sprintf(
                 'Cannot get %d elements, only %d in array',
                 $count,
                 $numberOfElements,
             ));
+        }
+
+        if (null === $count) {
+            $count = mt_rand(1, $numberOfElements);
         }
 
         $randomElements = [];

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -580,6 +580,11 @@ final class BaseTest extends TestCase
         self::assertCount(1, BaseProvider::randomElements(), 'Should work without any input');
     }
 
+    public function testRandomElementsReturnsRandomCountWhenNull(): void
+    {
+        self::assertCount(2, BaseProvider::randomElements(['foo', 'bar', 'baz'], null), 'Should return random count when null');
+    }
+
     public function testRandomElementsWorksWithEmptyArray(): void
     {
         $randomElements = BaseProvider::randomElements([], 0);


### PR DESCRIPTION
Hello!

### What is the reason for this PR?

This updates `randomElements` to return a random number of elements when no count is provided. Defaulting to a count of 1 is undesirable because if I only wanted one element I would just use `randomElement`. This cleans up having to pass `fake()->numberBetween(1, count($array))` as the `$count` when I don't care how many values are returned.

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes
- Made `$count` in `Base::randomElement` nullable, and if null, then default to random number of elements.
- Updated documentation

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
