### PR TITLE
Enhancement: Use `Helper` to select random number between minimum and maximum

### DIFF
--- a/src/Faker/ChanceGenerator.php
+++ b/src/Faker/ChanceGenerator.php
@@ -2,8 +2,6 @@
 
 namespace Faker;
 
-use Faker\Extension\Extension;
-
 /**
  * This generator returns a default value for all called properties
  * and methods. It works with Faker\Generator::optional().
@@ -17,7 +15,7 @@ class ChanceGenerator
     protected $default;
 
     /**
-     * @param Extension|Generator $generator
+     * @param Extension\Extension|Generator $generator
      */
     public function __construct($generator, float $weight, $default = null)
     {
@@ -51,7 +49,7 @@ class ChanceGenerator
      */
     public function __call($name, $arguments)
     {
-        if (mt_rand(1, 100) <= (100 * $this->weight)) {
+        if (Extension\Helper::randomNumberBetween(1, 100) <= (100 * $this->weight)) {
             return call_user_func_array([$this->generator, $name], $arguments);
         }
 

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -16,7 +16,7 @@ final class Number implements Extension\NumberExtension
         $int1 = min($min, $max);
         $int2 = max($min, $max);
 
-        return mt_rand($int1, $int2);
+        return Extension\Helper::randomNumberBetween($int1, $int2);
     }
 
     public function randomDigit(): int

--- a/src/Faker/Extension/Helper.php
+++ b/src/Faker/Extension/Helper.php
@@ -26,6 +26,11 @@ final class Helper
         return mt_rand();
     }
 
+    public static function randomNumberBetween(int $min, int $max): int
+    {
+        return mt_rand($min, $max);
+    }
+
     public static function largestRandomNumber(): int
     {
         return mt_getrandmax();
@@ -58,7 +63,7 @@ final class Helper
 
             while ($i < $nbReplacements) {
                 $size = min($nbReplacements - $i, $maxAtOnce);
-                $numbers .= str_pad((string) mt_rand(0, 10 ** $size - 1), $size, '0', STR_PAD_LEFT);
+                $numbers .= str_pad((string) self::randomNumberBetween(0, 10 ** $size - 1), $size, '0', STR_PAD_LEFT);
                 $i += $size;
             }
 
@@ -68,7 +73,7 @@ final class Helper
         }
 
         return self::replaceWildcard($string, '%', static function () {
-            return mt_rand(1, 9);
+            return self::randomNumberBetween(1, 9);
         });
     }
 
@@ -80,7 +85,7 @@ final class Helper
     public static function lexify(string $string): string
     {
         return self::replaceWildcard($string, '?', static function () {
-            return chr(mt_rand(97, 122));
+            return chr(self::randomNumberBetween(97, 122));
         });
     }
 
