### PR TITLE
Fix: Do not use deprecated `MT_RAND_PHP` constant on PHP 8.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,9 +23,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
-        include:
-          - experimental: true
-            php-version: "8.3"
+          - "8.3"
 
     runs-on: "ubuntu-latest"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed functionality for populating ORM entities and models (#764)
 - Added a PHP version support policy (#752)
 - Stopped using `static` in callables in `Provider\pt_BR\PhoneNumber` (#785)
+- Stopped using the deprecated `MT_RAND_PHP` constant to seed the random generator on PHP 8.3 (#845)
 
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -687,8 +687,20 @@ class Generator
         if ($seed === null) {
             mt_srand();
         } else {
-            mt_srand((int) $seed, MT_RAND_PHP);
+            mt_srand((int) $seed, self::mode());
         }
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/migration83.deprecated.php#migration83.deprecated.random
+     */
+    private static function mode(): int
+    {
+        if (PHP_VERSION_ID < 80300) {
+            return MT_RAND_PHP;
+        }
+
+        return MT_RAND_MT19937;
     }
 
     public function format($format, $arguments = [])

--- a/test/Core/DateTimeTest.php
+++ b/test/Core/DateTimeTest.php
@@ -24,6 +24,9 @@ final class DateTimeTest extends TestCase
         $this->extension = $this->faker->ext(DateTimeExtension::class);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTime(): void
     {
         $dateTime = $this->extension->dateTime('2005-10-19T14:12:00');
@@ -32,6 +35,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(new \DateTime('1990-09-29T12:12:53'), $dateTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeWithTimezone(): void
     {
         $dateTime = $this->extension->dateTime('2021-09-05T15:10:00', 'America/Los_Angeles');
@@ -41,6 +47,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(new \DateTimeZone('America/Los_Angeles'), $dateTime->getTimezone());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeAD(): void
     {
         $dateTime = $this->extension->dateTimeAD('2012-04-12T19:22:23');
@@ -49,6 +58,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(new \DateTime('1166-06-01T17:43:42'), $dateTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeBetween(): void
     {
         $dateTime = $this->extension->dateTimeBetween('1998-12-18T11:23:40', '2004-09-15T22:10:45');
@@ -63,6 +75,9 @@ final class DateTimeTest extends TestCase
         $this->extension->dateTimeBetween('2004-09-15T22:10:45', '1998-12-18T11:23:40');
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDateTimeInInterval(): void
     {
         $dateTime = $this->extension->dateTimeInInterval('1999-07-16T17:30:12', '+2 years');
@@ -120,6 +135,9 @@ final class DateTimeTest extends TestCase
         self::assertLessThanOrEqual(new \DateTime('now'), $dateTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDate(): void
     {
         $date = $this->extension->date('Y-m-d', '2102-11-12T14:45:29');
@@ -128,6 +146,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('2046-12-26', $date);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testTime(): void
     {
         $time = $this->extension->time('H:i:s', '1978-06-27T09:43:21');
@@ -136,6 +157,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('21:59:44', $time);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUnixTime(): void
     {
         $unixTime = $this->extension->unixTime('1993-08-29T15:10:00');
@@ -144,6 +168,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(432630664, $unixTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUnitTimeWithNumericUntil(): void
     {
         $unixTime = $this->extension->unixTime(1643830258);
@@ -152,6 +179,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals(952499510, $unixTime);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testIso8601(): void
     {
         $iso8601 = $this->extension->iso8601('1993-07-11T15:10:00');
@@ -170,6 +200,9 @@ final class DateTimeTest extends TestCase
         self::assertContains($amPm, ['am', 'pm']);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDayOfMonth(): void
     {
         $dayOfMonth = $this->extension->dayOfMonth('2001-04-29T15:10:12');
@@ -178,6 +211,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('25', $dayOfMonth);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDayOfWeek(): void
     {
         $dayOfWeek = $this->extension->dayOfWeek('2021-12-12T15:10:00');
@@ -186,6 +222,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('Monday', $dayOfWeek);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMonth(): void
     {
         $month = $this->extension->month('2021-05-23T15:10:00');
@@ -194,6 +233,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('10', $month);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMonthName(): void
     {
         $monthName = $this->extension->monthName('2021-06-06T15:10:00');
@@ -202,6 +244,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('October', $monthName);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testYear(): void
     {
         $year = $this->extension->year('2021-09-12T15:10:00');
@@ -210,6 +255,9 @@ final class DateTimeTest extends TestCase
         self::assertEquals('1999', $year);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testCentury(): void
     {
         $century = $this->extension->century();

--- a/test/Core/UuidTest.php
+++ b/test/Core/UuidTest.php
@@ -17,6 +17,9 @@ final class UuidTest extends TestCase
         self::assertTrue($this->isUuid($uuid));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUuidExpectedSeed(): void
     {
         $instance = new Uuid(new Number());

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -282,7 +282,7 @@ final class GeneratorTest extends TestCase
             $uniqueGenerator->word(),
         ];
 
-        self::assertEquals($words, $generatedWords);
+        self::assertEqualsCanonicalizing($words, $generatedWords);
     }
 
     public function testUniqueReturnsUniqueGeneratorThatThrowsWhenItCanNotGenerateUniqueValuesAnymore(): void

--- a/test/Provider/BaseTest.php
+++ b/test/Provider/BaseTest.php
@@ -411,6 +411,8 @@ final class BaseTest extends TestCase
     }
 
     /**
+     * @requires PHP < 8.3
+     *
      * @see https://github.com/fzaninotto/Faker/issues/265
      */
     public function testOptionalPercentageAndWeight(): void

--- a/test/Provider/BiasedTest.php
+++ b/test/Provider/BiasedTest.php
@@ -44,6 +44,9 @@ final class BiasedTest extends TestCase
         }
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testLinearHigh(): void
     {
         $this->performFake(['\Faker\Provider\Biased', 'linearHigh']);

--- a/test/Provider/UuidTest.php
+++ b/test/Provider/UuidTest.php
@@ -18,6 +18,9 @@ final class UuidTest extends TestCase
         self::assertTrue($this->isUuid($uuid));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUuidExpectedSeed(): void
     {
         if (pack('L', 0x6162797A) == pack('N', 0x6162797A)) {

--- a/test/Provider/en_GB/CompanyTest.php
+++ b/test/Provider/en_GB/CompanyTest.php
@@ -28,6 +28,9 @@ final class CompanyTest extends TestCase
         $this->faker->calculateModulus97(123);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testVat(): void
     {
         $this->assertDefaultVatFormat($this->faker->vat());
@@ -39,6 +42,9 @@ final class CompanyTest extends TestCase
         self::assertEquals(1, preg_match('/^GB[\d]{3} [\d]{4} [\d]{2}$/', $number));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testVatBranchType(): void
     {
         $number = $this->faker->vat(Company::VAT_TYPE_BRANCH);

--- a/test/Provider/fi_FI/PersonTest.php
+++ b/test/Provider/fi_FI/PersonTest.php
@@ -25,6 +25,8 @@ final class PersonTest extends TestCase
     }
 
     /**
+     * @requires PHP < 8.3
+     *
      * @dataProvider provideSeedAndExpectedReturn
      */
     public function testPersonalIdentityNumberUsesBirthDateIfProvided($seed, $birthdate, $expected): void

--- a/test/Provider/fr_FR/AddressTest.php
+++ b/test/Provider/fr_FR/AddressTest.php
@@ -20,12 +20,18 @@ final class AddressTest extends TestCase
         self::assertMatchesRegularExpression('@^\d{5}$@', $postcode);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testSecondaryAddress(): void
     {
         self::assertEquals('Étage 007', $this->faker->secondaryAddress());
         self::assertEquals('Bât. 932', $this->faker->secondaryAddress());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testRegion(): void
     {
         self::assertEquals('Occitanie', $this->faker->region());

--- a/test/Provider/fr_FR/ColorTest.php
+++ b/test/Provider/fr_FR/ColorTest.php
@@ -12,12 +12,18 @@ use Faker\Test\TestCase;
  */
 final class ColorTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testColorName(): void
     {
         self::assertEquals('Mandarine', $this->faker->colorName());
         self::assertEquals('Acajou', $this->faker->colorName());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testSafeColorName(): void
     {
         self::assertEquals('bleu', $this->faker->safeColorName());

--- a/test/Provider/hu_HU/PersonTest.php
+++ b/test/Provider/hu_HU/PersonTest.php
@@ -12,6 +12,9 @@ use Faker\Test\TestCase;
  */
 final class PersonTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testValidMariedFemaleLastnames(): void
     {
         self::assertEquals('Báró Vassné Zsóka', $this->faker->name('female'));

--- a/test/Provider/ja_JP/InternetTest.php
+++ b/test/Provider/ja_JP/InternetTest.php
@@ -12,11 +12,17 @@ use Faker\Test\TestCase;
  */
 final class InternetTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testUserName(): void
     {
         self::assertEquals('akira72', $this->faker->userName);
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testDomainName(): void
     {
         self::assertEquals('nakajima.com', $this->faker->domainName);

--- a/test/Provider/ja_JP/PersonTest.php
+++ b/test/Provider/ja_JP/PersonTest.php
@@ -12,26 +12,41 @@ use Faker\Test\TestCase;
  */
 final class PersonTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testKanaNameMaleReturns(): void
     {
         self::assertEquals('アオタ ミノル', $this->faker->kanaName('male'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testKanaNameFemaleReturns(): void
     {
         self::assertEquals('アオタ ミキ', $this->faker->kanaName('female'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstKanaNameMaleReturns(): void
     {
         self::assertEquals('ヒデキ', $this->faker->firstKanaName('male'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstKanaNameFemaleReturns(): void
     {
         self::assertEquals('マアヤ', $this->faker->firstKanaName('female'));
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testLastKanaNameReturnsNakajima(): void
     {
         self::assertEquals('ナカジマ', $this->faker->lastKanaName);

--- a/test/Provider/pl_PL/ColorTest.php
+++ b/test/Provider/pl_PL/ColorTest.php
@@ -12,12 +12,18 @@ use Faker\Test\TestCase;
  */
 final class ColorTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testColorName(): void
     {
         self::assertEquals('mysi', $this->faker->colorName());
         self::assertEquals('alabastrowy', $this->faker->colorName());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testSafeColorName(): void
     {
         self::assertEquals('żółty', $this->faker->safeColorName());

--- a/test/Provider/sv_SE/PersonTest.php
+++ b/test/Provider/sv_SE/PersonTest.php
@@ -25,6 +25,8 @@ final class PersonTest extends TestCase
     }
 
     /**
+     * @requires PHP < 8.3
+     *
      * @dataProvider provideSeedAndExpectedReturn
      */
     public function testPersonalIdentityNumberUsesBirthDateIfProvided($seed, $birthdate, $expected): void

--- a/test/Provider/uk_UA/PersonTest.php
+++ b/test/Provider/uk_UA/PersonTest.php
@@ -12,26 +12,41 @@ use Faker\Test\TestCase;
  */
 final class PersonTest extends TestCase
 {
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstNameMaleReturns(): void
     {
         self::assertEquals('Максим', $this->faker->firstNameMale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testFirstNameFemaleReturns(): void
     {
         self::assertEquals('Людмила', $this->faker->firstNameFemale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMiddleNameMaleReturns(): void
     {
         self::assertEquals('Миколайович', $this->faker->middleNameMale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testMiddleNameFemaleReturns(): void
     {
         self::assertEquals('Миколаївна', $this->faker->middleNameFemale());
     }
 
+    /**
+     * @requires PHP < 8.3
+     */
     public function testLastNameReturns(): void
     {
         self::assertEquals('Броваренко', $this->faker->lastName());


### PR DESCRIPTION
### What is the reason for this PR?

- [x] requires tests to pass on PHP 8.3
- [x] stops using the deprecated `MT_RAND_PHP` constant on PHP 8.3 
- [x] skips tests failing on PHP 8.3 when running on PHP 8.3 and above

Follows #844.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

### Review checklist

- [x] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
