### PR TITLE
Correct return type of `Generator::unique()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/Generator.php
 
 		-
-			message: "#^Method Faker\\\\Generator\\:\\:unique\\(\\) should return Faker\\\\Generator but returns Faker\\\\UniqueGenerator\\.$#"
-			count: 1
-			path: src/Generator.php
-
-		-
 			message: "#^Method Faker\\\\Generator\\:\\:valid\\(\\) should return Faker\\\\Generator but returns Faker\\\\ValidGenerator\\.$#"
 			count: 1
 			path: src/Generator.php

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -2,12 +2,10 @@
 <files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Generator.php">
     <InvalidReturnStatement>
-      <code><![CDATA[$this->uniqueGenerator]]></code>
       <code>new ChanceGenerator($this, $weight, $default)</code>
       <code>new ValidGenerator($this, $validator, $maxRetries)</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code>self</code>
       <code>self</code>
       <code>self</code>
     </InvalidReturnType>

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -624,7 +624,7 @@ class Generator
      *
      * @throws \OverflowException When no unique value can be found by iterating $maxRetries times
      *
-     * @return self A proxy class returning only non-existing values
+     * @return UniqueGenerator A proxy class returning only non-existing values
      */
     public function unique($reset = false, $maxRetries = 10000)
     {


### PR DESCRIPTION
### What is the reason for this PR?
`Generator::unique()` is documented as returning a `Generator` where it is actually returning a `UniqueGenerator` as annotated on the class property. This PR corrects this minor incorrection. Going through the issues and PR I didn't find anything related to this correct other that the initial commit that introduced the function.

- [ ] A new feature
- [X] Fixed an issue

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes
This PR corrects the return type in the PHPDOC block of the `Generator::unique()` function

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
