### PR TITLE
Add `$format` to `image` DocBlock

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -279,7 +279,7 @@ use Faker\Container\ContainerInterface;
  *
  * @property string $image
  *
- * @method string image($dir = null, $width = 640, $height = 480, $category = null, $fullPath = true, $randomize = true, $word = null, $gray = false)
+ * @method string image($dir = null, $width = 640, $height = 480, $category = null, $fullPath = true, $randomize = true, $word = null, $gray = false, string $format = 'png')
  *
  * @property string $email
  *


### PR DESCRIPTION
### What is the reason for this PR?

- [x] fixes a DocBlock

Similar to #630, the `image` DocBlock is missing the `$format` parameter:

https://github.com/FakerPHP/Faker/blob/5c1e5005cc0b11143e535ed50c965e58a46225b8/src/Faker/Provider/Image.php#L108-L118

https://github.com/FakerPHP/Faker/blob/5c1e5005cc0b11143e535ed50c965e58a46225b8/src/Faker/Generator.php#L282

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Adds `$format` to `image` DocBlock

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
