### PR TITLE
Fix: lv_LV generating invalid personal identity numbers

### DIFF
--- a/src/Faker/Provider/lv_LV/Person.php
+++ b/src/Faker/Provider/lv_LV/Person.php
@@ -163,7 +163,9 @@ class Person extends \Faker\Provider\Person
         $total = 0;
 
         foreach ($partialNumberSplit as $key => $digit) {
-            $total += $idDigitValidator[$key] * (int) $digit;
+            if (isset($idDigitValidator[$key])) {
+                $total += $idDigitValidator[$key] * (int) $digit;
+            }
         }
 
         $checksumDigit = (1101 - $total) % 11 % 10;

--- a/src/Faker/Provider/lv_LV/Person.php
+++ b/src/Faker/Provider/lv_LV/Person.php
@@ -2,7 +2,6 @@
 
 namespace Faker\Provider\lv_LV;
 
-use Faker\Calculator\Luhn;
 use Faker\Provider\DateTime;
 
 class Person extends \Faker\Provider\Person
@@ -145,11 +144,30 @@ class Person extends \Faker\Provider\Person
             $birthdate = DateTime::dateTimeThisCentury();
         }
 
+        $year = $birthdate->format('Y');
+
+        if ($year >= 2000 && $year <= 2099) {
+            $century = 2;
+        } elseif ($year >= 1900 && $year <= 1999) {
+            $century = 1;
+        } else {
+            $century = 0;
+        }
+
         $datePart = $birthdate->format('dmy');
-        $randomDigits = (string) static::numerify('####');
+        $serialNumber = static::numerify('###');
 
-        $checksum = Luhn::computeCheckDigit($datePart . $randomDigits);
+        $partialNumberSplit = str_split($datePart . $century . $serialNumber);
 
-        return $datePart . '-' . $randomDigits . $checksum;
+        $idDigitValidator = [1, 6, 3, 7, 9, 10, 5, 8, 4, 2];
+        $total = 0;
+
+        foreach ($partialNumberSplit as $key => $digit) {
+            $total += $idDigitValidator[$key] * (int) $digit;
+        }
+
+        $checksumDigit = (1101 - $total) % 11 % 10;
+
+        return $datePart . '-' . $century . $serialNumber . $checksumDigit;
     }
 }

--- a/test/Faker/Provider/lv_LV/PersonTest.php
+++ b/test/Faker/Provider/lv_LV/PersonTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Faker\Test\Provider\lv_LV;
+
+use Faker\Provider\lv_LV\Person;
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class PersonTest extends TestCase
+{
+    public function testPersonalIdentityNumber(): void
+    {
+        $idNumber = $this->faker->personalIdentityNumber();
+
+        self::assertMatchesRegularExpression('/^[0-9]{6}-[0-9]{5}$/', $idNumber);
+    }
+
+    public function testChecksumDigitCalculation(): void
+    {
+        $idNumber = $this->faker->personalIdentityNumber(\DateTime::createFromFormat('Y-m-d', '1981-05-24'));
+
+        $serialNumber = substr($idNumber, 8, 3);
+        $serialNumberSplit = str_split($serialNumber);
+
+        // calculate checksum, using static digits from date (2 4 0 5 8 1 1) and inserting random serial number digits
+        $checksumDigit = (1101 - (1 * 2 + 6 * 4 + 3 * 0 + 7 * 5 + 9 * 8 + 10 * 1 + 5 * 1 + 8 * (int) $serialNumberSplit[0] + 4 * (int) $serialNumberSplit[1] + 2 * (int) $serialNumberSplit[2])) % 11 % 10;
+
+        self::assertSame('240581-1' . $serialNumber . $checksumDigit, $idNumber);
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Person($this->faker);
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

Generated latvian personal identity number (_PIN_) part after dash is invalid. By implementing this, developers will have ability to work with randomly generated, valid _PIN_, especially if somewhere in tests they rely on a valid _PIN_.

- [ ] A new feature
- [x] Fixed an issue (No issue linked)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes
https://en.wikipedia.org/wiki/National_identification_number#Latvia

**Shortly:**
- First digit after dash is century the person is born in (19c. = `0`, 20c. = `1`, 21c. = `2`). This was random number.
- Next 3 digits are serial number in given date. Range: `000 - 999`. May stay random.
- Last digit is checksum of all previous digits. This was calculated wrong by using Luhn.

In this PR all theese things are taken into account, making _PIN_ totally valid.

#### About checksum digit formula

Format: `ABCDEF-XGHIZ`
Formula: `(1101-(1*A+6*B+3*C+7*D+9*E+10*F+5*X+8*G+4*H+2*I)) | Mod 11 | Mod 10`

**Example:**
Birth date: `1981-05-24`
Century: `1`
Serial number (random): `579`
_PIN_ without checksum (X) yet: `240581-1579X`

Inserting real numbers into formula:

> (1101 - (1 * <ins>2</ins> + 6 * <ins>4</ins> + 3 * <ins>0</ins> + 7 * <ins>5</ins> + 9 * <ins>8</ins> + 10 * <ins>1</ins> + 5 * <ins>1</ins> + 8 * <ins>5</ins> + 4 * <ins>7</ins> + 2 * <ins>9</ins>)) | Mod 11 | Mod 10 = **9**

Which makes _PIN_ to be: `240581-15799`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
