### PR TITLE
Improve address provider for en_NG locale

### DIFF
--- a/src/Provider/en_NG/Address.php
+++ b/src/Provider/en_NG/Address.php
@@ -21,7 +21,7 @@ class Address extends \Faker\Provider\Address
         '{{streetPrefix}} {{lastName}} {{streetSuffix}}',
     ];
 
-    private static $state = [
+    protected static $state = [
         'Abia', 'Adamawa', 'Akwa Ibom', 'Anambra',
         'Bauchi', 'Bayelsa', 'Benue', 'Borno',
         'Cross River',
@@ -69,7 +69,7 @@ class Address extends \Faker\Provider\Address
         'Zambia', 'Zimbabwe',
     ];
 
-    private static $cityName = [
+    protected static $cityName = [
         'Aba', 'Abakaliki', 'Abeokuta', 'Abuja', 'Ado Ekiti', 'Akure', 'Arochukwu', 'Asaba', 'Awka', 'Azare',
         'Badagry', 'Bama', 'Bauchi', 'Benin', 'Bida', 'Birnin Kebbi', 'Biu', 'Bonny Island', 'Brass', 'Bukuru', 'Buguma', 'Burutu', 'Bwari',
         'Calabar',
@@ -92,7 +92,7 @@ class Address extends \Faker\Provider\Address
         'Zaria',
     ];
 
-    private static $region = [
+    protected static $region = [
         'North-Central', 'North-East', 'North-West',
         'South-East', 'South-South', 'South-West',
     ];
@@ -124,7 +124,7 @@ class Address extends \Faker\Provider\Address
      *
      * @return string
      */
-    public function county()
+    public static function county()
     {
         return self::state();
     }

--- a/src/Provider/en_NG/Address.php
+++ b/src/Provider/en_NG/Address.php
@@ -13,7 +13,7 @@ class Address extends \Faker\Provider\Address
     protected static $postcode = ['######'];
 
     protected static $cityFormats = [
-        '{{cityName}}'
+        '{{cityName}}',
     ];
 
     protected static $streetNameFormats = [

--- a/src/Provider/en_NG/Address.php
+++ b/src/Provider/en_NG/Address.php
@@ -120,6 +120,16 @@ class Address extends \Faker\Provider\Address
     }
 
     /**
+     * Alias for <code>self::state()</code>
+     *
+     * @return string
+     */
+    public function county()
+    {
+        return self::state();
+    }
+
+    /**
      * Randomly returns a Nigerian state.
      *
      * @example 'Lagos'

--- a/src/Provider/en_NG/Address.php
+++ b/src/Provider/en_NG/Address.php
@@ -4,14 +4,30 @@ namespace Faker\Provider\en_NG;
 
 class Address extends \Faker\Provider\Address
 {
-    protected static $postcode = ['#####', '## ###'];
+    protected static $citySuffix = [];
 
-    private static $county = [
-        'Abuja', 'Abia', 'Adamawa', 'Akwa Ibom', 'Anambra',
+    protected static $streetPrefix = ['Chief', 'Dr.', 'Alhaji', 'General', 'Bishop', 'Rev.'];
+
+    protected static $streetSuffix = ['Street', 'Avenue', 'Close', 'Boulevard', 'Way'];
+
+    protected static $postcode = ['######'];
+
+    protected static $cityFormats = [
+        '{{cityName}}'
+    ];
+
+    protected static $streetNameFormats = [
+        '{{lastName}} {{streetSuffix}}',
+        '{{streetPrefix}} {{lastName}} {{streetSuffix}}',
+    ];
+
+    private static $state = [
+        'Abia', 'Adamawa', 'Akwa Ibom', 'Anambra',
         'Bauchi', 'Bayelsa', 'Benue', 'Borno',
         'Cross River',
         'Delta',
         'Ebonyi', 'Edo', 'Ekiti', 'Enugu', 'Gombe',
+        'Federal Capital Territory',
         'Imo', 'Jigawa',
         'Kaduna', 'Kano', 'Katsina', 'Kebbi', 'Kogi', 'Kwara',
         'Lagos',
@@ -53,46 +69,77 @@ class Address extends \Faker\Provider\Address
         'Zambia', 'Zimbabwe',
     ];
 
-    private static $regions = [
-        'Abakaliki', 'Abeokuta', 'Akure', 'Asaba', 'Awka',
-        'Bauchi',
-        'Calabar', 'City',
-        'Damaturu', 'Dutse',
-        'Ekiti', 'Enugu',
-        'Gombe', 'Gusau',
-        'Ibadan', 'Ikeja', 'Ilorin',
-        'Jalingo', 'Jos',
-        'Kaduna', 'Kano', 'Katsina', 'Kebbi',
-        'Lafia', 'Lokoja',
-        'Maiduguri', 'Makurdi', 'Minna',
-        'Oshogbo', 'Owerri',
-        'Port-Harcourt',
-        'Sokoto',
-        'Umuahia', 'Uyo',
+    private static $cityName = [
+        'Aba', 'Abakaliki', 'Abeokuta', 'Abuja', 'Ado Ekiti', 'Akure', 'Arochukwu', 'Asaba', 'Awka', 'Azare',
+        'Badagry', 'Bama', 'Bauchi', 'Benin', 'Bida', 'Birnin Kebbi', 'Biu', 'Bonny Island', 'Brass', 'Bukuru', 'Buguma', 'Burutu', 'Bwari',
+        'Calabar',
+        'Damaturu', 'Deba Habe', 'Degema', 'Dikwa', 'Dutse',
+        'Effom-Alaiye', 'Ekiti', 'Eleme', 'Enugu', 'Epe',
+        'Garki', 'Gashua', 'Gboko', 'Gombe', 'Gusau', 'Gwagwalada',
+        'Ibadan', 'Idah', 'Ijebu-Ode', 'Ikare', 'Ikeja', 'Ikorodu', 'Ikot Abasi', 'Ikot Ekpene', 'Ilaro', 'Ile-Ife', 'Ilesa', 'Ilorin',
+        'Jalingo', "Jama'are", 'Jebba', 'Jimeta', 'Jos',
+        'Kabba', 'Kaduna', 'Kano', 'Katagum', 'Katsina', 'Kaura Namoda', 'Kebbi', 'Keffi', 'Koko', 'Kontagora', 'Kukawa', 'Kuje', 'Kwali',
+        'Lafia', 'Lapai', 'Lekki', 'Lokoja',
+        'Maiduguri', 'Makurdi', 'Mubi', 'Minna', 'Misau', 'Mushin',
+        'Nsukka', 'Numan',
+        'Obafemi-Owode', 'Oka-Akoko', 'Okene', 'Okrika', 'Okpoko', 'Ogbomosho', 'Ogoja', 'Ondo', 'Onitsha', 'Oron', 'Oshogbo', 'Otukpo', 'Owerri', 'Owo',
+        'Port-Harcourt', 'Pategi',
+        'Sagamu', 'Sapele', 'Sokoto', 'Suleja',
+        'Ugep', 'Ughelli', 'Umuahia', 'Uromi', 'Uyo',
+        'Victoria Island', 'Vom',
+        'Warri', 'Wase',
         'Yenagoa', 'Yola',
+        'Zaria',
+    ];
+
+    private static $region = [
+        'North-Central', 'North-East', 'North-West',
+        'South-East', 'South-South', 'South-West',
     ];
 
     /**
-     * Randomly returns a Nigerian state or county.
-     *
-     * @example 'Lagos'
+     * @example 'Chief'
      *
      * @return string
      */
-    public static function county()
+    public static function streetPrefix()
     {
-        return static::randomElement(static::$county);
+        return static::randomElement(static::$streetPrefix);
     }
 
     /**
-     * Randomly returns a Nigerian region of a state.
+     * Randomly returns a Nigerian city.
      *
      * @example 'Ikeja'
      *
      * @return string
      */
+    public static function cityName()
+    {
+        return static::randomElement(static::$cityName);
+    }
+
+    /**
+     * Randomly returns a Nigerian state.
+     *
+     * @example 'Lagos'
+     *
+     * @return string
+     */
+    public static function state()
+    {
+        return static::randomElement(static::$state);
+    }
+
+    /**
+     * Randomly returns a Nigerian region.
+     *
+     * @example 'South-South'
+     *
+     * @return string
+     */
     public static function region()
     {
-        return static::randomElement(static::$regions);
+        return static::randomElement(static::$region);
     }
 }

--- a/test/Provider/en_NG/AddressTest.php
+++ b/test/Provider/en_NG/AddressTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Faker\Provider\en_NG;
+namespace Faker\Test\Provider\en_NG;
 
+use Faker\Provider\en_NG\Address;
+use Faker\Provider\en_NG\Person;
 use Faker\Test\TestCase;
 
 /**
@@ -17,17 +19,34 @@ final class AddressTest extends TestCase
 
         self::assertNotEmpty($postcode);
         self::assertIsString($postcode);
+        self::assertEquals(6, strlen($postcode));
+    }
+
+    public function testStreetNameIsAValidString(): void
+    {
+        $streetName = $this->faker->streetName();
+
+        self::assertNotEmpty($streetName);
+        self::assertIsString($streetName);
+    }
+
+    public function testCityNameIsAValidString(): void
+    {
+        $city = $this->faker->city();
+
+        self::assertNotEmpty($city);
+        self::assertIsString($city);
     }
 
     /**
-     * Test the name of the Nigerian State/County
+     * Test the name of the Nigerian State
      */
-    public function testCountyIsAValidString(): void
+    public function testStateIsAValidString(): void
     {
-        $county = $this->faker->county;
+        $state = $this->faker->state();
 
-        self::assertNotEmpty($county);
-        self::assertIsString($county);
+        self::assertNotEmpty($state);
+        self::assertIsString($state);
     }
 
     /**
@@ -35,7 +54,7 @@ final class AddressTest extends TestCase
      */
     public function testRegionIsAValidString(): void
     {
-        $region = $this->faker->region;
+        $region = $this->faker->region();
 
         self::assertNotEmpty($region);
         self::assertIsString($region);
@@ -44,5 +63,7 @@ final class AddressTest extends TestCase
     protected function getProviders(): iterable
     {
         yield new Address($this->faker);
+
+        yield new Person($this->faker);
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

To improve the address data generated for the en_NG locale.  

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

- Renamed 'Abuja' to 'Federal Capital Territory'. Abuja is the name of a city and government administration area, but not a state.
- Postcodes in Nigeria are strictly made up of 6 digits. The `$postcode` variable has been updated to reflect that.
- Updated 'county' to act as an alias of 'state' - which is the actual term used to refer to the major sub-administrative governments directly below the Federal.
- City names in Nigeria do not require a suffix. Hence, the array has been left empty.
- It's common to see street names in Nigeria with prefixes such as 'Chief', 'General', 'Rev.', 'Bishop'. The street name format has been updated to reflect this.
- 'Region' in Nigeria typically refers to the political regional divisions of the country, and not cities. Hence, `cityName` has been added (instead) to reflect actual city names, and `region` has been updated to reflect the political regional divisions of Nigeria.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer