### PR TITLE
only set a new random seed if _the last_ Generator gets destruct'ed

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -561,9 +561,9 @@ class Generator
     private $container;
 
     /**
-     * In order top prevent resetting the seed while another Generator instance is still alive, we keep track of the
-     * total, global number of Generator being "active". Incremented in __construct, decremented in __destruct.
-     * This is necessary, because __destruct modified global state (`mt_srand`).
+     * In order to prevent resetting the seed while another Generator instance is still alive, we keep track of the
+     * total, global number of Generators being "active". Incremented in __construct, decremented in __destruct.
+     * This is necessary, because __destruct modifies global state (`mt_srand`).
      */
     private static int $generatorsAlive = 0;
 

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -11,6 +11,7 @@ use Faker\Core\File;
 use Faker\Extension\BloodExtension;
 use Faker\Extension\ExtensionNotFound;
 use Faker\Extension\FileExtension;
+use Faker\Factory;
 use Faker\Generator;
 use Faker\Provider;
 use Faker\UniqueGenerator;
@@ -326,5 +327,25 @@ final class GeneratorTest extends TestCase
         ));
 
         $uniqueGenerator->word();
+    }
+
+    public function testDestructingOldGeneratorDoesNotResetTheSeed(): void
+    {
+        $faker = Factory::create('en_US');
+        $faker->seed(1);
+
+        $expected1 = $faker->numberBetween(1000, 10000);
+        $expected2 = $faker->numberBetween(1000, 10000);
+        $faker = null;
+
+        for ($i = 0; $i < 3; ++$i) {
+            $faker = Factory::create('en_US');
+            $faker->seed(1);
+            self::assertSame($expected1, $faker->numberBetween(1000, 10000));
+
+            gc_collect_cycles();
+
+            self::assertSame($expected2, $faker->numberBetween(1000, 10000));
+        }
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

In cases where multiple Generator instances might be created, a gc cycle collection run can trigger at any time, potentially removing "old" Generator instances, which then calls __destruct and thus seed, which reset the *global* mt_rand seed, impacting everyone else.

If another, still live instance of Generator gets used after that, its output is no longer deterministic, since a new random seed was set.

- [ ] A new feature
- [x] Fixed an issue (resolve #870 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

I added a new static class property to `Faker\Generator` which counts the number of currently existing Generator instances: It gets incremented in __construct, and decremented in __destruct. Only if this counter reaches 0 does __destruct also call `seed` to restore the system to a "properly random" state.

Using a global counter is, imho, quite ugly, but since `Generator::seed` already modifies global state anyway I think its like fighting fire with fire. 
Other than that, I think its a quite minimal change that does not impact any other use of Faker. Cases that "properly" only ever use exactly one instance of the Generator will not see any difference in behaviour.

It's not a perfect solution by any means. But I think it is a reasonable one.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
