### PR TITLE
Fix: Operator

### DIFF
--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -185,7 +185,7 @@ final class ImageTest extends TestCase
         $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
         curl_close($curlPing);
 
-        if ($httpCode < 200 | $httpCode > 300) {
+        if ($httpCode < 200 || $httpCode > 300) {
             self::markTestSkipped(sprintf('"%s" is offline, skipping test', $url));
         }
     }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] uses the `||` instead of the `|` operator in a condition in a test

Follows #473.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes


### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
