### PR TITLE
Enhancement: Use `Helper` to generate random number without arguments

### DIFF
--- a/src/Faker/Extension/Helper.php
+++ b/src/Faker/Extension/Helper.php
@@ -21,6 +21,11 @@ final class Helper
         return $array[array_rand($array, 1)];
     }
 
+    public static function randomNumber(): int
+    {
+        return mt_rand();
+    }
+
     public static function largestRandomNumber(): int
     {
         return mt_getrandmax();

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -4,6 +4,7 @@ namespace Faker\ORM\Doctrine;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
+use Faker\Extension;
 
 require_once 'backward-compatibility.php';
 
@@ -240,7 +241,7 @@ class EntityPopulator
         $ids = array_map('current', $result->toArray());
 
         do {
-            $id = mt_rand();
+            $id = Extension\Helper::randomNumber();
         } while (in_array($id, $ids, false));
 
         return $id;

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -128,7 +128,7 @@ class Base
             $max = $tmp;
         }
 
-        return round($min + mt_rand() / Extension\Helper::largestRandomNumber() * ($max - $min), $nbMaxDecimals);
+        return round($min + Extension\Helper::randomNumber() / Extension\Helper::largestRandomNumber() * ($max - $min), $nbMaxDecimals);
     }
 
     /**
@@ -643,7 +643,7 @@ class Base
     {
         // old system based on 0.1 <= $weight <= 0.9
         // TODO: remove in v2
-        if ($weight > 0 && $weight < 1 && mt_rand() / Extension\Helper::largestRandomNumber() <= $weight) {
+        if ($weight > 0 && $weight < 1 && Extension\Helper::randomNumber() / Extension\Helper::largestRandomNumber() <= $weight) {
             return $this->generator;
         }
 

--- a/src/Faker/Provider/Biased.php
+++ b/src/Faker/Provider/Biased.php
@@ -25,8 +25,8 @@ class Biased extends Base
     public function biasedNumberBetween($min = 0, $max = 100, $function = 'sqrt')
     {
         do {
-            $x = mt_rand() / Extension\Helper::largestRandomNumber();
-            $y = mt_rand() / (Extension\Helper::largestRandomNumber() + 1);
+            $x = Extension\Helper::randomNumber() / Extension\Helper::largestRandomNumber();
+            $y = Extension\Helper::randomNumber() / (Extension\Helper::largestRandomNumber() + 1);
         } while (call_user_func($function, $x) < $y);
 
         return (int) floor($x * ($max - $min + 1) + $min);


### PR DESCRIPTION
### What is the reason for this PR?

- [x] uses the `Helper` to generate a random number without arguments

Follows #754.

💁‍♂️ Following up on using the `Helper` to select a random element from a list of elements, this - as an intermediate step - moves generating a random number without any arguments to the `Helper`.

Running

```shell
git grep mt_rand\(\)
```

on current `2.0` yields

```
src/Faker/ORM/Doctrine/EntityPopulator.php:243:            $id = mt_rand();
src/Faker/Provider/Base.php:130:        return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
src/Faker/Provider/Base.php:645:        if ($weight > 0 && $weight < 1 && mt_rand() / mt_getrandmax() <= $weight) {
src/Faker/Provider/Biased.php:26:            $x = mt_rand() / mt_getrandmax();
src/Faker/Provider/Biased.php:27:            $y = mt_rand() / (mt_getrandmax() + 1);
test/Faker/GeneratorTest.php:190:        $mtRandWithSeedZero = mt_rand();
test/Faker/GeneratorTest.php:192:        self::assertEquals($mtRandWithSeedZero, mt_rand(), 'seed(0) should be deterministic.');
test/Faker/GeneratorTest.php:195:        $mtRandWithoutSeed = mt_rand();
test/Faker/GeneratorTest.php:198:        self::assertNotEquals($mtRandWithoutSeed, mt_rand(), 'seed() should not be deterministic.');
```

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
