### PR TITLE
Fix: Mark trait as experimental

### DIFF
--- a/src/Faker/Extension/GeneratorAwareExtensionTrait.php
+++ b/src/Faker/Extension/GeneratorAwareExtensionTrait.php
@@ -7,6 +7,8 @@ namespace Faker\Extension;
 use Faker\Generator;
 
 /**
+ * @experimental This trait is experimental and does not fall under our BC promise
+ *
  * A helper trait to be used with GeneratorAwareExtension.
  */
 trait GeneratorAwareExtensionTrait


### PR DESCRIPTION
### What is the reason for this PR?

- [x] marks a trait that depends on and is solely used by experimental classes as experimental

Follows #154 and #165.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
