### PR TITLE
Remove invalid postcode pattern for France

### DIFF
--- a/src/Faker/Provider/fr_FR/Address.php
+++ b/src/Faker/Provider/fr_FR/Address.php
@@ -34,7 +34,11 @@ class Address extends \Faker\Provider\Address
     ];
 
     protected static $buildingNumber = ['%', '%#', '%#', '%#', '%##'];
-    protected static $postcode = ['#####', '## ###'];
+
+    /**
+     * @see https://en.wikipedia.org/wiki/Postal_codes_in_France
+     */
+    protected static $postcode = ['#####'];
 
     protected static $country = [
         'Afghanistan', 'Afrique du sud', 'Albanie', 'Algérie', 'Allemagne', 'Andorre', 'Angola', 'Anguilla', 'Antarctique', 'Antigua et Barbuda', 'Antilles néerlandaises', 'Arabie saoudite', 'Argentine', 'Arménie', 'Aruba', 'Australie', 'Autriche', 'Azerbaïdjan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Belgique', 'Belize', 'Benin', 'Bermudes (Les)', 'Bhoutan', 'Biélorussie', 'Bolivie', 'Bosnie-Herzégovine', 'Botswana', 'Bouvet (Îles)', 'Brunei', 'Brésil', 'Bulgarie', 'Burkina Faso', 'Burundi', 'Cambodge', 'Cameroun', 'Canada', 'Cap Vert', 'Cayman (Îles)', 'Chili', 'Chine (Rép. pop.)', 'Christmas (Île)', 'Chypre', 'Cocos (Îles)', 'Colombie', 'Comores', 'Cook (Îles)', 'Corée du Nord', 'Corée, Sud', 'Costa Rica', 'Croatie', 'Cuba', 'Côte d\'Ivoire', 'Danemark', 'Djibouti', 'Dominique', 'Égypte', 'El Salvador', 'Émirats arabes unis', 'Équateur', 'Érythrée', 'Espagne', 'Estonie', 'États-Unis', 'Ethiopie', 'Falkland (Île)', 'Fidji (République des)', 'Finlande', 'France', 'Féroé (Îles)', 'Gabon',

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -10,6 +10,14 @@ use Faker\Test\TestCase;
  */
 final class AddressTest extends TestCase
 {
+    public function testPostcode(): void
+    {
+        $postcode = $this->faker->postcode();
+        self::assertNotEmpty($postcode);
+        self::assertIsString($postcode);
+        self::assertMatchesRegularExpression('@^\d{5}$@', $postcode);
+    }
+
     public function testSecondaryAddress(): void
     {
         self::assertEquals('Étage 007', $this->faker->secondaryAddress());


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Remove invalid post code pattern for France. All post code in France are composed of 5 digits without any space.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
