### PR TITLE
chore: ensure php 8.3 compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
     runs-on: "ubuntu-latest"
 


### PR DESCRIPTION
i do not expect to be merged before the offical release of php 8.3.
But it would be grat to know if ci is green for php 8.3