@@ -93,7 +98,7 @@ final class Helper
     public static function bothify(string $string): string
     {
         $string = self::replaceWildcard($string, '*', static function () {
-            return mt_rand(0, 1) === 1 ? '#' : '?';
+            return self::randomNumberBetween(0, 1) === 1 ? '#' : '?';
         });
 
         return self::lexify(self::numerify($string));

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -32,7 +32,7 @@ class Base
      */
     public static function randomDigit()
     {
-        return mt_rand(0, 9);
+        return Extension\Helper::randomNumberBetween(0, 9);
     }
 
     /**
@@ -42,7 +42,7 @@ class Base
      */
     public static function randomDigitNotNull()
     {
-        return mt_rand(1, 9);
+        return Extension\Helper::randomNumberBetween(1, 9);
     }
 
     /**
@@ -91,10 +91,10 @@ class Base
         }
 
         if ($strict) {
-            return mt_rand(10 ** ($nbDigits - 1), $max);
+            return Extension\Helper::randomNumberBetween(10 ** ($nbDigits - 1), $max);
         }
 
-        return mt_rand(0, $max);
+        return Extension\Helper::randomNumberBetween(0, $max);
     }
 
     /**
@@ -146,7 +146,7 @@ class Base
         $min = $int1 < $int2 ? $int1 : $int2;
         $max = $int1 < $int2 ? $int2 : $int1;
 
-        return mt_rand($min, $max);
+        return Extension\Helper::randomNumberBetween($min, $max);
     }
 
     /**
@@ -164,7 +164,7 @@ class Base
      */
     public static function randomLetter()
     {
-        return chr(mt_rand(97, 122));
+        return chr(Extension\Helper::randomNumberBetween(97, 122));
     }
 
     /**
@@ -174,7 +174,7 @@ class Base
      */
     public static function randomAscii()
     {
-        return chr(mt_rand(33, 126));
+        return chr(Extension\Helper::randomNumberBetween(33, 126));
     }
 
     /**
@@ -223,7 +223,7 @@ class Base
         }
 
         if (null === $count) {
-            $count = mt_rand(1, $numberOfElements);
+            $count = Extension\Helper::randomNumberBetween(1, $numberOfElements);
         }
 
         $randomElements = [];
@@ -234,7 +234,7 @@ class Base
         $numberOfRandomElements = 0;
 
         while ($numberOfRandomElements < $count) {
-            $index = mt_rand(0, $maxIndex);
+            $index = Extension\Helper::randomNumberBetween(0, $maxIndex);
 
             if (!$allowDuplicates) {
                 if (isset($elementHasBeenSelectedAlready[$index])) {
@@ -305,7 +305,7 @@ class Base
         }
         $keys = array_keys($array);
 
-        return $keys[mt_rand(0, count($keys) - 1)];
+        return $keys[Extension\Helper::randomNumberBetween(0, count($keys) - 1)];
     }
 
     /**
@@ -362,7 +362,7 @@ class Base
             if ($i == 0) {
                 $j = 0;
             } else {
-                $j = mt_rand(0, $i);
+                $j = Extension\Helper::randomNumberBetween(0, $i);
             }
 
             if ($j == $i) {
@@ -492,7 +492,7 @@ class Base
     public static function bothify($string = '## ??')
     {
         $string = self::replaceWildcard($string, '*', static function () {
-            return mt_rand(0, 1) === 1 ? '#' : '?';
+            return Extension\Helper::randomNumberBetween(0, 1) === 1 ? '#' : '?';
         });
 
         return static::lexify(static::numerify($string));
@@ -648,7 +648,7 @@ class Base
         }
 
         // new system with percentage
-        if (is_int($weight) && mt_rand(1, 100) <= $weight) {
+        if (is_int($weight) && Extension\Helper::randomNumberBetween(1, 100) <= $weight) {
             return $this->generator;
         }
 

--- a/src/Faker/Provider/ar_EG/Person.php
+++ b/src/Faker/Provider/ar_EG/Person.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\ar_EG;
 
+use Faker\Extension;
+
 class Person extends \Faker\Provider\Person
 {
     protected static $maleNameFormats = [
@@ -86,12 +88,12 @@ class Person extends \Faker\Provider\Person
      */
     public static function nationalIdNumber($gender = null)
     {
-        $randomBirthDateTimestamp = mt_rand(strtotime('1950-Jan-10'), strtotime('2005-Dec-25'));
+        $randomBirthDateTimestamp = Extension\Helper::randomNumberBetween(strtotime('1950-Jan-10'), strtotime('2005-Dec-25'));
 
         $centuryId = ((int) date('Y', $randomBirthDateTimestamp)) >= 2000 ? 3 : 2;
         $fullBirthDate = date('ymd', $randomBirthDateTimestamp);
         $governorateId = Address::governorateId();
-        $birthRegistrationSequence = mt_rand(1, 500);
+        $birthRegistrationSequence = Extension\Helper::randomNumberBetween(1, 500);
 
         if ($gender === static::GENDER_MALE) {
             $birthRegistrationSequence = $birthRegistrationSequence | 1; // Convert to the nearest odd number
@@ -100,7 +102,7 @@ class Person extends \Faker\Provider\Person
         }
 
         $birthRegistrationSequence = str_pad((string) $birthRegistrationSequence, 4, '0', STR_PAD_LEFT);
-        $randomCheckDigit = mt_rand(1, 9);
+        $randomCheckDigit = Extension\Helper::randomNumberBetween(1, 9);
 
         return $centuryId . $fullBirthDate . $governorateId . $birthRegistrationSequence . $randomCheckDigit;
     }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] uses the `Helper` to select a random number between a minimum and a maximum

