### PR TITLE
Enhancement: Allow defining services that resolve to `object` instead of `Extension`

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -31,6 +31,7 @@ parameters:
     - '#\[BC\] CHANGED: The parameter \$partialValue of Faker\\Calculator\\Luhn::generateLuhnNumber\(\) changed from no type to a non-contravariant string#'
     - '#\[BC\] CHANGED: The parameter \$partialValue of Faker\\Calculator\\Luhn::generateLuhnNumber\(\) changed from no type to string#'
     - '#\[BC\] CHANGED: The parameter \$value of Faker\\Container\\ContainerBuilder\#add\(\) changed from no type to a non-contravariant string#'
+    - '#\[BC\] CHANGED: The return type of Faker\\Container\\Container\#get\(\) changed from Faker\\Extension\\Extension to the non-covariant object#'
     - '#\[BC\] CHANGED: The return type of Faker\\Extension\\PersonExtension\#name\(\) changed from no type to string#'
     - '#\[BC\] CHANGED: Type documentation for property Faker\\Provider\\en_ZA\\Internet::\$tld changed from having no type to array#'
     - '#\[BC\] REMOVED: Class Faker\\Extension\\Container has been deleted#'

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -19,7 +19,7 @@ final class Container implements ContainerInterface
     private array $definitions;
 
     /**
-     * @var array<string, Extension>
+     * @var array<string, object>
      */
     private array $services = [];
 
@@ -44,7 +44,7 @@ final class Container implements ContainerInterface
      * @throws ContainerException
      * @throws NotInContainerException
      */
-    public function get($id): Extension
+    public function get($id): object
     {
         if (!is_string($id)) {
             throw new \InvalidArgumentException(sprintf(
@@ -68,11 +68,10 @@ final class Container implements ContainerInterface
 
         $service = $this->getService($id, $definition);
 
-        if (!$service instanceof Extension) {
+        if (!is_object($service)) {
             throw new \RuntimeException(sprintf(
-                'Service resolved for identifier "%s" does not implement the %s" interface.',
+                'Service resolved for identifier "%s" is not an object.',
                 $id,
-                Extension::class,
             ));
         }
 


### PR DESCRIPTION
### What is the reason for this PR?

- [x] adjusts the `Container` to allow defining services that resolve to `object` instead of `Extension`

Follows #753.

💁‍♂️ I believe it makes sense to define services required by extensions that are not extensions, see for example #769.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
