### PR TITLE
Fix: Switch order of parameters

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -18,3 +18,4 @@ parameters:
     - '#\[BC\] CHANGED: The parameter \$container of Faker\\Generator\#\_\_construct\(\) changed from Psr\\Container\\ContainerInterface\|null to Faker\\Container\\ContainerInterface\|null#'
     - '#\[BC\] CHANGED: The number of required arguments for Faker\\Container\\ContainerBuilder\#add\(\) increased from 1 to 2#'
     - '#\[BC\] CHANGED: The parameter \$name of Faker\\Container\\ContainerBuilder\#add\(\) changed from string\|null to a non-contravariant string#'
+    - '#\[BC\] CHANGED: The parameter \$value of Faker\\Container\\ContainerBuilder\#add\(\) changed from no type to a non-contravariant string#'

--- a/src/Faker/Container/ContainerBuilder.php
+++ b/src/Faker/Container/ContainerBuilder.php
@@ -29,7 +29,7 @@ final class ContainerBuilder
      *
      * @throws \InvalidArgumentException
      */
-    public function add($value, string $name): self
+    public function add(string $name, $value): self
     {
         if (!is_string($value) && !is_callable($value) && !is_object($value)) {
             throw new \InvalidArgumentException(sprintf(
@@ -71,7 +71,7 @@ final class ContainerBuilder
         $instance = new self();
 
         foreach (self::defaultExtensions() as $id => $definition) {
-            $instance->add($definition, $id);
+            $instance->add($id, $definition);
         }
 
         return $instance->build();

--- a/test/Faker/Extension/ContainerBuilderTest.php
+++ b/test/Faker/Extension/ContainerBuilderTest.php
@@ -29,7 +29,7 @@ final class ContainerBuilderTest extends TestCase
             ContainerBuilder::class,
         ));
 
-        $containerBuilder->add($value, 'foo');
+        $containerBuilder->add('foo', $value);
     }
 
     /**
@@ -71,7 +71,7 @@ final class ContainerBuilderTest extends TestCase
     {
         $builder = new ContainerBuilder();
 
-        $builder->add(File::class, 'foo');
+        $builder->add('foo', File::class);
 
         $container = $builder->build();
 
@@ -82,8 +82,8 @@ final class ContainerBuilderTest extends TestCase
     {
         $builder = new ContainerBuilder();
 
-        $builder->add(File::class, 'foo');
-        $builder->add(File::class, 'foo');
+        $builder->add('foo', File::class);
+        $builder->add('foo', File::class);
 
         $container = $builder->build();
 
@@ -94,7 +94,7 @@ final class ContainerBuilderTest extends TestCase
     {
         $builder = new ContainerBuilder();
 
-        $builder->add(new File(), 'foo');
+        $builder->add('foo', new File());
 
         $container = $builder->build();
 
@@ -105,9 +105,9 @@ final class ContainerBuilderTest extends TestCase
     {
         $builder = new ContainerBuilder();
 
-        $builder->add(static function () {
+        $builder->add('foo', static function () {
             return new File();
-        }, 'foo');
+        });
 
         $container = $builder->build();
 

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -135,7 +135,7 @@ final class GeneratorTest extends TestCase
     public function testFormatterCallsGenerator(): void
     {
         $builder = new ContainerBuilder();
-        $builder->add(Blood::class, BloodExtension::class);
+        $builder->add(BloodExtension::class, Blood::class);
         $faker = new Generator($builder->build());
 
         $output = $faker->format('bloodType');


### PR DESCRIPTION
### What is the reason for this PR?

- [x] switches the order of parameters passed to `ContainerBuilder::add()`

Follows #702.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
