### PR TITLE
Fix: Explicitly reference configuration for `friendsofphp/php-cs-fixer`

### DIFF
--- a/.github/workflows/coding-standards.yaml
+++ b/.github/workflows/coding-standards.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: "Run php-cs-fixer"
         run: |
-          vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --verbose
+          vendor/bin/php-cs-fixer fix --ansi --config=.php-cs-fixer.dist.php --diff --dry-run --verbose
 
       - name: "Run php-cs-fixer for test code"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 
 .PHONY: cs
 cs: vendor ## Fixes coding standard issues with php-cs-fixer
-	vendor/bin/php-cs-fixer fix --diff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff --verbose
 	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.test.php --diff --verbose
 
 .PHONY: coverage


### PR DESCRIPTION
### What is the reason for this PR?

- [x] explicitly references the configuration for `friendsofphp/php-cs-fixer`

💁‍♂️ There is 

- no rule in [`.gitignore`](https://github.com/FakerPHP/Faker/blob/550cd893d344b5fa31b5d12e0d2fbb17c1101ff5/.gitignore) that would ignore a `.php-cs-fixer.php`
- no need for a maintainer or contributor to override the existing configuration file `.php-cs-fixer.dist.php`

so why bother using the configuration resolving mechanism of `friendsofphp/php-cs-fixer` instead of explicitly referencing the configuration file with the configuration for our agreed-upon coding standard?

Also see #780.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
