### PR TITLE
Enhancement: Reuse `NumberExtension`

### DIFF
--- a/src/Faker/Core/Barcode.php
+++ b/src/Faker/Core/Barcode.php
@@ -12,6 +12,13 @@ use Faker\Extension;
  */
 final class Barcode implements Extension\BarcodeExtension
 {
+    private Extension\NumberExtension $numberExtension;
+
+    public function __construct(Extension\NumberExtension $numberExtension = null)
+    {
+        $this->numberExtension = $numberExtension ?: new Number();
+    }
+
     private function ean(int $length = 13): string
     {
         $code = Extension\Helper::numerify(str_repeat('#', $length - 1));
@@ -38,7 +45,7 @@ final class Barcode implements Extension\BarcodeExtension
 
     public function isbn13(): string
     {
-        $code = '97' . mt_rand(8, 9) . Extension\Helper::numerify(str_repeat('#', 9));
+        $code = '97' . $this->numberExtension->numberBetween(8, 9) . Extension\Helper::numerify(str_repeat('#', 9));
 
         return sprintf('%s%s', $code, Calculator\Ean::checksum($code));
     }

--- a/src/Faker/Core/Color.php
+++ b/src/Faker/Core/Color.php
@@ -12,6 +12,8 @@ use Faker\Extension\Helper;
  */
 final class Color implements Extension\ColorExtension
 {
+    private Extension\NumberExtension $numberExtension;
+
     /**
      * @var string[]
      */
@@ -20,7 +22,6 @@ final class Color implements Extension\ColorExtension
         'purple', 'teal', 'lime', 'blue', 'silver',
         'gray', 'yellow', 'fuchsia', 'aqua', 'white',
     ];
-
     /**
      * @var string[]
      */
@@ -53,14 +54,17 @@ final class Color implements Extension\ColorExtension
         'Turquoise', 'Violet', 'Wheat', 'White', 'WhiteSmoke', 'Yellow', 'YellowGreen',
     ];
 
+    public function __construct(Extension\NumberExtension $numberExtension = null)
+    {
+        $this->numberExtension = $numberExtension ?: new Number();
+    }
+
     /**
      * @example '#fa3cc2'
      */
     public function hexColor(): string
     {
-        $number = new Number();
-
-        return '#' . str_pad(dechex($number->numberBetween(1, 16777215)), 6, '0', STR_PAD_LEFT);
+        return '#' . str_pad(dechex($this->numberExtension->numberBetween(1, 16777215)), 6, '0', STR_PAD_LEFT);
     }
 
     /**
@@ -68,8 +72,7 @@ final class Color implements Extension\ColorExtension
      */
     public function safeHexColor(): string
     {
-        $number = new Number();
-        $color = str_pad(dechex($number->numberBetween(0, 255)), 3, '0', STR_PAD_LEFT);
+        $color = str_pad(dechex($this->numberExtension->numberBetween(0, 255)), 3, '0', STR_PAD_LEFT);
 
         return sprintf(
             '#%s%s%s%s%s%s',
@@ -122,12 +125,10 @@ final class Color implements Extension\ColorExtension
      */
     public function rgbaCssColor(): string
     {
-        $number = new Number();
-
         return sprintf(
             'rgba(%s,%s)',
             $this->rgbColor(),
-            $number->randomFloat(1, 0, 1),
+            $this->numberExtension->randomFloat(1, 0, 1),
         );
     }
 
@@ -152,13 +153,11 @@ final class Color implements Extension\ColorExtension
      */
     public function hslColor(): string
     {
-        $number = new Number();
-
         return sprintf(
             '%s,%s,%s',
-            $number->numberBetween(0, 360),
-            $number->numberBetween(0, 100),
-            $number->numberBetween(0, 100),
+            $this->numberExtension->numberBetween(0, 360),
+            $this->numberExtension->numberBetween(0, 100),
+            $this->numberExtension->numberBetween(0, 100),
         );
     }
 
@@ -169,12 +168,10 @@ final class Color implements Extension\ColorExtension
      */
     public function hslColorAsArray(): array
     {
-        $number = new Number();
-
         return [
-            $number->numberBetween(0, 360),
-            $number->numberBetween(0, 100),
-            $number->numberBetween(0, 100),
+            $this->numberExtension->numberBetween(0, 360),
+            $this->numberExtension->numberBetween(0, 100),
+            $this->numberExtension->numberBetween(0, 100),
         ];
     }
 }

--- a/src/Faker/Core/Coordinates.php
+++ b/src/Faker/Core/Coordinates.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Faker\Core;
 
-use Faker\Extension\Extension;
+use Faker\Extension;
 
-class Coordinates implements Extension
+class Coordinates implements Extension\Extension
 {
+    private Extension\NumberExtension $numberExtension;
+
+    public function __construct(Extension\NumberExtension $numberExtension = null)
+    {
+        $this->numberExtension = $numberExtension ?: new Number();
+    }
+
     /**
      * @example '77.147489'
      *
@@ -63,6 +70,6 @@ class Coordinates implements Extension
             throw new \LogicException('Invalid coordinates boundaries');
         }
 
-        return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
+        return $this->numberExtension->randomFloat($nbMaxDecimals, $min, $max);
     }
 }

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -21,7 +21,7 @@ final class Number implements Extension\NumberExtension
 
     public function randomDigit(): int
     {
-        return mt_rand(0, 9);
+        return $this->numberBetween(0, 9);
     }
 
     public function randomDigitNot(int $except): int
@@ -37,7 +37,7 @@ final class Number implements Extension\NumberExtension
 
     public function randomDigitNotZero(): int
     {
-        return mt_rand(1, 9);
+        return $this->numberBetween(1, 9);
     }
 
     public function randomFloat(?int $nbMaxDecimals = null, float $min = 0, ?float $max = null): float
@@ -60,7 +60,7 @@ final class Number implements Extension\NumberExtension
             $max = $tmp;
         }
 
-        return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
+        return round($min + $this->numberBetween() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
     }
 
     public function randomNumber(int $nbDigits = null, bool $strict = false): int
@@ -75,9 +75,9 @@ final class Number implements Extension\NumberExtension
         }
 
         if ($strict) {
-            return mt_rand(10 ** ($nbDigits - 1), $max);
+            return $this->numberBetween(10 ** ($nbDigits - 1), $max);
         }
 
-        return mt_rand(0, $max);
+        return $this->numberBetween(0, $max);
     }
 }

--- a/src/Faker/Core/Uuid.php
+++ b/src/Faker/Core/Uuid.php
@@ -2,17 +2,23 @@
 
 namespace Faker\Core;
 
-use Faker\Extension\UuidExtension;
+use Faker\Extension;
 
-final class Uuid implements UuidExtension
+final class Uuid implements Extension\UuidExtension
 {
+    private Extension\NumberExtension $numberExtension;
+
+    public function __construct(Extension\NumberExtension $numberExtension = null)
+    {
+
+        $this->numberExtension = $numberExtension ?: new Number();
+    }
+
     public function uuid3(): string
     {
-        $number = new Number();
-
         // fix for compatibility with 32bit architecture; each mt_rand call is restricted to 32bit
         // two such calls will cause 64bits of randomness regardless of architecture
-        $seed = $number->numberBetween(0, 2147483647) . '#' . $number->numberBetween(0, 2147483647);
+        $seed = $this->numberExtension->numberBetween(0, 2147483647) . '#' . $this->numberExtension->numberBetween(0, 2147483647);
 
         // Hash the seed and convert to a byte array
         $val = md5($seed, true);

--- a/src/Faker/Core/Version.php
+++ b/src/Faker/Core/Version.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace Faker\Core;
 
-use Faker\Extension\Helper;
-use Faker\Extension\VersionExtension;
+use Faker\Extension;
 use Faker\Provider\DateTime;
 
-final class Version implements VersionExtension
+final class Version implements Extension\VersionExtension
 {
+    private Extension\NumberExtension $numberExtension;
     /**
      * @var string[]
      */
     private $semverCommonPreReleaseIdentifiers = ['alpha', 'beta', 'rc'];
+
+    public function __construct(Extension\NumberExtension $numberExtension = null)
+    {
+
+        $this->numberExtension = $numberExtension ?: new  Number();
+    }
 
     /**
      * Represents v2.0.0 of the semantic versioning: https://semver.org/spec/v2.0.0.html
@@ -22,11 +28,11 @@ final class Version implements VersionExtension
     {
         return sprintf(
             '%d.%d.%d%s%s',
-            mt_rand(0, 9),
-            mt_rand(0, 99),
-            mt_rand(0, 99),
-            $preRelease && mt_rand(0, 1) === 1 ? '-' . $this->semverPreReleaseIdentifier() : '',
-            $build && mt_rand(0, 1) === 1 ? '+' . $this->semverBuildIdentifier() : '',
+            $this->numberExtension->numberBetween(0, 9),
+            $this->numberExtension->numberBetween(0, 99),
+            $this->numberExtension->numberBetween(0, 99),
+            $preRelease && $this->numberExtension->numberBetween(0, 1) === 1 ? '-' . $this->semverPreReleaseIdentifier() : '',
+            $build && $this->numberExtension->numberBetween(0, 1) === 1 ? '+' . $this->semverBuildIdentifier() : '',
         );
     }
 
@@ -35,13 +41,13 @@ final class Version implements VersionExtension
      */
     private function semverPreReleaseIdentifier(): string
     {
-        $ident = Helper::randomElement($this->semverCommonPreReleaseIdentifiers);
+        $ident = Extension\Helper::randomElement($this->semverCommonPreReleaseIdentifiers);
 
-        if (mt_rand(0, 1) !== 1) {
+        if ($this->numberExtension->numberBetween(0, 1) !== 1) {
             return $ident;
         }
 
-        return $ident . '.' . mt_rand(1, 99);
+        return $ident . '.' . $this->numberExtension->numberBetween(1, 99);
     }
 
     /**
@@ -49,9 +55,9 @@ final class Version implements VersionExtension
      */
     private function semverBuildIdentifier(): string
     {
-        if (mt_rand(0, 1) === 1) {
+        if ($this->numberExtension->numberBetween(0, 1) === 1) {
             // short git revision syntax: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
-            return substr(sha1(Helper::lexify('??????')), 0, 7);
+            return substr(sha1(Extension\Helper::lexify('??????')), 0, 7);
         }
 
         // date syntax


### PR DESCRIPTION
### What is the reason for this PR?

- [x] adjusts existing `Extension`s to reuse the `NumberExtension`

Somewhat related to #694.

💁‍♂️ If we want to provide a path towards using [`Random\Randomizer`](https://www.php.net/manual/en/class.random-randomizer.php) in the distant future, I believe it would be best to centralize the source of randomness.

This could be one step.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [ ] All checks have passed
- [ ] Changes are approved by maintainer
