### PR TITLE
Enhancement: Use `Helper` to determine largest random number

### DIFF
--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -60,7 +60,7 @@ final class Number implements Extension\NumberExtension
             $max = $tmp;
         }
 
-        return round($min + $this->numberBetween() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
+        return round($min + $this->numberBetween() / Extension\Helper::largestRandomNumber() * ($max - $min), $nbMaxDecimals);
     }
 
     public function randomNumber(int $nbDigits = null, bool $strict = false): int
@@ -70,7 +70,7 @@ final class Number implements Extension\NumberExtension
         }
         $max = 10 ** $nbDigits - 1;
 
-        if ($max > mt_getrandmax()) {
+        if ($max > Extension\Helper::largestRandomNumber()) {
             throw new \InvalidArgumentException('randomNumber() can only generate numbers up to mt_getrandmax()');
         }
 

--- a/src/Faker/Extension/Helper.php
+++ b/src/Faker/Extension/Helper.php
@@ -21,6 +21,11 @@ final class Helper
         return $array[array_rand($array, 1)];
     }
 
+    public static function largestRandomNumber(): int
+    {
+        return mt_getrandmax();
+    }
+
     /**
      * Replaces all hash sign ('#') occurrences with a random number
      * Replaces all percentage sign ('%') occurrences with a non-zero number.
@@ -42,7 +47,7 @@ final class Helper
         }
 
         if ($nbReplacements = count($toReplace)) {
-            $maxAtOnce = strlen((string) mt_getrandmax()) - 1;
+            $maxAtOnce = strlen((string) self::largestRandomNumber()) - 1;
             $numbers = '';
             $i = 0;
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -3,6 +3,7 @@
 namespace Faker\Provider;
 
 use Faker\DefaultGenerator;
+use Faker\Extension;
 use Faker\Generator;
 use Faker\UniqueGenerator;
 use Faker\ValidGenerator;
@@ -85,7 +86,7 @@ class Base
         }
         $max = 10 ** $nbDigits - 1;
 
-        if ($max > mt_getrandmax()) {
+        if ($max > Extension\Helper::largestRandomNumber()) {
             throw new \InvalidArgumentException('randomNumber() can only generate numbers up to mt_getrandmax()');
         }
 
@@ -127,7 +128,7 @@ class Base
             $max = $tmp;
         }
 
-        return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
+        return round($min + mt_rand() / Extension\Helper::largestRandomNumber() * ($max - $min), $nbMaxDecimals);
     }
 
     /**
@@ -449,7 +450,7 @@ class Base
         }
 
         if ($nbReplacements = count($toReplace)) {
-            $maxAtOnce = strlen((string) mt_getrandmax()) - 1;
+            $maxAtOnce = strlen((string) Extension\Helper::largestRandomNumber()) - 1;
             $numbers = '';
             $i = 0;
 
@@ -642,7 +643,7 @@ class Base
     {
         // old system based on 0.1 <= $weight <= 0.9
         // TODO: remove in v2
-        if ($weight > 0 && $weight < 1 && mt_rand() / mt_getrandmax() <= $weight) {
+        if ($weight > 0 && $weight < 1 && mt_rand() / Extension\Helper::largestRandomNumber() <= $weight) {
             return $this->generator;
         }
 

--- a/src/Faker/Provider/Biased.php
+++ b/src/Faker/Provider/Biased.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider;
 
+use Faker\Extension;
+
 class Biased extends Base
 {
     /**
@@ -23,8 +25,8 @@ class Biased extends Base
     public function biasedNumberBetween($min = 0, $max = 100, $function = 'sqrt')
     {
         do {
-            $x = mt_rand() / mt_getrandmax();
-            $y = mt_rand() / (mt_getrandmax() + 1);
+            $x = mt_rand() / Extension\Helper::largestRandomNumber();
+            $y = mt_rand() / (Extension\Helper::largestRandomNumber() + 1);
         } while (call_user_func($function, $x) < $y);
 
         return (int) floor($x * ($max - $min + 1) + $min);


### PR DESCRIPTION
### What is the reason for this PR?

- [x] uses the `Helper` to determine largest random number

Follows #754.

Running

```shell
git grep mt_getrandmax\(\)
```

on current `2.0` yields

```
src/Faker/Core/Number.php:63:        return round($min + $this->numberBetween() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
src/Faker/Core/Number.php:73:        if ($max > mt_getrandmax()) {
src/Faker/Core/Number.php:74:            throw new \InvalidArgumentException('randomNumber() can only generate numbers up to mt_getrandmax()');
src/Faker/Extension/Helper.php:45:            $maxAtOnce = strlen((string) mt_getrandmax()) - 1;
src/Faker/Extension/NumberExtension.php:45:     * The maximum value returned is mt_getrandmax()
src/Faker/Generator.php:903:     * The maximum value returned is mt_getrandmax()
src/Faker/Provider/Base.php:68:     * The maximum value returned is mt_getrandmax()
src/Faker/Provider/Base.php:88:        if ($max > mt_getrandmax()) {
src/Faker/Provider/Base.php:89:            throw new \InvalidArgumentException('randomNumber() can only generate numbers up to mt_getrandmax()');
src/Faker/Provider/Base.php:130:        return round($min + mt_rand() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
src/Faker/Provider/Base.php:452:            $maxAtOnce = strlen((string) mt_getrandmax()) - 1;
src/Faker/Provider/Base.php:645:        if ($weight > 0 && $weight < 1 && mt_rand() / mt_getrandmax() <= $weight) {
src/Faker/Provider/Biased.php:26:            $x = mt_rand() / mt_getrandmax();
src/Faker/Provider/Biased.php:27:            $y = mt_rand() / (mt_getrandmax() + 1);
src/Faker/Provider/bg_BG/Payment.php:42:            self::randomNumber(5, true), // workaround for mt_getrandmax() limitation
```

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
