### PR TITLE
Fix: Require to pass name to `ContainerBuilder::add()`

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -16,3 +16,5 @@ parameters:
     - '#\[BC\] REMOVED: Class Faker\\Extension\\Container has been deleted#'
     - '#\[BC\] CHANGED: The parameter \$container of Faker\\Generator\#\_\_construct\(\) changed from Psr\\Container\\ContainerInterface\|null to a non-contravariant Faker\\Container\\ContainerInterface\|null#'
     - '#\[BC\] CHANGED: The parameter \$container of Faker\\Generator\#\_\_construct\(\) changed from Psr\\Container\\ContainerInterface\|null to Faker\\Container\\ContainerInterface\|null#'
+    - '#\[BC\] CHANGED: The number of required arguments for Faker\\Container\\ContainerBuilder\#add\(\) increased from 1 to 2#'
+    - '#\[BC\] CHANGED: The parameter \$name of Faker\\Container\\ContainerBuilder\#add\(\) changed from string\|null to a non-contravariant string#'

--- a/src/Faker/Container/ContainerBuilder.php
+++ b/src/Faker/Container/ContainerBuilder.php
@@ -29,26 +29,13 @@ final class ContainerBuilder
      *
      * @throws \InvalidArgumentException
      */
-    public function add($value, string $name = null): self
+    public function add($value, string $name): self
     {
         if (!is_string($value) && !is_callable($value) && !is_object($value)) {
             throw new \InvalidArgumentException(sprintf(
                 'First argument to "%s::add()" must be a string, callable or object.',
                 self::class,
             ));
-        }
-
-        if ($name === null) {
-            if (is_string($value)) {
-                $name = $value;
-            } elseif (is_object($value)) {
-                $name = get_class($value);
-            } else {
-                throw new \InvalidArgumentException(sprintf(
-                    'Second argument to "%s::add()" is required not passing a string or object as first argument',
-                    self::class,
-                ));
-            }
         }
 
         $this->definitions[$name] = $value;

--- a/test/Faker/Extension/ContainerBuilderTest.php
+++ b/test/Faker/Extension/ContainerBuilderTest.php
@@ -7,7 +7,6 @@ namespace Faker\Test\Extension;
 use Faker\Container\ContainerBuilder;
 use Faker\Container\ContainerInterface;
 use Faker\Core\File;
-use Faker\Extension\Extension;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,7 +29,7 @@ final class ContainerBuilderTest extends TestCase
             ContainerBuilder::class,
         ));
 
-        $containerBuilder->add($value);
+        $containerBuilder->add($value, 'foo');
     }
 
     /**
@@ -59,46 +58,6 @@ final class ContainerBuilderTest extends TestCase
         }
     }
 
-    public function testAddRejectsNameWhenValueIsCallableAndNameIsNull(): void
-    {
-        $value = [
-            new class() {
-                public static function create(): Extension
-                {
-                    return new class() implements Extension {
-                    };
-                }
-            },
-            'create',
-        ];
-
-        $containerBuilder = new ContainerBuilder();
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf(
-            'Second argument to "%s::add()" is required not passing a string or object as first argument',
-            ContainerBuilder::class,
-        ));
-
-        $containerBuilder->add($value);
-    }
-
-    public function testAddAcceptsValueWhenItIsAnObjectAndNameIsNull(): void
-    {
-        $value = new class() implements Extension {};
-
-        $name = get_class($value);
-
-        $containerBuilder = new ContainerBuilder();
-
-        $containerBuilder->add($value);
-
-        $container = $containerBuilder->build();
-
-        self::assertTrue($container->has($name));
-        self::assertSame($value, $container->get($name));
-    }
-
     public function testBuildEmpty(): void
     {
         $builder = new ContainerBuilder();
@@ -112,7 +71,7 @@ final class ContainerBuilderTest extends TestCase
     {
         $builder = new ContainerBuilder();
 
-        $builder->add(File::class);
+        $builder->add(File::class, 'foo');
 
         $container = $builder->build();
 
@@ -123,8 +82,8 @@ final class ContainerBuilderTest extends TestCase
     {
         $builder = new ContainerBuilder();
 
-        $builder->add(File::class);
-        $builder->add(File::class);
+        $builder->add(File::class, 'foo');
+        $builder->add(File::class, 'foo');
 
         $container = $builder->build();
 

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -145,7 +145,7 @@ final class GeneratorTest extends TestCase
     public function testFormatterCallsExtension(): void
     {
         $builder = new ContainerBuilder();
-        $builder->add(Blood::class);
+        $builder->add(Blood::class, Blood::class);
         $faker = new Generator($builder->build());
 
         $output = $faker->format('Faker\Core\Blood->bloodType');


### PR DESCRIPTION
### What is the reason for this PR?

- [x] requires to pass the name of a service to `ContainerBuilder::add()`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
