### PR TITLE
Fix: Drop support for PHP 7.4

### DIFF
--- a/.github/workflows/branch-alias.yaml
+++ b/.github/workflows/branch-alias.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "7.4"
+          php-version: "8.0"
           coverage: "none"
 
       - name: "Checkout code"

--- a/.github/workflows/coding-standards.yaml
+++ b/.github/workflows/coding-standards.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ["7.4"]
+        php-version: ["8.0"]
 
     steps:
       - name: "Checkout code"
@@ -55,7 +55,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ["7.4"]
+        php-version: ["8.0"]
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,6 @@ jobs:
         experimental:
           - false
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.23.0...main)
 
+- Dropped support for PHP 7.4 (#733)
+
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 
 - Update `randomElements` to return random number of elements when no count is provided (#658)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Calculator/Iban.php
 
@@ -606,11 +606,6 @@ parameters:
 			path: src/Faker/ORM/Spot/Populator.php
 
 		-
-			message: "#^Class UnitEnum not found\\.$#"
-			count: 2
-			path: src/Faker/Provider/Base.php
-
-		-
 			message: """
 				#^Instantiation of deprecated class Faker\\\\DefaultGenerator\\:
 				Use ChanceGenerator instead$#
@@ -624,7 +619,7 @@ parameters:
 			path: src/Faker/Provider/Base.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Base.php
 
@@ -674,12 +669,12 @@ parameters:
 			path: src/Faker/Provider/Lorem.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function md5 expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function md5 expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Miscellaneous.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function sha1 expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function sha1 expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/Miscellaneous.php
 
@@ -769,7 +764,7 @@ parameters:
 			path: src/Faker/Provider/en_NG/Address.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/en_ZA/Person.php
 
@@ -894,12 +889,7 @@ parameters:
 			path: src/Faker/Provider/pt_PT/Address.php
 
 		-
-			message: "#^Left side of \\|\\| is always true\\.$#"
-			count: 1
-			path: src/Faker/Provider/pt_PT/Person.php
-
-		-
-			message: "#^Right side of \\|\\| is always false\\.$#"
+			message: "#^Binary operation \"\\*\" between string and int results in an error\\.$#"
 			count: 1
 			path: src/Faker/Provider/pt_PT/Person.php
 
@@ -909,7 +899,7 @@ parameters:
 			path: src/Faker/Provider/ro_RO/Person.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/ru_RU/Company.php
 
@@ -929,7 +919,7 @@ parameters:
 			path: src/Faker/Provider/sv_SE/Municipality.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function str_pad expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/Faker/Provider/zh_CN/Address.php
 
@@ -939,7 +929,7 @@ parameters:
 			path: src/Faker/Provider/zh_CN/Address.php
 
 		-
-			message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, Closure\\(mixed\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function spl_autoload_register expects \\(callable\\(string\\)\\: void\\)\\|null, Closure\\(mixed\\)\\: bool given\\.$#"
 			count: 1
 			path: src/autoload.php
 


### PR DESCRIPTION
### What is the reason for this PR?

- [x] drops support for PHP 7.4

💁‍♂️ PHP 7.4 reached its end of life on November 28, 2022.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are approved by maintainer
