### PR TITLE
fix (Doctrine backward-compatibility) Fixed conditional to avoid raise warning when old interface exists

### DIFF
--- a/src/Faker/ORM/Doctrine/backward-compatibility.php
+++ b/src/Faker/ORM/Doctrine/backward-compatibility.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-if (!class_exists('Doctrine\Common\Persistence\Mapping\ClassMetadata')) {
+if (!interface_exists('Doctrine\Common\Persistence\Mapping\ClassMetadata')) {
     class_alias(\Doctrine\Persistence\Mapping\ClassMetadata::class, 'Doctrine\Common\Persistence\Mapping\ClassMetadata');
 }
 
-if (!class_exists('Doctrine\Common\Persistence\ObjectManager')) {
+if (!interface_exists('Doctrine\Common\Persistence\ObjectManager')) {
     class_alias(\Doctrine\Persistence\ObjectManager::class, 'Doctrine\Common\Persistence\ObjectManager');
 }

--- a/test/Faker/ORM/Doctrine/PopulatorTest.php
+++ b/test/Faker/ORM/Doctrine/PopulatorTest.php
@@ -19,5 +19,23 @@ final class PopulatorTest extends TestCase
         $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
 
         self::assertEmpty($populator->execute($objectManager));
+        self::assertEmpty($this->getTestResultObject()->warnings());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testClassGenerationWithBackwardCompatibilityForDoctrineOldInterfaces(): void
+    {
+        // Add old interface to autoloader
+        $loader = new \Composer\Autoload\ClassLoader();
+        $loader->addPsr4('Doctrine\Common\Persistence\Mapping\\', __DIR__ . '/stubs/');
+        $loader->register();
+        
+        $populator = new Populator($this->faker);
+
+        $objectManager = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $populator->execute($objectManager);
+        self::assertEmpty($this->getTestResultObject()->warnings());
     }
 }

--- a/test/Faker/ORM/Doctrine/PopulatorTest.php
+++ b/test/Faker/ORM/Doctrine/PopulatorTest.php
@@ -12,14 +12,13 @@ final class PopulatorTest extends TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testClassGenerationWithBackwardCompatibility(): void
+    public function testCfasdfa(): void
     {
         $populator = new Populator($this->faker);
         // Mock ObjectManager after autoload to test class alias
         $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
 
         self::assertEmpty($populator->execute($objectManager));
-        self::assertEmpty($this->getTestResultObject()->warnings());
     }
 
     /**

--- a/test/Faker/ORM/Doctrine/PopulatorTest.php
+++ b/test/Faker/ORM/Doctrine/PopulatorTest.php
@@ -12,7 +12,7 @@ final class PopulatorTest extends TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testCfasdfa(): void
+    public function testClassGenerationWithBackwardCompatibility(): void
     {
         $populator = new Populator($this->faker);
         // Mock ObjectManager after autoload to test class alias

--- a/test/Faker/ORM/Doctrine/stubs/ClassMetadata.php
+++ b/test/Faker/ORM/Doctrine/stubs/ClassMetadata.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\Common\Persistence\Mapping;
+
+interface ClassMetadata
+{
+    // Agrega aquí los métodos que necesitas para tu prueba
+}

--- a/test/Faker/ORM/Doctrine/stubs/ClassMetadata.php
+++ b/test/Faker/ORM/Doctrine/stubs/ClassMetadata.php
@@ -4,5 +4,5 @@ namespace Doctrine\Common\Persistence\Mapping;
 
 interface ClassMetadata
 {
-    // Agrega aquí los métodos que necesitas para tu prueba
+    // Fake interface for testing purposes
 }


### PR DESCRIPTION
### What is the reason for this PR?

The conditional for old classes of Doctrine is wrong. The `class_exists` method [only works for classes](https://www.php.net/manual/en/function.class-exists.php#125366) but the compatibility is over interfaces.
When you uses an old version of Doctrine, php raise the next warning:

```bash
 Warning: Cannot declare interface Doctrine\Common\Persistence\Mapping\ClassMetadata, because the name is already in use in vendor/fakerphp/faker/src/Faker/ORM/Doctrine/backward-compatibility.php on line 6
```

[ ] A new feature
[ X] Fixed an issue

### Author's checklist

[X ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
[ X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Fixed `backward-compatibility.php` 

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
