### PR TITLE
Fix: Avoid useless tests for `ContainerBuilder`

### DIFF
--- a/test/Faker/Extension/ContainerBuilderTest.php
+++ b/test/Faker/Extension/ContainerBuilderTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Faker\Test\Extension;
 
 use Faker\Container\ContainerBuilder;
-use Faker\Container\ContainerInterface;
 use Faker\Core\File;
+use Faker\Core\Number;
+use Faker\Extension;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -58,66 +59,89 @@ final class ContainerBuilderTest extends TestCase
         }
     }
 
-    public function testBuildEmpty(): void
+    public function testBuildReturnsContainerWhenContainerBuilderDoesNotHaveDefinitions(): void
     {
         $builder = new ContainerBuilder();
 
         $container = $builder->build();
 
-        self::assertInstanceOf(ContainerInterface::class, $container);
+        self::assertFalse($container->has('foo'));
     }
 
-    public function testBuild(): void
+    public function testBuildReturnsContainerWhenContainerBuilderHasDefinitions(): void
     {
+        $id = 'foo';
+        $definition = File::class;
+
         $builder = new ContainerBuilder();
 
-        $builder->add('foo', File::class);
+        $builder->add($id, $definition);
 
         $container = $builder->build();
 
-        self::assertInstanceOf(ContainerInterface::class, $container);
+        self::assertTrue($container->has($id));
+        self::assertInstanceOf($definition, $container->get($id));
     }
 
-    public function testBuildWithDuplicates(): void
+    public function testBuildReturnsContainerWhenContainerBuilderHasOverriddenDefinitions(): void
     {
+        $id = 'foo';
+        $definition = Number::class;
+
         $builder = new ContainerBuilder();
 
-        $builder->add('foo', File::class);
-        $builder->add('foo', File::class);
+        $builder->add($id, File::class);
+        $builder->add($id, $definition);
 
         $container = $builder->build();
 
-        self::assertInstanceOf(ContainerInterface::class, $container);
+        self::assertTrue($container->has($id));
+        self::assertInstanceOf($definition, $container->get($id));
     }
 
-    public function testBuildWithObject(): void
+    public function testBuildReturnsContainerWhenContainerBuilderHasObjectAsDefinition(): void
     {
+        $id = 'foo';
+        $definition = new File();
+
         $builder = new ContainerBuilder();
 
-        $builder->add('foo', new File());
+        $builder->add($id, $definition);
 
         $container = $builder->build();
 
-        self::assertInstanceOf(ContainerInterface::class, $container);
+        self::assertTrue($container->has($id));
+        self::assertSame($definition, $container->get($id));
     }
 
-    public function testBuildWithCallable(): void
+    public function testBuildReturnsContainerWhenContainerBuilderHasCallableAsDefinition(): void
     {
-        $builder = new ContainerBuilder();
-
-        $builder->add('foo', static function () {
+        $id = 'foo';
+        $definition = static function (): File {
             return new File();
-        });
+        };
+
+        $builder = new ContainerBuilder();
+
+        $builder->add($id, $definition);
 
         $container = $builder->build();
 
-        self::assertInstanceOf(ContainerInterface::class, $container);
+        self::assertTrue($container->has($id));
+        self::assertEquals($definition(), $container->get($id));
     }
 
-    public function testBuildDefault(): void
+    public function testGetDefaultReturnsContainerWithDefaultExtensions(): void
     {
         $container = ContainerBuilder::getDefault();
 
-        self::assertInstanceOf(ContainerInterface::class, $container);
+        self::assertTrue($container->has(Extension\BarcodeExtension::class));
+        self::assertTrue($container->has(Extension\BloodExtension::class));
+        self::assertTrue($container->has(Extension\ColorExtension::class));
+        self::assertTrue($container->has(Extension\DateTimeExtension::class));
+        self::assertTrue($container->has(Extension\FileExtension::class));
+        self::assertTrue($container->has(Extension\NumberExtension::class));
+        self::assertTrue($container->has(Extension\UuidExtension::class));
+        self::assertTrue($container->has(Extension\VersionExtension::class));
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] avoids useless tests for the `ContainerBuilder`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
