### PR TITLE
Enhancement: Enable `long_to_shorthand_operator` fixer

### DIFF
--- a/.php-cs-fixer.rules.php
+++ b/.php-cs-fixer.rules.php
@@ -67,6 +67,7 @@ return [
     'list_syntax' => [
         'syntax' => 'short',
     ],
+    'long_to_shorthand_operator' => true,
     'lowercase_cast' => true,
     'lowercase_static_reference' => true,
     'magic_constant_casing' => true,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,7 +6,7 @@ parameters:
 			path: src/Calculator/Iban.php
 
 		-
-			message: "#^Binary operation \"\\*\" between int and string results in an error\\.$#"
+			message: "#^Binary operation \"\\*\\=\" between string and int results in an error\\.$#"
 			count: 1
 			path: src/Calculator/Isbn.php
 

--- a/src/Calculator/Isbn.php
+++ b/src/Calculator/Isbn.php
@@ -35,7 +35,7 @@ class Isbn
         array_walk(
             $digits,
             static function (&$digit, $position): void {
-                $digit = (10 - $position) * $digit;
+                $digit *= (10 - $position)  ;
             },
         );
         $result = (11 - array_sum($digits) % 11) % 11;

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -646,7 +646,7 @@ class Generator
     {
         if ($weight > 1) {
             trigger_deprecation('fakerphp/faker', '1.16', 'First argument ($weight) to method "optional()" must be between 0 and 1. You passed %f, we assume you meant %f.', $weight, $weight / 100);
-            $weight = $weight / 100;
+            $weight /= 100;
         }
 
         return new ChanceGenerator($this, $weight, $default);

--- a/src/Provider/ar_EG/Person.php
+++ b/src/Provider/ar_EG/Person.php
@@ -96,9 +96,9 @@ class Person extends \Faker\Provider\Person
         $birthRegistrationSequence = Extension\Helper::randomNumberBetween(1, 500);
 
         if ($gender === static::GENDER_MALE) {
-            $birthRegistrationSequence = $birthRegistrationSequence | 1; // Convert to the nearest odd number
+            $birthRegistrationSequence |= 1; // Convert to the nearest odd number
         } elseif ($gender === static::GENDER_FEMALE) {
-            $birthRegistrationSequence = $birthRegistrationSequence & ~1; // Convert to the nearest even number
+            $birthRegistrationSequence &= ~1; // Convert to the nearest even number
         }
 
         $birthRegistrationSequence = str_pad((string) $birthRegistrationSequence, 4, '0', STR_PAD_LEFT);

--- a/src/Provider/en_GB/Company.php
+++ b/src/Provider/en_GB/Company.php
@@ -117,13 +117,13 @@ class Company extends \Faker\Provider\Company
         }
 
         if ($use9755) {
-            $sum = $sum + 55;
+            $sum += 55;
         }
 
         while ($sum > 0) {
             $sum -= 97;
         }
-        $sum = $sum * -1;
+        $sum *= -1;
 
         return str_pad((string) $sum, 2, '0', STR_PAD_LEFT);
     }

--- a/src/Provider/ms_MY/Person.php
+++ b/src/Provider/ms_MY/Person.php
@@ -795,9 +795,9 @@ class Person extends \Faker\Provider\Person
 
         //Credit: https://gist.github.com/mauris/3629548
         if ($gender === static::GENDER_MALE) {
-            $g = $g | 1;
+            $g |= 1;
         } elseif ($gender === static::GENDER_FEMALE) {
-            $g = $g & ~1;
+            $g &= ~1;
         }
 
         // formatting with hyphen

--- a/src/Provider/pl_PL/Payment.php
+++ b/src/Provider/pl_PL/Payment.php
@@ -113,7 +113,7 @@ class Payment extends \Faker\Provider\Payment
         for ($i = 0; $i < 7; ++$i) {
             $checksum += $weights[$i] * (int) $iban[$i];
         }
-        $checksum = $checksum % 10;
+        $checksum %= 10;
 
         return substr($iban, 0, 7) . $checksum . substr($iban, 8);
     }

--- a/src/Provider/ro_RO/Person.php
+++ b/src/Provider/ro_RO/Person.php
@@ -244,7 +244,7 @@ class Person extends \Faker\Provider\Person
         foreach (range(0, 11) as $digit) {
             $checksum += (int) substr($value, $digit, 1) * (int) substr($checkNumber, $digit, 1);
         }
-        $checksum = $checksum % 11;
+        $checksum %= 11;
 
         return $checksum == 10 ? 1 : $checksum;
     }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] enables the `long_to_shorthand_operator` fixer
- [x] runs `make cs`
- [x] runs `make baseline`

Follows #765.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.27.0/doc/rules/operator/long_to_shorthand_operator.rst.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
