### PR TITLE
Fix: Mark classes as experimental

### DIFF
--- a/src/Faker/Core/Coordinates.php
+++ b/src/Faker/Core/Coordinates.php
@@ -6,6 +6,9 @@ namespace Faker\Core;
 
 use Faker\Extension;
 
+/**
+ * @experimental This class is experimental and does not fall under our BC promise
+ */
 class Coordinates implements Extension\Extension
 {
     private Extension\NumberExtension $numberExtension;

--- a/src/Faker/Core/Uuid.php
+++ b/src/Faker/Core/Uuid.php
@@ -4,6 +4,9 @@ namespace Faker\Core;
 
 use Faker\Extension;
 
+/**
+ * @experimental This class is experimental and does not fall under our BC promise
+ */
 final class Uuid implements Extension\UuidExtension
 {
     private Extension\NumberExtension $numberExtension;

--- a/src/Faker/Core/Version.php
+++ b/src/Faker/Core/Version.php
@@ -7,6 +7,9 @@ namespace Faker\Core;
 use Faker\Extension;
 use Faker\Provider\DateTime;
 
+/**
+ * @experimental This class is experimental and does not fall under our BC promise
+ */
 final class Version implements Extension\VersionExtension
 {
     private Extension\NumberExtension $numberExtension;


### PR DESCRIPTION
### What is the reason for this PR?

- [x] marks implementations of the experimental `Extension` interface as experimental

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
