### PR TITLE
Fix: Do not use `static` in callables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.23.0...main)
 
 - Fixed polish license plates (#685)
+- Stopped using `static` in callables in `Provider\pt_BR\PhoneNumber` (#785)
 
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 

--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -83,7 +83,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
             ['landline', null],
         ]);
 
-        return call_user_func("static::{$options[0]}", $formatted, $options[1]);
+        return call_user_func([static::class, $options[0]], $formatted, $options[1]);
     }
 
     /**
@@ -135,7 +135,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
         $method = static::randomElement(['cellphoneNumber', 'landlineNumber']);
 
-        return call_user_func("static::$method", true);
+        return call_user_func([static::class, $method], true);
     }
 
     /**
@@ -145,6 +145,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
         $method = static::randomElement(['cellphoneNumber', 'landlineNumber']);
 
-        return call_user_func("static::$method", false);
+        return call_user_func([static::class, $method], false);
     }
 }

--- a/test/Faker/Provider/pt_BR/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_BR/PhoneNumberTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\Provider\pt_BR;
+
+use Faker\Provider;
+use Faker\Test;
+
+/**
+ * @covers \Faker\Provider\pt_BR\PhoneNumber
+ */
+final class PhoneNumberTest extends Test\TestCase
+{
+    public function testPhoneReturnsPhoneNumberWhenArgumentIsFalse(): void
+    {
+        $phoneNumber = $this->faker->phone(false);
+
+        self::assertIsString($phoneNumber);
+        self::assertNotEmpty($phoneNumber);
+    }
+
+    public function testPhoneReturnsPhoneNumberWhenArgumentIsTrue(): void
+    {
+        $phoneNumber = $this->faker->phone(true);
+
+        self::assertIsString($phoneNumber);
+        self::assertNotEmpty($phoneNumber);
+    }
+
+    public function testPhoneNumberReturnsPhoneNumber(): void
+    {
+        $phoneNumber = $this->faker->phoneNumber();
+
+        self::assertIsString($phoneNumber);
+        self::assertNotEmpty($phoneNumber);
+    }
+
+    public function testPhoneNumberClearedReturnsPhoneNumber(): void
+    {
+        $phoneNumber = $this->faker->phoneNumberCleared();
+
+        self::assertIsString($phoneNumber);
+        self::assertNotEmpty($phoneNumber);
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Provider\pt_BR\PhoneNumber($this->faker);
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

- [x] stops using `static` in callables 

Fixes #784.
Follows #479.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
