### PR TITLE
Support newer version of symfony deprecation-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "psr/container": "^1.0 || ^2.0",
-        "symfony/deprecation-contracts": "^2.2 || ^3.0"
+        "symfony/deprecation-contracts": "^2.2 || ^3.0 || ^3.1 || ^3.2 || ^3.3 || ^3.4"
     },
     "require-dev": {
         "ext-intl": "*",


### PR DESCRIPTION
### What is the reason for this PR?

Support newer version of symfony deprecation-contracts

When trying to install lib https://github.com/web-auth/webauthn-lib v4.7, I get error:

```
Problem 1
    - web-auth/webauthn-lib 4.7.0 requires web-auth/metadata-service 4.7.0 -> satisfiable by web-auth/metadata-service[4.7.0].
    - web-auth/webauthn-lib 4.7.1 requires web-auth/metadata-service 4.7.1 -> satisfiable by web-auth/metadata-service[4.7.1].
    - web-auth/webauthn-lib 4.7.2 requires web-auth/metadata-service 4.7.2 -> satisfiable by web-auth/metadata-service[4.7.2].
    - web-auth/webauthn-lib 4.7.3 requires web-auth/metadata-service 4.7.3 -> satisfiable by web-auth/metadata-service[4.7.3].
    - web-auth/webauthn-lib 4.7.4 requires web-auth/metadata-service 4.7.4 -> satisfiable by web-auth/metadata-service[4.7.4].
    - web-auth/webauthn-lib 4.7.5 requires web-auth/metadata-service 4.7.5 -> satisfiable by web-auth/metadata-service[4.7.5].
    - web-auth/webauthn-lib 4.7.6 requires web-auth/metadata-service 4.7.6 -> satisfiable by web-auth/metadata-service[4.7.6].
    - web-auth/webauthn-lib 4.7.7 requires web-auth/metadata-service 4.7.7 -> satisfiable by web-auth/metadata-service[4.7.7].
    - web-auth/webauthn-lib 4.7.8 requires web-auth/metadata-service 4.7.8 -> satisfiable by web-auth/metadata-service[4.7.8].
    - web-auth/metadata-service[4.7.0, ..., 4.7.8] require symfony/deprecation-contracts ^3.2 -> found symfony/deprecation-contracts[v3.2.0, v3.2.1, v3.3.0, v3.4.0] but these were not loaded, likely because it conflicts with another require.
    - Root composer.json requires web-auth/webauthn-lib ^4.7 -> satisfiable by web-auth/webauthn-lib[4.7.0, ..., 4.7.8].
```

I also user FakerPHP/Faker in same project.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)
- [x] not a issue-fix neither new feature

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Support newer version of symfony deprecation-contracts

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
