### PR TITLE
Fix: Do not memoize invalid service

### DIFF
--- a/src/Faker/Container/Container.php
+++ b/src/Faker/Container/Container.php
@@ -63,7 +63,7 @@ final class Container implements ContainerInterface
 
         $definition = $this->definitions[$id];
 
-        $service = $this->services[$id] = $this->getService($id, $definition);
+        $service = $this->getService($id, $definition);
 
         if (!$service instanceof Extension) {
             throw new \RuntimeException(sprintf(
@@ -72,6 +72,8 @@ final class Container implements ContainerInterface
                 Extension::class,
             ));
         }
+
+        $this->services[$id] = $service;
 
         return $service;
     }

--- a/test/Faker/Extension/ContainerTest.php
+++ b/test/Faker/Extension/ContainerTest.php
@@ -65,6 +65,33 @@ final class ContainerTest extends TestCase
     }
 
     /**
+     * @dataProvider provideDefinitionThatDoesNotResolveToExtension
+     */
+    public function testGetThrowsRuntimeExceptionWhenServiceResolvedForIdentifierIsNotAnExtensionOnSecondTry($definition): void
+    {
+        $id = 'file';
+
+        $container = new Container([
+            $id => $definition,
+        ]);
+
+        try {
+            $container->get($id);
+        } catch (\RuntimeException $e) {
+            // do nothing
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Service resolved for identifier "%s" does not implement the %s" interface.',
+            $id,
+            Extension::class,
+        ));
+
+        $container->get($id);
+    }
+
+    /**
      * @return \Generator<string, array{0: callable|object|string}>
      */
     public function provideDefinitionThatDoesNotResolveToExtension(): \Generator


### PR DESCRIPTION
### What is the reason for this PR?

- [x] asserts that `Container::get($id)` throws a `RuntimeException` on the second attempt of retrieving a service that does not resolve to an `Extension`
- [x] stops memoizing the resolved service before inspecting whether it has resolved to an `Extension`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
