### PR TITLE
Add iranian bank cards

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -425,6 +425,10 @@ use Faker\Container\ContainerInterface;
  *
  * @method string creditCardNumber($type = null, $formatted = false, $separator = '-')
  *
+ * @property string $debitCardNumber
+ *
+ * @method string debitCardNumber($type = null, $formatted = false, $separator = '-')
+ *
  * @property \DateTime $creditCardExpirationDate
  *
  * @method \DateTime creditCardExpirationDate($valid = true)

--- a/src/Faker/Provider/fa_IR/Payment.php
+++ b/src/Faker/Provider/fa_IR/Payment.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Faker\Provider\fa_IR;
+
+use Faker\Calculator\Luhn;
+
+class Payment extends \Faker\Provider\Payment
+{
+    protected static $cardVendors = [
+        'Melli', 'Mellat', 'Sepah', 'Saderat', 'Keshavarzi',
+        'Maskan', 'Parsian', 'Saman', 'Sina', 'Shahr', 'Tejarat',
+    ];
+
+    protected static $cardParams = [
+        'Melli' => [
+            '603799##########',
+        ],
+        'Mellat' => [
+            '610433##########',
+        ],
+        'Sepah' => [
+            '589210##########',
+        ],
+        'Saderat' => [
+            '627648##########',
+            '207177##########',
+        ],
+        'Keshavarzi' => [
+            '603770##########',
+            '639217##########',
+        ],
+        'Maskan' => [
+            '628023##########',
+        ],
+        'Parsian' => [
+            '622108##########',
+            '639194##########',
+            '627884##########',
+        ],
+        'Saman' => [
+            '621986##########',
+        ],
+        'Sina' => [
+            '639346##########',
+        ],
+        'Shahr' => [
+            '502806##########',
+            '504806##########',
+        ],
+        'Tejarat' => [
+            '627353##########',
+        ],
+    ];
+
+    /**
+     * Returns the String of an Iranian card number.
+     *
+     * @param string $type      Supporting any of 'Melli', 'Mellat', 'Sepah', 'Saderat', 'Keshavarzi',
+     *                                            'Maskan', 'Parsian', 'Saman', 'Sina', 'Shahr' and 'Tejarat',
+     * @param bool   $formatted Set to true if the output string should contain one separator every 4 digits
+     * @param string $separator Separator string for formatting card number. Defaults to dash (-).
+     *
+     * @return string
+     *
+     * @example '6104337526776537'
+     */
+    public static function debitCardNumber($type = null, $formatted = false, $separator = '-')
+    {
+        return static::creditCardNumber($type, $formatted, $separator);
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

This adds a provider for Iranian Farsi (fa_IR) locale, to provide valid Iranian debit card numbers.

I added the `debitCardNumber` method as an alias, because while the algorithm is the same, there are no credit cards in Iran.

- [x] A new feature

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

I haven't overrode the methods. I've just overrode the arrays that provide payment provider data.

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
