### PR TITLE
House numbers according to DIN 5008

### DIFF
--- a/src/Provider/de_DE/Address.php
+++ b/src/Provider/de_DE/Address.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\de_DE;
 
 class Address extends \Faker\Provider\Address
 {
-    protected static $buildingNumber = ['%##', '%#', '%', '%/%', '%#[abc]', '%[abc]'];
+    protected static $buildingNumber = ['%##', '%#', '%', '%/%', '%# [a-h]', '% [a-h]', '%# - %#', '%#// %#'];
 
     protected static $streetSuffixLong = [
         'Gasse', 'Platz', 'Ring', 'Straße', 'Weg', 'Allee',


### PR DESCRIPTION
House numbers according to DIN 5008
Some of the house numbers for Germany created using Faker do not comply with DIN 5008:

    According to DIN 5008, you insert a space before the house number after a street name.
    If the house number is followed by a letter, this is again separated by a space.
    Compound house numbers are written with the "to" character (10 - 25) or the slash.
    Insert an apartment number after the house number and separate it with two slashes and a space.
Examples:
    Berliner Ring 27
    Hindenburgdamm 19 a
    Hochstraße 56/58
    Hochstraße 56 - 58
    Züricher Strasse 17// 28

URL: https://www.dashoefer.de/newsletter/artikel/hausnummern_nach_der_din_5008.html