### PR TITLE
Enhancement: Enable `self_static_accessor` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -187,6 +187,7 @@ return $config
         'random_api_migration' => true,
         'return_assignment' => true,
         'return_type_declaration' => true,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'short_scalar_cast' => true,
         'single_line_comment_style' => true,

--- a/src/Faker/Extension/Helper.php
+++ b/src/Faker/Extension/Helper.php
@@ -86,7 +86,7 @@ final class Helper
             return mt_rand(0, 1) === 1 ? '#' : '?';
         });
 
-        return static::lexify(static::numerify($string));
+        return self::lexify(self::numerify($string));
     }
 
     private static function replaceWildcard(string $string, string $wildcard, callable $callback): string

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -35,10 +35,10 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->city);
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->postcode);
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->address);
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->country);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->city);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->postcode);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->address);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->country);
     }
 
     /**
@@ -50,7 +50,7 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->company);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->company);
     }
 
     /**
@@ -62,8 +62,8 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->century);
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->timezone);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->century);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->timezone);
     }
 
     /**
@@ -75,12 +75,12 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->userName);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->userName);
 
-        self::assertMatchesRegularExpression(static::TEST_EMAIL_REGEX, $faker->email);
-        self::assertMatchesRegularExpression(static::TEST_EMAIL_REGEX, $faker->safeEmail);
-        self::assertMatchesRegularExpression(static::TEST_EMAIL_REGEX, $faker->freeEmail);
-        self::assertMatchesRegularExpression(static::TEST_EMAIL_REGEX, $faker->companyEmail);
+        self::assertMatchesRegularExpression(self::TEST_EMAIL_REGEX, $faker->email);
+        self::assertMatchesRegularExpression(self::TEST_EMAIL_REGEX, $faker->safeEmail);
+        self::assertMatchesRegularExpression(self::TEST_EMAIL_REGEX, $faker->freeEmail);
+        self::assertMatchesRegularExpression(self::TEST_EMAIL_REGEX, $faker->companyEmail);
     }
 
     /**
@@ -92,10 +92,10 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->name);
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->title);
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->firstName);
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->lastName);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->name);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->title);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->firstName);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->lastName);
     }
 
     /**
@@ -107,7 +107,7 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->phoneNumber);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->phoneNumber);
     }
 
     /**
@@ -119,7 +119,7 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->userAgent);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->userAgent);
     }
 
     /**
@@ -132,6 +132,6 @@ final class ProviderOverrideTest extends TestCase
     {
         $faker = Faker\Factory::create($locale);
 
-        self::assertMatchesRegularExpression(static::TEST_STRING_REGEX, $faker->uuid);
+        self::assertMatchesRegularExpression(self::TEST_STRING_REGEX, $faker->uuid);
     }
 }

--- a/test/Faker/Provider/id_ID/PersonTest.php
+++ b/test/Faker/Provider/id_ID/PersonTest.php
@@ -77,7 +77,7 @@ final class PersonTest extends TestCase
     {
         $nik = $this->faker->nik();
 
-        self::assertContains(substr($nik, 0, 4), static::$birthPlaceCode);
+        self::assertContains(substr($nik, 0, 4), self::$birthPlaceCode);
     }
 
     protected function getProviders(): iterable

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -206,7 +206,7 @@ final class PersonTest extends TestCase
 
     protected function isValidCnp($cnp)
     {
-        if (preg_match(static::TEST_CNP_REGEX, $cnp) !== false) {
+        if (preg_match(self::TEST_CNP_REGEX, $cnp) !== false) {
             $checkNumber = 279146358279;
 
             $checksum = 0;


### PR DESCRIPTION
### What is the reason for this PR?

- [x] enables the `self_static_accessor` fixer
- [x] runs `make cs`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.25.1/doc/rules/class_notation/self_static_accessor.rst.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
