### PR TITLE
Fix: Configure `bamarni/composer-bin-plugin`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,10 @@
         "sort-packages": true
     },
     "extra": {
+        "bamarni-bin": {
+            "bin-links": true,
+            "forward-command": false
+        },
         "branch-alias": {
             "dev-main": "v1.21-dev"
         }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] configures `bamarni/composer-bin-plugin`

💁‍♂️ Running

```shell
composer update
``` 

on current `2.0` yields

```
[bamarni-bin] The setting "extra.bamarni-bin.bin-links" will be set to "false" from 2.x onwards. If you wish to keep it to "true", you need to set it explicitly.
[bamarni-bin] The setting "extra.bamarni-bin.forward-command" will be set to "true" from 2.x onwards. If you wish to keep it to "false", you need to set it explicitly.
```

For reference, see

- https://github.com/bamarni/composer-bin-plugin/tree/1.8.2#bin-links-bin-links
- https://github.com/bamarni/composer-bin-plugin/tree/1.8.2#forward-command-forward-command

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
