### PR TITLE
Feature: Unique key

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -618,10 +618,10 @@ class Generator
      * $faker->unique()->randomElement(array(1, 2, 3));
      * </code>
      *
-     * @param bool $reset      If set to true, resets the list of existing values
-     * @param int  $maxRetries Maximum number of retries to find a unique value,
-     *                         After which an OverflowException is thrown.
-     * @param string  $key Unique identifier to allow multiple independent UniqueGenerator instances
+     * @param bool   $reset      If set to true, resets the list of existing values
+     * @param int    $maxRetries Maximum number of retries to find a unique value,
+     *                           After which an OverflowException is thrown.
+     * @param string $key        Unique identifier to allow multiple independent UniqueGenerator instances
      *
      * @throws \OverflowException When no unique value can be found by iterating $maxRetries times
      *
@@ -629,7 +629,7 @@ class Generator
      */
     public function unique($reset = false, $maxRetries = 10000, $key = 'default')
     {
-        if ($reset || ! array_key_exists($key, $this->uniqueGenerators)) {
+        if ($reset || !array_key_exists($key, $this->uniqueGenerators)) {
             $this->uniqueGenerators[$key] = new UniqueGenerator($this, $maxRetries);
         }
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -561,9 +561,9 @@ class Generator
     private $container;
 
     /**
-     * @var UniqueGenerator
+     * @var array<UniqueGenerator>
      */
-    private $uniqueGenerator;
+    private $uniqueGenerators = [];
 
     public function __construct(ContainerInterface $container = null)
     {
@@ -621,18 +621,19 @@ class Generator
      * @param bool $reset      If set to true, resets the list of existing values
      * @param int  $maxRetries Maximum number of retries to find a unique value,
      *                         After which an OverflowException is thrown.
+     * @param string  $key Unique identifier to allow multiple independent UniqueGenerator instances
      *
      * @throws \OverflowException When no unique value can be found by iterating $maxRetries times
      *
      * @return self A proxy class returning only non-existing values
      */
-    public function unique($reset = false, $maxRetries = 10000)
+    public function unique($reset = false, $maxRetries = 10000, $key = 'default')
     {
-        if ($reset || $this->uniqueGenerator === null) {
-            $this->uniqueGenerator = new UniqueGenerator($this, $maxRetries);
+        if ($reset || ! array_key_exists($key, $this->uniqueGenerators)) {
+            $this->uniqueGenerators[$key] = new UniqueGenerator($this, $maxRetries);
         }
 
-        return $this->uniqueGenerator;
+        return $this->uniqueGenerators[$key];
     }
 
     /**

--- a/test/Faker/UniqueGeneratorTest.php
+++ b/test/Faker/UniqueGeneratorTest.php
@@ -26,4 +26,17 @@ final class UniqueGeneratorTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
+
+    public function testUniqueGeneratorWithKey(): void
+    {
+        for ($i = 0; $i < 10; ++$i) {
+            $this->faker->unique(key: 'id')->ext(NumberExtension::class)->numberBetween(0, 9);
+        }
+
+        for ($i = 0; $i < 10; ++$i) {
+            $this->faker->unique(key: 'order')->ext(NumberExtension::class)->numberBetween(0, 9);
+        }
+
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

When using FakerPHP in database factories, such as in Laravel, I frequently encounter the need for unique values for a specific model or column. For example, unique emails for that model or a non-auto-incrementing ID that needs to be set.

Consider this implementation of a Laravel database factory:

```php
class UserFactory extends Factory
{
    public function definition(): array
    {
        return [
            'external_id' => $this->faker->unique()->numberBetween(0, 99),
        ];
    }
}
```

Because of the `->unique()` method, we obtain a unique `external_id` for each user. However, we may have another model that also requires unique numbers. Ideally, the IDs should be reset for this model. However, calling `->unique(reset: true)` would reset the entire generator, causing it to reset on every call.

```php
class EmployeeFactory extends Factory
{
    public function definition(): array
    {
        return [
            'external_id' => $this->faker->unique(reset: true)->numberBetween(0, 99),
        ];
    }
}
```

Therefore, I propose an option to add a key so that people can have multiple unique generators. This would allow us to have an independent set of unique numbers for both factories and models.

```php
class UserFactory extends Factory
{
    public function definition(): array
    {
        return [
            'external_id' => $this->faker->unique(key: 'user.external_id')->numberBetween(0, 99),
        ];
    }
}

class EmployeeFactory extends Factory
{
    public function definition(): array
    {
        return [
            'external_id' => $this->faker->unique(key: 'employee.external_id')->numberBetween(0, 99),
        ];
    }
}
```

What do you think about this?

I'm not sure whether you consider `$uniqueGenerator` internal or if removing `$uniqueGenerator` and adding `$uniqueGenerators` is considered a breaking change.

Maybe this should be implemented as a new method, but I couldn't think of a better name than `keyedUnique()`. It appears that there is some confusion surrounding the usage of `->unique()` in general.

https://github.com/laravel/framework/issues/46287
https://github.com/laravel/laravel/pull/5137



### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
