### PR TITLE
Fix: Remove branch alias for `2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,6 @@
         "bamarni-bin": {
             "bin-links": true,
             "forward-command": false
-        },
-        "branch-alias": {
-            "dev-main": "v1.21-dev"
         }
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

- [x] removes the branch alias for `2.0`

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
