### PR TITLE
Fix: Allow tests to fail on PHP 8.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,16 +11,20 @@ name: "Tests"
 
 jobs:
   phpunit:
-    name: "PHPUnit"
+    name: "PHPUnit (${{ matrix.php-version }})"
 
     strategy:
       matrix:
+        experimental:
+          - false
         php-version:
           - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"
-          - "8.3"
+        include:
+          - experimental: true
+            php-version: "8.3"
 
     runs-on: "ubuntu-latest"
 
@@ -53,3 +57,4 @@ jobs:
 
       - name: "Run tests"
         run: "./vendor/bin/phpunit --colors=always"
+        continue-on-error: "${{ matrix.experimental }}"


### PR DESCRIPTION
### What is the reason for this PR?

- [x] allows tests to fail on PHP 8.3

Follows #684.
Related to #694.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

In all likelihood, [PHP 8.3 will be released on November 23, 2023](https://wiki.php.net/todo/php83) - we still have enough time to fix issues until and after then.

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
