### PR TITLE
Fix: Mark class as `final`

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -1,5 +1,6 @@
 parameters:
   ignoreErrors:
+    - '#\[BC\] CHANGED: Class Faker\\Core\\Coordinates became final#'
     - '#\[BC\] CHANGED: Property Faker\\Factory::\$defaultProviders changed default value#'
     - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-z_A-Z]+\\[a-zA-Z]+::\$[1-9a-zA-Z]+ changed default value#'
     - '#\[BC\] CHANGED: Property Faker\\Provider\\[a-zA-Z]+::\$[1-9a-zA-Z]+ changed default value#'

--- a/src/Faker/Core/Coordinates.php
+++ b/src/Faker/Core/Coordinates.php
@@ -9,7 +9,7 @@ use Faker\Extension;
 /**
  * @experimental This class is experimental and does not fall under our BC promise
  */
-class Coordinates implements Extension\Extension
+final class Coordinates implements Extension\Extension
 {
     private Extension\NumberExtension $numberExtension;
 


### PR DESCRIPTION
### What is the reason for this PR?

- [x] marks a class that should be experimental as `final`

Follows #716.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
