### PR TITLE
Fix psalm baseline in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,6 @@
 /phpstan-baseline.neon    export-ignore
 /phpstan.neon.dist        export-ignore
 /phpunit.xml.dist         export-ignore
-/psalm-baseline.xml       export-ignore
+/psalm.baseline.xml       export-ignore
 /psalm.xml                export-ignore
 /roave-bc-check.yaml      export-ignore


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Hi @localheinz, I found a typo in the gitattribute file ; the psalm baseline is named psalm.baseline.xml in this lib

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
