### PR TITLE
Enhancement: Use `Helper` to select random element instead of `array_rand()`

### DIFF
--- a/src/Faker/Core/File.php
+++ b/src/Faker/Core/File.php
@@ -547,14 +547,14 @@ final class File implements Extension\FileExtension
 
     public function mimeType(): string
     {
-        return array_rand($this->mimeTypes, 1);
+        return Extension\Helper::randomElement(array_keys($this->mimeTypes));
     }
 
     public function extension(): string
     {
-        $extension = $this->mimeTypes[array_rand($this->mimeTypes, 1)];
+        $extension = Extension\Helper::randomElement($this->mimeTypes);
 
-        return is_array($extension) ? $extension[array_rand($extension, 1)] : $extension;
+        return is_array($extension) ? Extension\Helper::randomElement($extension) : $extension;
     }
 
     public function filePath(): string

--- a/src/Faker/ORM/CakePHP/EntityPopulator.php
+++ b/src/Faker/ORM/CakePHP/EntityPopulator.php
@@ -3,6 +3,7 @@
 namespace Faker\ORM\CakePHP;
 
 use Cake\ORM\TableRegistry;
+use Faker\Extension;
 
 class EntityPopulator
 {
@@ -112,7 +113,7 @@ class EntityPopulator
                     throw new \Exception(sprintf('%s belongsTo %s, which seems empty at this point.', $this->getTable($this->class)->table(), $assoc->table()));
                 }
 
-                $foreignKey = $foreignKeys[array_rand($foreignKeys)];
+                $foreignKey = Extension\Helper::randomElement($foreignKeys);
                 $data[$assoc->foreignKey()] = $foreignKey;
 
                 return $data;


### PR DESCRIPTION
### What is the reason for this PR?

- [x] uses the [`Helper`](https://github.com/FakerPHP/Faker/blob/2c2882162a46bedefbe1577dd9b22d638edb1e81/src/Faker/Extension/Helper.php#L15-L22) to select a random element instead of `array_rand()`

Somewhat related to #753.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