Follows #754.

💁‍♂️ Running

```shell
git grep mt_rand\(
```

on current `2.0` yields

```
.github/CONTRIBUTING.md:21:* Never use `rand()` in your provider. Faker utilizes the Mersenne Twister Randomizer, so use `mt_rand()` or any of the base generators (`randomNumber`, `randomElement`, etc.) instead.
src/Faker/ChanceGenerator.php:54:        if (mt_rand(1, 100) <= (100 * $this->weight)) {
src/Faker/Core/Number.php:19:        return mt_rand($int1, $int2);
src/Faker/Extension/Helper.php:26:        return mt_rand();
src/Faker/Extension/Helper.php:61:                $numbers .= str_pad((string) mt_rand(0, 10 ** $size - 1), $size, '0', STR_PAD_LEFT);
src/Faker/Extension/Helper.php:71:            return mt_rand(1, 9);
src/Faker/Extension/Helper.php:83:            return chr(mt_rand(97, 122));
src/Faker/Extension/Helper.php:96:            return mt_rand(0, 1) === 1 ? '#' : '?';
src/Faker/Provider/Base.php:35:        return mt_rand(0, 9);
src/Faker/Provider/Base.php:45:        return mt_rand(1, 9);
src/Faker/Provider/Base.php:94:            return mt_rand(10 ** ($nbDigits - 1), $max);
src/Faker/Provider/Base.php:97:        return mt_rand(0, $max);
src/Faker/Provider/Base.php:149:        return mt_rand($min, $max);
src/Faker/Provider/Base.php:167:        return chr(mt_rand(97, 122));
src/Faker/Provider/Base.php:177:        return chr(mt_rand(33, 126));
src/Faker/Provider/Base.php:226:            $count = mt_rand(1, $numberOfElements);
src/Faker/Provider/Base.php:237:            $index = mt_rand(0, $maxIndex);
src/Faker/Provider/Base.php:308:        return $keys[mt_rand(0, count($keys) - 1)];
src/Faker/Provider/Base.php:365:                $j = mt_rand(0, $i);
src/Faker/Provider/Base.php:495:            return mt_rand(0, 1) === 1 ? '#' : '?';
src/Faker/Provider/Base.php:651:        if (is_int($weight) && mt_rand(1, 100) <= $weight) {
src/Faker/Provider/ar_EG/Person.php:89:        $randomBirthDateTimestamp = mt_rand(strtotime('1950-Jan-10'), strtotime('2005-Dec-25'));
src/Faker/Provider/ar_EG/Person.php:94:        $birthRegistrationSequence = mt_rand(1, 500);
src/Faker/Provider/ar_EG/Person.php:103:        $randomCheckDigit = mt_rand(1, 9);
test/Faker/GeneratorTest.php:190:        $mtRandWithSeedZero = mt_rand();
test/Faker/GeneratorTest.php:192:        self::assertEquals($mtRandWithSeedZero, mt_rand(), 'seed(0) should be deterministic.');
test/Faker/GeneratorTest.php:195:        $mtRandWithoutSeed = mt_rand();
test/Faker/GeneratorTest.php:198:        self::assertNotEquals($mtRandWithoutSeed, mt_rand(), 'seed() should not be deterministic.');
```

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
