### PR TITLE
Fix: Declare strict types in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Use `Faker\Factory::create()` to create and initialize a Faker generator, which 
 
 ```php
 <?php
+
+declare(strict_types=1);
+
 require_once 'vendor/autoload.php';
 
 // use the factory to create a Faker\Generator instance
@@ -48,6 +51,9 @@ Each call to `$faker->name()` yields a different (random) result. This is becaus
 
 ```php
 <?php
+
+declare(strict_types=1);
+
 for ($i = 0; $i < 3; $i++) {
     echo $faker->name() . "\n";
 }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] declares strict types in examples in `README.md`

Somewhat related to #742.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
