### PR TITLE
Fix: lv_LV postcode format

### DIFF
--- a/src/Faker/Provider/lv_LV/Address.php
+++ b/src/Faker/Provider/lv_LV/Address.php
@@ -12,7 +12,7 @@ class Address extends \Faker\Provider\Address
     ];
 
     protected static $buildingNumber = ['%#'];
-    protected static $postcode = ['LV ####'];
+    protected static $postcode = ['LV-####'];
 
     /**
      * @see https://lv.wikipedia.org/wiki/Suver%C4%93no_valstu_uzskait%C4%ABjums

--- a/test/Faker/Provider/lv_LV/AddressTest.php
+++ b/test/Faker/Provider/lv_LV/AddressTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Faker\Test\Provider\lv_LV;
+
+use Faker\Provider\lv_LV\Address;
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class AddressTest extends TestCase
+{
+    public function testPostcode(): void
+    {
+        $postcode = $this->faker->postcode();
+        self::assertNotEmpty($postcode);
+        self::assertIsString($postcode);
+        self::assertMatchesRegularExpression('/LV-\d{4}/', $postcode);
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Address($this->faker);
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

This fixes lv_LV Address provider postcode format to correct one:

- [ ] A new feature
- [x] Fixed an issue (resolve #652 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

ISO3166-1 alpha-2 country code in front which is `LV`, next symbol must be dash `-` and then 4 digits. e.g. `LV-1000`, instead of `LV 1000`

https://en.wikipedia.org/wiki/Postal_codes_in_Latvia

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
