### PR TITLE
Add safeIpv4 and safeIpv6

### DIFF
--- a/src/Provider/Internet.php
+++ b/src/Provider/Internet.php
@@ -255,6 +255,32 @@ class Internet extends Base
     }
 
     /**
+     * @example '192.0.2.1'
+     *
+     * @return string
+     */
+    public static function safeIpv4()
+    {
+        return '192.0.2.' . static::numberBetween(0, 255);
+    }
+
+    /**
+     * @example '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff'
+     *
+     * @return string
+     */
+    public static function safeIpv6()
+    {
+        $res = ['2001', 'db8'];
+
+        for ($i = 0; $i < 6; ++$i) {
+            $res[] = dechex(self::numberBetween(0, 65535));
+        }
+
+        return implode(':', $res);
+    }
+
+    /**
      * @example '32:F1:39:2F:D6:18'
      *
      * @return string

--- a/test/Provider/InternetTest.php
+++ b/test/Provider/InternetTest.php
@@ -125,6 +125,16 @@ final class InternetTest extends TestCase
         self::assertNotFalse(filter_var($this->faker->ipv6(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
     }
 
+    public function testSafeIpv4(): void
+    {
+        self::assertNotFalse(filter_var($this->faker->safeIpv4(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));
+    }
+
+    public function testSafeIpv6(): void
+    {
+        self::assertNotFalse(filter_var($this->faker->safeIpv6(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+    }
+
     public function testMacAddress(): void
     {
         self::assertNotFalse(filter_var($this->faker->macAddress(), FILTER_VALIDATE_MAC));


### PR DESCRIPTION
### What is the reason for this PR?

Add the posibility to generate "safe" documentation IP addresses:
* [IPv4 Address Blocks Reserved for Documentation](https://datatracker.ietf.org/doc/html/rfc5737)
* [IPv6 Address Prefix Reserved for Documentation](https://datatracker.ietf.org/doc/html/rfc3849)

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Added two new methods:
* `safeIpv4`
* `safeIpv6`

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
