### PR TITLE
remove gmail.com.au from free email domains.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed functionality for populating ORM entities and models (#764)
 - Added a PHP version support policy (#752)
 - Stopped using `static` in callables in `Provider\pt_BR\PhoneNumber` (#785)
+- Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#885)
 
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 

--- a/src/Provider/en_AU/Internet.php
+++ b/src/Provider/en_AU/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\en_AU;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'gmail.com.au', 'yahoo.com.au', 'hotmail.com.au'];
+    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'yahoo.com.au', 'hotmail.com.au'];
     protected static $tld = ['com', 'com.au', 'org', 'org.au', 'net', 'net.au', 'biz', 'info', 'edu', 'edu.au'];
 }


### PR DESCRIPTION
### What is the reason for this PR?

`freeEmail()` function for AU provider included the domain `gmail.com.au`, which does not exist. It causes failing tests when validating emails with `email:rfc,dns`

- [ ] A new feature
- [x] Fixed an issue (resolve #886 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Removed the errant domain from the en_AU/Internet provider file

### Review checklist

- [ ] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
