### PR TITLE
Fix: Do not use deprecated `MT_RAND_PHP` constant on PHP 8.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,9 +22,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
-        include:
-          - experimental: true
-            php-version: "8.3"
+          - "8.3"
 
     runs-on: "ubuntu-latest"
 
@@ -57,4 +55,3 @@ jobs:
 
       - name: "Run tests"
         run: "./vendor/bin/phpunit --colors=always"
-        continue-on-error: "${{ matrix.experimental }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed polish license plates (#685)
 - Stopped using `static` in callables in `Provider\pt_BR\PhoneNumber` (#785)
 - Fixed incorrect female name (#794)
+- Stopped using the deprecated `MT_RAND_PHP` constant to seed the random generator on PHP 8.3 (#844)
 
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -687,8 +687,20 @@ class Generator
         if ($seed === null) {
             mt_srand();
         } else {
-            mt_srand((int) $seed, MT_RAND_PHP);
+            mt_srand((int) $seed, self::mode());
         }
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/migration83.deprecated.php#migration83.deprecated.random
+     */
+    private static function mode(): int
+    {
+        if (PHP_VERSION_ID < 80300) {
+            return MT_RAND_PHP;
+        }
+
+        return MT_RAND_MT19937;
     }
 
     public function format($format, $arguments = [])

--- a/test/Faker/Core/DateTimeTest.php
+++ b/test/Faker/Core/DateTimeTest.php
@@ -24,6 +24,9 @@ final class DateTimeTest extends TestCase
         $this->extension = $this->faker->ext(DateTimeExtension::class);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTime(): void
     {
         $dateTime = $this->extension->dateTime('2005-10-19T14:12:00');
@@ -32,6 +35,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(new \DateTime('1990-09-29T12:12:53'), $dateTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeWithTimezone(): void
     {
         $dateTime = $this->extension->dateTime('2021-09-05T15:10:00', 'America/Los_Angeles');
@@ -41,6 +47,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(new \DateTimeZone('America/Los_Angeles'), $dateTime->getTimezone());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeAD(): void
     {
         $dateTime = $this->extension->dateTimeAD('2012-04-12T19:22:23');
@@ -49,6 +58,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(new \DateTime('1166-06-01T17:43:42'), $dateTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeBetween(): void
     {
         $dateTime = $this->extension->dateTimeBetween('1998-12-18T11:23:40', '2004-09-15T22:10:45');
@@ -63,6 +75,9 @@ final class DateTimeTest extends TestCase
         $this->extension->dateTimeBetween('2004-09-15T22:10:45', '1998-12-18T11:23:40');
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeInInterval(): void
     {
         $dateTime = $this->extension->dateTimeInInterval('1999-07-16T17:30:12', '+2 years');
@@ -120,6 +135,9 @@ final class DateTimeTest extends TestCase
         self::assertLessThanOrEqual(new \DateTime('now'), $dateTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDate(): void
     {
         $date = $this->extension->date('Y-m-d', '2102-11-12T14:45:29');
@@ -128,6 +146,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('2046-12-26', $date);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testTime(): void
     {
         $time = $this->extension->time('H:i:s', '1978-06-27T09:43:21');
@@ -136,6 +157,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('21:59:44', $time);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUnixTime(): void
     {
         $unixTime = $this->extension->unixTime('1993-08-29T15:10:00');
@@ -144,6 +168,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(432630664, $unixTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUnitTimeWithNumericUntil(): void
     {
         $unixTime = $this->extension->unixTime(1643830258);
@@ -152,6 +179,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(952499510, $unixTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testIso8601(): void
     {
         $iso8601 = $this->extension->iso8601('1993-07-11T15:10:00');
@@ -170,6 +200,9 @@ final class DateTimeTest extends TestCase
         self::assertContains($amPm, ['am', 'pm']);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDayOfMonth(): void
     {
         $dayOfMonth = $this->extension->dayOfMonth('2001-04-29T15:10:12');
@@ -178,6 +211,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('25', $dayOfMonth);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDayOfWeek(): void
     {
         $dayOfWeek = $this->extension->dayOfWeek('2021-12-12T15:10:00');
@@ -186,6 +222,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('Monday', $dayOfWeek);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMonth(): void
     {
         $month = $this->extension->month('2021-05-23T15:10:00');
@@ -194,6 +233,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('10', $month);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMonthName(): void
     {
         $monthName = $this->extension->monthName('2021-06-06T15:10:00');
@@ -202,6 +244,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('October', $monthName);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testYear(): void
     {
         $year = $this->extension->year('2021-09-12T15:10:00');
@@ -210,6 +255,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('1999', $year);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testCentury(): void
     {
         $century = $this->extension->century();

--- a/test/Faker/Core/UuidTest.php
+++ b/test/Faker/Core/UuidTest.php
@@ -14,6 +14,9 @@ final class UuidTest extends TestCase
         self::assertTrue($this->isUuid($uuid));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUuidExpectedSeed(): void
     {
         $instance = new Uuid();

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -245,6 +245,9 @@ final class GeneratorTest extends TestCase
         self::assertNotSame($uniqueGenerator, $generator->unique(true));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUniqueReturnsUniqueGeneratorThatGeneratesUniqueValues(): void
     {
         $words = [

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -410,6 +410,8 @@ final class BaseTest extends TestCase
 
     /**
      * @see https://github.com/fzaninotto/Faker/issues/265
+     *
+     * @requires PHP < 8.3
      */
     public function testOptionalPercentageAndWeight(): void
     {

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -42,6 +42,9 @@ final class BiasedTest extends TestCase
         }
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testLinearHigh(): void
     {
         $this->performFake(['\Faker\Provider\Biased', 'linearHigh']);

--- a/test/Faker/Provider/UuidTest.php
+++ b/test/Faker/Provider/UuidTest.php
@@ -16,6 +16,9 @@ final class UuidTest extends TestCase
         self::assertTrue($this->isUuid($uuid));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUuidExpectedSeed(): void
     {
         if (pack('L', 0x6162797A) == pack('N', 0x6162797A)) {

--- a/test/Faker/Provider/en_GB/CompanyTest.php
+++ b/test/Faker/Provider/en_GB/CompanyTest.php
@@ -26,6 +26,9 @@ final class CompanyTest extends TestCase
         $this->faker->calculateModulus97(123);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testVat(): void
     {
         $this->assertDefaultVatFormat($this->faker->vat());
@@ -37,6 +40,9 @@ final class CompanyTest extends TestCase
         self::assertEquals(1, preg_match('/^GB[\d]{3} [\d]{4} [\d]{2}$/', $number));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testVatBranchType(): void
     {
         $number = $this->faker->vat(Company::VAT_TYPE_BRANCH);

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -23,6 +23,8 @@ final class PersonTest extends TestCase
     }
 
     /**
+     * @requires PHP < 8.3
+     *
      * @dataProvider provideSeedAndExpectedReturn
      */
     public function testPersonalIdentityNumberUsesBirthDateIfProvided($seed, $birthdate, $expected): void

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -18,12 +18,18 @@ final class AddressTest extends TestCase
         self::assertMatchesRegularExpression('@^\d{5}$@', $postcode);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testSecondaryAddress(): void
     {
         self::assertEquals('Étage 007', $this->faker->secondaryAddress());
         self::assertEquals('Bât. 932', $this->faker->secondaryAddress());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testRegion(): void
     {
         self::assertEquals('Occitanie', $this->faker->region());

--- a/test/Faker/Provider/fr_FR/ColorTest.php
+++ b/test/Faker/Provider/fr_FR/ColorTest.php
@@ -10,12 +10,18 @@ use Faker\Test\TestCase;
  */
 final class ColorTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testColorName(): void
     {
         self::assertEquals('Mandarine', $this->faker->colorName());
         self::assertEquals('Acajou', $this->faker->colorName());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testSafeColorName(): void
     {
         self::assertEquals('bleu', $this->faker->safeColorName());

--- a/test/Faker/Provider/hu_HU/PersonTest.php
+++ b/test/Faker/Provider/hu_HU/PersonTest.php
@@ -10,6 +10,9 @@ use Faker\Test\TestCase;
  */
 final class PersonTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testValidMariedFemaleLastnames(): void
     {
         self::assertEquals('Báró Vassné Zsóka', $this->faker->name('female'));

--- a/test/Faker/Provider/ja_JP/InternetTest.php
+++ b/test/Faker/Provider/ja_JP/InternetTest.php
@@ -10,11 +10,17 @@ use Faker\Test\TestCase;
  */
 final class InternetTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUserName(): void
     {
         self::assertEquals('akira72', $this->faker->userName);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDomainName(): void
     {
         self::assertEquals('nakajima.com', $this->faker->domainName);

--- a/test/Faker/Provider/ja_JP/PersonTest.php
+++ b/test/Faker/Provider/ja_JP/PersonTest.php
@@ -10,26 +10,41 @@ use Faker\Test\TestCase;
  */
 final class PersonTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testKanaNameMaleReturns(): void
     {
         self::assertEquals('アオタ ミノル', $this->faker->kanaName('male'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testKanaNameFemaleReturns(): void
     {
         self::assertEquals('アオタ ミキ', $this->faker->kanaName('female'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstKanaNameMaleReturns(): void
     {
         self::assertEquals('ヒデキ', $this->faker->firstKanaName('male'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstKanaNameFemaleReturns(): void
     {
         self::assertEquals('マアヤ', $this->faker->firstKanaName('female'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testLastKanaNameReturnsNakajima(): void
     {
         self::assertEquals('ナカジマ', $this->faker->lastKanaName);

--- a/test/Faker/Provider/pl_PL/ColorTest.php
+++ b/test/Faker/Provider/pl_PL/ColorTest.php
@@ -10,12 +10,18 @@ use Faker\Test\TestCase;
  */
 final class ColorTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testColorName(): void
     {
         self::assertEquals('mysi', $this->faker->colorName());
         self::assertEquals('alabastrowy', $this->faker->colorName());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testSafeColorName(): void
     {
         self::assertEquals('żółty', $this->faker->safeColorName());

--- a/test/Faker/Provider/ru_RU/PersonTest.php
+++ b/test/Faker/Provider/ru_RU/PersonTest.php
@@ -32,6 +32,8 @@ final class PersonTest extends TestCase
     }
 
     /**
+     * @requires PHP < 8.3
+     *
      * @dataProvider dataLastNameMale
      */
     public function testLastNameMale(int $seed, string $expected): void
@@ -78,6 +80,8 @@ final class PersonTest extends TestCase
     }
 
     /**
+     * @requires PHP < 8.3
+     *
      * @dataProvider dataLastNameFemale
      */
     public function testLastNameFemale(int $seed, string $expected): void
@@ -125,6 +129,8 @@ final class PersonTest extends TestCase
 
     /**
      * Issue 832
+     *
+     * @requires PHP < 8.3
      *
      * @dataProvider dataFemaleSurnameWithoutDoubleALetter
      */

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -23,6 +23,8 @@ final class PersonTest extends TestCase
     }
 
     /**
+     * @requires PHP < 8.3
+     *
      * @dataProvider provideSeedAndExpectedReturn
      */
     public function testPersonalIdentityNumberUsesBirthDateIfProvided($seed, $birthdate, $expected): void

--- a/test/Faker/Provider/uk_UA/PersonTest.php
+++ b/test/Faker/Provider/uk_UA/PersonTest.php
@@ -10,26 +10,41 @@ use Faker\Test\TestCase;
  */
 final class PersonTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstNameMaleReturns(): void
     {
         self::assertEquals('Максим', $this->faker->firstNameMale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstNameFemaleReturns(): void
     {
         self::assertEquals('Людмила', $this->faker->firstNameFemale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMiddleNameMaleReturns(): void
     {
         self::assertEquals('Миколайович', $this->faker->middleNameMale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMiddleNameFemaleReturns(): void
     {
         self::assertEquals('Миколаївна', $this->faker->middleNameFemale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testLastNameReturns(): void
     {
         self::assertEquals('Броваренко', $this->faker->lastName());


### PR DESCRIPTION
### What is the reason for this PR?

- [x] requires tests to pass on PHP 8.3
- [x] stops using the deprecated `MT_RAND_PHP` constant on PHP 8.3 
- [x] skips tests failing on PHP 8.3 when running on PHP 8.3 and above

Fixes #694.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
