### PR TITLE
Enhancement: Allow creating `ContainerBuilder` with definitions for default extensions

### DIFF
--- a/src/Faker/Container/ContainerBuilder.php
+++ b/src/Faker/Container/ContainerBuilder.php
@@ -59,8 +59,19 @@ final class ContainerBuilder
         ];
     }
 
+    public static function withDefaultExtensions(): self
+    {
+        $instance = new self();
+
+        foreach (self::defaultExtensions() as $id => $definition) {
+            $instance->add($id, $definition);
+        }
+
+        return $instance;
+    }
+
     public static function getDefault(): ContainerInterface
     {
-        return new Container(self::defaultExtensions());
+        return self::withDefaultExtensions()->build();
     }
 }

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -567,7 +567,7 @@ class Generator
 
     public function __construct(ContainerInterface $container = null)
     {
-        $this->container = $container ?: Container\ContainerBuilder::getDefault();
+        $this->container = $container ?: Container\ContainerBuilder::withDefaultExtensions()->build();
     }
 
     /**

--- a/test/Faker/Extension/ContainerBuilderTest.php
+++ b/test/Faker/Extension/ContainerBuilderTest.php
@@ -131,9 +131,11 @@ final class ContainerBuilderTest extends TestCase
         self::assertEquals($definition(), $container->get($id));
     }
 
-    public function testGetDefaultReturnsContainerWithDefaultExtensions(): void
+    public function testWithDefaultExtensionsReturnsContainerBuilderWithDefaultExtensions(): void
     {
-        $container = ContainerBuilder::getDefault();
+        $builder = ContainerBuilder::withDefaultExtensions();
+
+        $container = $builder->build();
 
         self::assertTrue($container->has(Extension\BarcodeExtension::class));
         self::assertTrue($container->has(Extension\BloodExtension::class));


### PR DESCRIPTION
### What is the reason for this PR?

- [x] allows creating a `ContainerBuilder` with definitions for default extensions

Related to #719.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [x] Changes are approved by maintainer
