### PR TITLE
Fix issue #759 : The output of the hash generators is misleading 

### DIFF
--- a/src/Provider/Miscellaneous.php
+++ b/src/Provider/Miscellaneous.php
@@ -243,13 +243,29 @@ class Miscellaneous extends Base
     }
 
     /**
+     * Return a string representing a big number, which size is $n * 4 bytes ($n * 32 bits)
+     *
+     * @param int $n multiplier for numberBetween.
+     *
+     * @return string
+     *
+     * @example "38921908753913698485999935526730716"
+     */
+    public static function multiplyNumberBetweenNTimes($n)
+    {
+        return array_reduce(range(1, $n), static function ($carry, $item) {
+            return bcmul($carry, self::numberBetween());
+        }, '1');
+    }
+
+    /**
      * @example 'cfcd208495d565ef66e7dff9f98764da'
      *
      * @return string
      */
     public static function md5()
     {
-        return md5(random_bytes(16));
+        return md5(self::multiplyNumberBetweenNTimes(128 / 32));
     }
 
     /**
@@ -259,7 +275,7 @@ class Miscellaneous extends Base
      */
     public static function sha1()
     {
-        return sha1(random_bytes(20));
+        return sha1(self::multiplyNumberBetweenNTimes(160 / 32));
     }
 
     /**
@@ -269,7 +285,7 @@ class Miscellaneous extends Base
      */
     public static function sha256()
     {
-        return hash('sha256', random_bytes(32));
+        return hash('sha256', self::multiplyNumberBetweenNTimes(256 / 32));
     }
 
     /**

--- a/src/Provider/Miscellaneous.php
+++ b/src/Provider/Miscellaneous.php
@@ -243,49 +243,33 @@ class Miscellaneous extends Base
     }
 
     /**
-     * Return a string representing a big number, which size is $n * 4 bytes ($n * 32 bits)
-     *
-     * @param int $n multiplier for numberBetween.
+     * @example '7c2a5276141e81fdf60015689c53d8a1'
      *
      * @return string
-     *
-     * @example "38921908753913698485999935526730716"
      */
-    public static function multiplyNumberBetweenNTimes($n)
+    public static function md5($seed = null)
     {
-        return array_reduce(range(1, $n), static function ($carry, $item) {
-            return bcmul($carry, self::numberBetween());
-        }, '1');
+        return md5($seed ?? random_bytes(128 / 8));
     }
 
     /**
-     * @example 'cfcd208495d565ef66e7dff9f98764da'
+     * @example '2d37797087b5130d79e51a08fa7f1cf7678c70ab'
      *
      * @return string
      */
-    public static function md5()
+    public static function sha1($seed = null)
     {
-        return md5(self::multiplyNumberBetweenNTimes(128 / 32));
+        return sha1($seed ?? random_bytes(160 / 8));
     }
 
     /**
-     * @example 'b5d86317c2a144cd04d0d7c03b2b02666fafadf2'
+     * @example 'a5aa26c454007319b3458f9a9162822c8c1ac5394c4124186b4d54703d9ac3cd'
      *
      * @return string
      */
