### PR TITLE
Enhancement: Inject services

### DIFF
--- a/src/Faker/Container/Container.php
+++ b/src/Faker/Container/Container.php
@@ -87,7 +87,7 @@ final class Container implements ContainerInterface
     {
         if (is_callable($definition)) {
             try {
-                return $definition();
+                return $definition($this);
             } catch (\Throwable $e) {
                 throw new ContainerException(
                     sprintf('Error while invoking callable for "%s"', $id),

--- a/src/Faker/Container/ContainerBuilder.php
+++ b/src/Faker/Container/ContainerBuilder.php
@@ -44,14 +44,22 @@ final class ContainerBuilder
     private static function defaultExtensions(): array
     {
         return [
-            Extension\BarcodeExtension::class => Core\Barcode::class,
+            Extension\BarcodeExtension::class => static function (ContainerInterface $container): Extension\BarcodeExtension {
+                return new Core\Barcode($container->get(Extension\NumberExtension::class));
+            },
             Extension\BloodExtension::class => Core\Blood::class,
-            Extension\ColorExtension::class => Core\Color::class,
+            Extension\ColorExtension::class => static function (ContainerInterface $container): Extension\ColorExtension {
+                return new Core\Color($container->get(Extension\NumberExtension::class));
+            },
             Extension\DateTimeExtension::class => Core\DateTime::class,
             Extension\FileExtension::class => Core\File::class,
             Extension\NumberExtension::class => Core\Number::class,
-            Extension\UuidExtension::class => Core\Uuid::class,
-            Extension\VersionExtension::class => Core\Version::class,
+            Extension\VersionExtension::class => static function (ContainerInterface $container): Extension\VersionExtension {
+                return new Core\Version($container->get(Extension\NumberExtension::class));
+            },
+            Extension\UuidExtension::class => static function (ContainerInterface $container): Extension\UuidExtension {
+                return new Core\Uuid($container->get(Extension\NumberExtension::class));
+            },
         ];
     }
 

--- a/src/Faker/Core/Barcode.php
+++ b/src/Faker/Core/Barcode.php
@@ -14,9 +14,9 @@ final class Barcode implements Extension\BarcodeExtension
 {
     private Extension\NumberExtension $numberExtension;
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(Extension\NumberExtension $numberExtension)
     {
-        $this->numberExtension = $numberExtension ?: new Number();
+        $this->numberExtension = $numberExtension;
     }
 
     private function ean(int $length = 13): string

--- a/src/Faker/Core/Color.php
+++ b/src/Faker/Core/Color.php
@@ -54,9 +54,9 @@ final class Color implements Extension\ColorExtension
         'Turquoise', 'Violet', 'Wheat', 'White', 'WhiteSmoke', 'Yellow', 'YellowGreen',
     ];
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(Extension\NumberExtension $numberExtension)
     {
-        $this->numberExtension = $numberExtension ?: new Number();
+        $this->numberExtension = $numberExtension;
     }
 
     /**

--- a/src/Faker/Core/Coordinates.php
+++ b/src/Faker/Core/Coordinates.php
@@ -13,9 +13,9 @@ final class Coordinates implements Extension\Extension
 {
     private Extension\NumberExtension $numberExtension;
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(Extension\NumberExtension $numberExtension)
     {
-        $this->numberExtension = $numberExtension ?: new Number();
+        $this->numberExtension = $numberExtension;
     }
 
     /**

--- a/src/Faker/Core/Uuid.php
+++ b/src/Faker/Core/Uuid.php
@@ -11,10 +11,10 @@ final class Uuid implements Extension\UuidExtension
 {
     private Extension\NumberExtension $numberExtension;
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(Extension\NumberExtension $numberExtension)
     {
 
-        $this->numberExtension = $numberExtension ?: new Number();
+        $this->numberExtension = $numberExtension;
     }
 
     public function uuid3(): string

--- a/src/Faker/Core/Version.php
+++ b/src/Faker/Core/Version.php
@@ -18,10 +18,10 @@ final class Version implements Extension\VersionExtension
      */
     private array $semverCommonPreReleaseIdentifiers = ['alpha', 'beta', 'rc'];
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(Extension\NumberExtension $numberExtension)
     {
 
-        $this->numberExtension = $numberExtension ?: new  Number();
+        $this->numberExtension = $numberExtension;
     }
 
     /**

--- a/test/Faker/Core/ColorTest.php
+++ b/test/Faker/Core/ColorTest.php
@@ -5,45 +5,46 @@ declare(strict_types=1);
 namespace Faker\Test\Core;
 
 use Faker\Core\Color;
+use Faker\Core\Number;
 use Faker\Test\TestCase;
 
 final class ColorTest extends TestCase
 {
     public function testHexColor(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         self::assertMatchesRegularExpression('/^#[a-f0-9]{6}$/i', $color->hexColor());
     }
 
     public function testSafeHexColor(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         self::assertMatchesRegularExpression('/^#[a-f0-9]{6}$/i', $color->safeHexColor());
     }
 
     public function testRgbColorAsArray(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         self::assertCount(3, $color->rgbColorAsArray());
     }
 
     public function testRgbColor(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         $regexp = '([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])';
         self::assertMatchesRegularExpression('/^' . $regexp . ',' . $regexp . ',' . $regexp . '$/i', $color->rgbColor());
     }
 
     public function testRgbCssColor(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         $regexp = '([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])';
         self::assertMatchesRegularExpression('/^rgb\(' . $regexp . ',' . $regexp . ',' . $regexp . '\)$/i', $color->rgbCssColor());
     }
 
     public function testRgbaCssColor(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         $regexp = '([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])';
         $regexpAlpha = '([01]?(\.\d+)?)';
         self::assertMatchesRegularExpression('/^rgba\(' . $regexp . ',' . $regexp . ',' . $regexp . ',' . $regexpAlpha . '\)$/i', $color->rgbaCssColor());
@@ -51,19 +52,19 @@ final class ColorTest extends TestCase
 
     public function testSafeColorName(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         self::assertMatchesRegularExpression('/^[\w]+$/', $color->safeColorName());
     }
 
     public function testColorName(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         self::assertMatchesRegularExpression('/^[\w]+$/', $color->colorName());
     }
 
     public function testHslColor(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         $regexp360 = '(?:36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])';
         $regexp100 = '(?:100|[1-9]?[0-9])';
         self::assertMatchesRegularExpression('/^' . $regexp360 . ',' . $regexp100 . ',' . $regexp100 . '$/', $color->hslColor());
@@ -71,7 +72,7 @@ final class ColorTest extends TestCase
 
     public function testHslColorArray(): void
     {
-        $color = new Color();
+        $color = new Color(new Number());
         self::assertCount(3, $color->hslColorAsArray());
     }
 }

--- a/test/Faker/Core/UuidTest.php
+++ b/test/Faker/Core/UuidTest.php
@@ -2,6 +2,7 @@
 
 namespace Faker\Test\Core;
 
+use Faker\Core\Number;
 use Faker\Core\Uuid;
 use Faker\Test\TestCase;
 
@@ -9,14 +10,14 @@ final class UuidTest extends TestCase
 {
     public function testUuidReturnsUuid(): void
     {
-        $instance = new Uuid();
+        $instance = new Uuid(new Number());
         $uuid = $instance->uuid3();
         self::assertTrue($this->isUuid($uuid));
     }
 
     public function testUuidExpectedSeed(): void
     {
-        $instance = new Uuid();
+        $instance = new Uuid(new Number());
 
         if (pack('L', 0x6162797A) == pack('N', 0x6162797A)) {
             self::markTestSkipped('Big Endian');


### PR DESCRIPTION
### What is the reason for this PR?

- [x] injects services into extensions

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

The idea here is to allow extensions to depend on other services, rather than depending on [`static` methods from the `Helper`](https://github.com/FakerPHP/Faker/blob/2.0/src/Faker/Extension/Helper.php#L15-L22) or similar.

This could allow for

- centralizing (and reusing) the randomization aspect of `fakerphp/faker`
  - selecting a random number
  - [selecting a random element from a list of elements](https://github.com/FakerPHP/Faker/blob/2c2882162a46bedefbe1577dd9b22d638edb1e81/src/Faker/Extension/Helper.php#L15-L22)
  - [shuffling a list of elements](https://github.com/FakerPHP/Faker/blob/2c2882162a46bedefbe1577dd9b22d638edb1e81/src/Faker/Provider/Base.php#L338-L377)
- extracting randomization strategies
  - using [`mt_*`](https://www.php.net/manual/en/function.mt-rand.php) functions
  - using [`Random\Randomizer`](https://www.php.net/manual/en/class.random-randomizer.php)
  - using a deterministic strategy in tests, for example)
- letting extensions and extension packages focus on providing data

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
