### PR TITLE
Fix: Enable and configure `type_declaration_spaces` instead of deprecated `function_typehint_space` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -74,7 +74,6 @@ return $config
         'curly_braces_position' => true,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,
-        'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => [
             'annotations' => [
                 'author',
@@ -222,6 +221,11 @@ return $config
             ],
         ],
         'trim_array_spaces' => true,
+        'type_declaration_spaces' => [
+            'elements' => [
+                'function',
+            ],
+        ],
         'unary_operator_spaces' => true,
         'visibility_required' => [
             'elements' => [


### PR DESCRIPTION
### What is the reason for this PR?

- [x] enables and configures the `type_declaration_spaces` instead of the deprecated `function_typehint_space` fixer

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

Running

```sh
vendor/bin/php-cs-fixer fix --diff --verbose
```

on current `main` yields

```
PHP CS Fixer 3.25.0 Crank Cake by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 7.4.33
Loaded config faker from "/Users/am/Sites/FakerPHP/Faker/.php-cs-fixer.dist.php".
Using cache file ".build/php-cs-fixer/cache".
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 266 / 690 ( 39%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 532 / 690 ( 77%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS                                                                                                             690 / 690 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error

Fixed 0 of 690 files in 0.043 seconds, 16.000 MB memory used

Detected deprecations in use:
- Rule "function_typehint_space" is deprecated. Use "type_declaration_spaces" instead.
```

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