-    public static function sha1()
+    public static function sha256($seed = null)
     {
-        return sha1(self::multiplyNumberBetweenNTimes(160 / 32));
-    }
-
-    /**
-     * @example '85086017559ccc40638fcde2fecaf295e0de7ca51b7517b6aebeaaf75b4d4654'
-     *
-     * @return string
-     */
-    public static function sha256()
-    {
-        return hash('sha256', self::multiplyNumberBetweenNTimes(256 / 32));
+        return hash('sha256', $seed ?? random_bytes(256 / 8));
     }
 
     /**

--- a/src/Provider/Miscellaneous.php
+++ b/src/Provider/Miscellaneous.php
@@ -249,7 +249,7 @@ class Miscellaneous extends Base
      */
     public static function md5()
     {
-        return md5(self::numberBetween());
+        return md5(random_bytes(16));
     }
 
     /**
@@ -259,7 +259,7 @@ class Miscellaneous extends Base
      */
     public static function sha1()
     {
-        return sha1(self::numberBetween());
+        return sha1(random_bytes(20));
     }
 
     /**
@@ -269,7 +269,7 @@ class Miscellaneous extends Base
      */
     public static function sha256()
     {
-        return hash('sha256', self::numberBetween());
+        return hash('sha256', random_bytes(32));
     }
 
     /**

--- a/test/Provider/MiscellaneousTest.php
+++ b/test/Provider/MiscellaneousTest.php
@@ -22,14 +22,32 @@ final class MiscellaneousTest extends TestCase
         self::assertMatchesRegularExpression('/^[a-z0-9]{32}$/', Miscellaneous::md5());
     }
 
+    public function testMd5ExpectedSeed(): void
+    {
+        $this->faker->seed(252);
+        self::assertEquals('fa72146b50f73db08c92053d1fc5f263', $this->faker->md5());
+    }
+
     public function testSha1(): void
     {
         self::assertMatchesRegularExpression('/^[a-z0-9]{40}$/', Miscellaneous::sha1());
     }
 
+    public function testSha1ExpectedSeed(): void
+    {
+        $this->faker->seed(252);
+        self::assertEquals('5ecb7a1b22291b6b15e534852e03ac72f4187a48', $this->faker->sha1());
+    }
+
     public function testSha256(): void
     {
         self::assertMatchesRegularExpression('/^[a-z0-9]{64}$/', Miscellaneous::sha256());
+    }
+
+    public function testSha256ExpectedSeed(): void
+    {
+        $this->faker->seed(252);
+        self::assertEquals('ea98b35136e020d9dd9b594252d9263021d1742da2bd4c8592b854c62b4122c2', $this->faker->sha256());
     }
 
     public function testLocale(): void
@@ -60,5 +78,10 @@ final class MiscellaneousTest extends TestCase
     public function testEmoji(): void
     {
         self::assertMatchesRegularExpression('/^[\x{1F600}-\x{1F637}]$/u', Miscellaneous::emoji());
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Miscellaneous($this->faker);
     }
 }

--- a/test/Provider/MiscellaneousTest.php
+++ b/test/Provider/MiscellaneousTest.php
@@ -24,8 +24,7 @@ final class MiscellaneousTest extends TestCase
 
     public function testMd5ExpectedSeed(): void
     {
-        $this->faker->seed(252);
-        self::assertEquals('fa72146b50f73db08c92053d1fc5f263', $this->faker->md5());
+        self::assertEquals('7c2a5276141e81fdf60015689c53d8a1', $this->faker->md5('seed_123'));
     }
 
     public function testSha1(): void
@@ -35,8 +34,7 @@ final class MiscellaneousTest extends TestCase
 
     public function testSha1ExpectedSeed(): void
     {
-        $this->faker->seed(252);
-        self::assertEquals('5ecb7a1b22291b6b15e534852e03ac72f4187a48', $this->faker->sha1());
+        self::assertEquals('2d37797087b5130d79e51a08fa7f1cf7678c70ab', $this->faker->sha1('seed_123'));
     }
 
     public function testSha256(): void
@@ -46,8 +44,7 @@ final class MiscellaneousTest extends TestCase
 
     public function testSha256ExpectedSeed(): void
     {
-        $this->faker->seed(252);
-        self::assertEquals('ea98b35136e020d9dd9b594252d9263021d1742da2bd4c8592b854c62b4122c2', $this->faker->sha256());
+        self::assertEquals('a5aa26c454007319b3458f9a9162822c8c1ac5394c4124186b4d54703d9ac3cd', $this->faker->sha256('seed_123'));
     }
 
     public function testLocale(): void


### PR DESCRIPTION
md5(), sha1() and sha256() generators is misleading

### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue (resolve #759)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->

In order to leverage the full output space of the respective hashes, I use the the function  random_bytes($length)
In order to keep those functions seedable, I add a $seed parameter that can be used to pass a parameter so that the function will always return the same hash given the same seed.

* md5 produces a 128 bits hash value, so random_bytes is called with a $length of 16 (128/8)
* sha1 produces a 160 bits hash value, so random_bytes is called with a $length of 20 (160/8)
* sha256 produces a 256 bits hash value, so random_bytes is called with a $length of 32 (256/8)

When this one is merged, I can take car of https://github.com/FakerPHP/Faker/issues/761

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
