### PR TITLE
Add missing e164 format for Switzerland French

### DIFF
--- a/src/Provider/fr_CH/PhoneNumber.php
+++ b/src/Provider/fr_CH/PhoneNumber.php
@@ -31,6 +31,10 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         '079#######',
     ];
 
+    protected static $e164Formats = [
+        '+41##########',
+    ];
+
     /**
      * Return a Swiss mobile phone number.
      *


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [X] A new feature

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

I added the missing e164 format for Switzerland french (which was present for German but not for French).

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
