### PR TITLE
Fix internal deprecations in Doctrine's populator

### DIFF
--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -27,7 +27,7 @@ class ColumnTypeGuesser
         switch ($type) {
             case 'boolean':
                 return static function () use ($generator) {
-                    return $generator->boolean;
+                    return $generator->boolean();
                 };
 
             case 'decimal':
@@ -66,14 +66,14 @@ class ColumnTypeGuesser
 
             case 'text':
                 return static function () use ($generator) {
-                    return $generator->text;
+                    return $generator->text();
                 };
 
             case 'datetime':
             case 'date':
             case 'time':
                 return static function () use ($generator) {
-                    return $generator->datetime;
+                    return $generator->datetime();
                 };
 
             case 'datetime_immutable':


### PR DESCRIPTION
### What is the reason for this PR?

Fixes internal deprecations like : 

> Since fakerphp/faker 1.14: Accessing property "datetime" is deprecated, use "datetime()" instead.
