### PR TITLE
PHP 8.4 Support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
 
     runs-on: "ubuntu-latest"
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -126,6 +126,7 @@ return $config
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
         'operator_linebreak' => [
             'only_booleans' => true,
             'position' => 'beginning',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.23.1...1.23)
 
+- Added support for PHP 8.4 (#904)
+
 ## [2023-09-29, v1.23.1](https://github.com/FakerPHP/Faker/compare/v1.23.0..v1.23.1)
 
 - Fixed double `а` female lastName in `ru_RU/Person::name()` (#832)

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -125,7 +125,6 @@
   <file src="src/Faker/ORM/Spot/Populator.php">
     <UndefinedClass>
       <code><![CDATA[$this->locator]]></code>
-      <code>Locator</code>
     </UndefinedClass>
     <UndefinedDocblockClass>
       <code>Locator</code>
@@ -133,27 +132,19 @@
   </file>
   <file src="src/Faker/Provider/Base.php">
     <InvalidArgument>
-      <code>[static::class, 'randomDigit']</code>
-      <code>static function ($matches) {
+      <code><![CDATA[[static::class, 'randomDigit']]]></code>
+      <code><![CDATA[static function ($matches) {
             // remove backslashes (that are not followed by another backslash) because they are escape characters
             $match = preg_replace('/\\\(?!\\\)/', '', $matches[1]);
             $randomElement = Base::randomElement(str_split($match));
 
             //[.] should not be a random character, but a literal .
             return str_replace('.', '\.', $randomElement);
-        }</code>
+        }]]></code>
     </InvalidArgument>
-    <UndefinedClass>
-      <code>\UnitEnum</code>
-      <code>\UnitEnum</code>
-    </UndefinedClass>
     <UndefinedDocblockClass>
       <code>Closure</code>
     </UndefinedDocblockClass>
-    <UndefinedFunction>
-      <code>enum_exists($array)</code>
-      <code>enum_exists($array)</code>
-    </UndefinedFunction>
   </file>
   <file src="src/Faker/Provider/Biased.php">
     <InvalidParamDefault>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -125,6 +125,7 @@
   <file src="src/Faker/ORM/Spot/Populator.php">
     <UndefinedClass>
       <code><![CDATA[$this->locator]]></code>
+      <code>?Locator</code>
     </UndefinedClass>
     <UndefinedDocblockClass>
       <code>Locator</code>
@@ -132,19 +133,27 @@
   </file>
   <file src="src/Faker/Provider/Base.php">
     <InvalidArgument>
-      <code><![CDATA[[static::class, 'randomDigit']]]></code>
-      <code><![CDATA[static function ($matches) {
+      <code>[static::class, 'randomDigit']</code>
+      <code>static function ($matches) {
             // remove backslashes (that are not followed by another backslash) because they are escape characters
             $match = preg_replace('/\\\(?!\\\)/', '', $matches[1]);
             $randomElement = Base::randomElement(str_split($match));
 
             //[.] should not be a random character, but a literal .
             return str_replace('.', '\.', $randomElement);
-        }]]></code>
+        }</code>
     </InvalidArgument>
+    <UndefinedClass>
+      <code>\UnitEnum</code>
+      <code>\UnitEnum</code>
+    </UndefinedClass>
     <UndefinedDocblockClass>
       <code>Closure</code>
     </UndefinedDocblockClass>
+    <UndefinedFunction>
+      <code>enum_exists($array)</code>
+      <code>enum_exists($array)</code>
+    </UndefinedFunction>
   </file>
   <file src="src/Faker/Provider/Biased.php">
     <InvalidParamDefault>

--- a/src/Faker/Core/Barcode.php
+++ b/src/Faker/Core/Barcode.php
@@ -14,7 +14,7 @@ final class Barcode implements Extension\BarcodeExtension
 {
     private Extension\NumberExtension $numberExtension;
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(?Extension\NumberExtension $numberExtension = null)
     {
         $this->numberExtension = $numberExtension ?: new Number();
     }

--- a/src/Faker/Core/Color.php
+++ b/src/Faker/Core/Color.php
@@ -54,7 +54,7 @@ final class Color implements Extension\ColorExtension
         'Turquoise', 'Violet', 'Wheat', 'White', 'WhiteSmoke', 'Yellow', 'YellowGreen',
     ];
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(?Extension\NumberExtension $numberExtension = null)
     {
         $this->numberExtension = $numberExtension ?: new Number();
     }

--- a/src/Faker/Core/Coordinates.php
+++ b/src/Faker/Core/Coordinates.php
@@ -13,7 +13,7 @@ final class Coordinates implements Extension\Extension
 {
     private Extension\NumberExtension $numberExtension;
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(?Extension\NumberExtension $numberExtension = null)
     {
         $this->numberExtension = $numberExtension ?: new Number();
     }

--- a/src/Faker/Core/DateTime.php
+++ b/src/Faker/Core/DateTime.php
@@ -72,7 +72,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
         return $dateTime->setTimezone(new \DateTimeZone($timezone));
     }
 
-    public function dateTime($until = 'now', string $timezone = null): \DateTime
+    public function dateTime($until = 'now', ?string $timezone = null): \DateTime
     {
         return $this->setTimezone(
             $this->getTimestampDateTime($this->unixTime($until)),
@@ -80,7 +80,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
         );
     }
 
-    public function dateTimeAD($until = 'now', string $timezone = null): \DateTime
+    public function dateTimeAD($until = 'now', ?string $timezone = null): \DateTime
     {
         $min = (PHP_INT_SIZE > 4) ? -62135597361 : -PHP_INT_MAX;
 
@@ -90,7 +90,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
         );
     }
 
-    public function dateTimeBetween($from = '-30 years', $until = 'now', string $timezone = null): \DateTime
+    public function dateTimeBetween($from = '-30 years', $until = 'now', ?string $timezone = null): \DateTime
     {
         $start = $this->getTimestamp($from);
         $end = $this->getTimestamp($until);
@@ -107,7 +107,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
         );
     }
 
-    public function dateTimeInInterval($from = '-30 years', string $interval = '+5 days', string $timezone = null): \DateTime
+    public function dateTimeInInterval($from = '-30 years', string $interval = '+5 days', ?string $timezone = null): \DateTime
     {
         $intervalObject = \DateInterval::createFromDateString($interval);
         $datetime = $from instanceof \DateTime ? $from : new \DateTime($from);
@@ -120,29 +120,29 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
         return $this->dateTimeBetween($begin, $end, $timezone);
     }
 
-    public function dateTimeThisWeek($until = 'sunday this week', string $timezone = null): \DateTime
+    public function dateTimeThisWeek($until = 'sunday this week', ?string $timezone = null): \DateTime
     {
         return $this->dateTimeBetween('monday this week', $until, $timezone);
     }
 
-    public function dateTimeThisMonth($until = 'last day of this month', string $timezone = null): \DateTime
+    public function dateTimeThisMonth($until = 'last day of this month', ?string $timezone = null): \DateTime
     {
         return $this->dateTimeBetween('first day of this month', $until, $timezone);
     }
 
-    public function dateTimeThisYear($until = 'last day of december', string $timezone = null): \DateTime
+    public function dateTimeThisYear($until = 'last day of december', ?string $timezone = null): \DateTime
     {
         return $this->dateTimeBetween('first day of january', $until, $timezone);
     }
 
-    public function dateTimeThisDecade($until = 'now', string $timezone = null): \DateTime
+    public function dateTimeThisDecade($until = 'now', ?string $timezone = null): \DateTime
     {
         $year = floor(date('Y') / 10) * 10;
 
         return $this->dateTimeBetween("first day of january $year", $until, $timezone);
     }
 
-    public function dateTimeThisCentury($until = 'now', string $timezone = null): \DateTime
+    public function dateTimeThisCentury($until = 'now', ?string $timezone = null): \DateTime
     {
         $year = floor(date('Y') / 100) * 100;
 
@@ -204,7 +204,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
         return Helper::randomElement($this->centuries);
     }
 
-    public function timezone(string $countryCode = null): string
+    public function timezone(?string $countryCode = null): string
     {
         if ($countryCode) {
             $timezones = \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, $countryCode);

--- a/src/Faker/Core/Number.php
+++ b/src/Faker/Core/Number.php
@@ -63,7 +63,7 @@ final class Number implements Extension\NumberExtension
         return round($min + $this->numberBetween() / mt_getrandmax() * ($max - $min), $nbMaxDecimals);
     }
 
-    public function randomNumber(int $nbDigits = null, bool $strict = false): int
+    public function randomNumber(?int $nbDigits = null, bool $strict = false): int
     {
         if (null === $nbDigits) {
             $nbDigits = $this->randomDigitNotZero();

--- a/src/Faker/Core/Uuid.php
+++ b/src/Faker/Core/Uuid.php
@@ -11,7 +11,7 @@ final class Uuid implements Extension\UuidExtension
 {
     private Extension\NumberExtension $numberExtension;
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(?Extension\NumberExtension $numberExtension = null)
     {
 
         $this->numberExtension = $numberExtension ?: new Number();

--- a/src/Faker/Core/Version.php
+++ b/src/Faker/Core/Version.php
@@ -18,7 +18,7 @@ final class Version implements Extension\VersionExtension
      */
     private array $semverCommonPreReleaseIdentifiers = ['alpha', 'beta', 'rc'];
 
-    public function __construct(Extension\NumberExtension $numberExtension = null)
+    public function __construct(?Extension\NumberExtension $numberExtension = null)
     {
 
         $this->numberExtension = $numberExtension ?: new  Number();

--- a/src/Faker/Extension/DateTimeExtension.php
+++ b/src/Faker/Extension/DateTimeExtension.php
@@ -25,7 +25,7 @@ interface DateTimeExtension
      *
      * @example DateTime('2005-08-16 20:39:21')
      */
-    public function dateTime($until = 'now', string $timezone = null): \DateTime;
+    public function dateTime($until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a DateTime object for a date between January 1, 0001, and now.
@@ -38,7 +38,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeAD($until = 'now', string $timezone = null): \DateTime;
+    public function dateTimeAD($until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a DateTime object a random date between `$from` and `$until`.
@@ -52,7 +52,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeBetween($from = '-30 years', $until = 'now', string $timezone = null): \DateTime;
+    public function dateTimeBetween($from = '-30 years', $until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a DateTime object based on a random date between `$from` and an interval.
@@ -66,7 +66,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeInInterval($from = '-30 years', string $interval = '+5 days', string $timezone = null): \DateTime;
+    public function dateTimeInInterval($from = '-30 years', string $interval = '+5 days', ?string $timezone = null): \DateTime;
 
     /**
      * Get a date time object somewhere inside the current week.
@@ -78,7 +78,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeThisWeek($until = 'now', string $timezone = null): \DateTime;
+    public function dateTimeThisWeek($until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a date time object somewhere inside the current month.
@@ -90,7 +90,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeThisMonth($until = 'now', string $timezone = null): \DateTime;
+    public function dateTimeThisMonth($until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a date time object somewhere inside the current year.
@@ -102,7 +102,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeThisYear($until = 'now', string $timezone = null): \DateTime;
+    public function dateTimeThisYear($until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a date time object somewhere inside the current decade.
@@ -114,7 +114,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeThisDecade($until = 'now', string $timezone = null): \DateTime;
+    public function dateTimeThisDecade($until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a date time object somewhere inside the current century.
@@ -126,7 +126,7 @@ interface DateTimeExtension
      * @see http://php.net/manual/en/timezones.php
      * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public function dateTimeThisCentury($until = 'now', string $timezone = null): \DateTime;
+    public function dateTimeThisCentury($until = 'now', ?string $timezone = null): \DateTime;
 
     /**
      * Get a date string between January 1, 1970, and `$until`.
@@ -238,5 +238,5 @@ interface DateTimeExtension
      *
      * @example 'Europe/Rome'
      */
-    public function timezone(string $countryCode = null): string;
+    public function timezone(?string $countryCode = null): string;
 }

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -565,7 +565,7 @@ class Generator
      */
     private $uniqueGenerator;
 
-    public function __construct(ContainerInterface $container = null)
+    public function __construct(?ContainerInterface $container = null)
     {
         $this->container = $container ?: Container\ContainerBuilder::withDefaultExtensions()->build();
     }

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -48,7 +48,7 @@ class Populator
      *
      * @param int $batchSize
      */
-    public function __construct(Generator $generator, ObjectManager $manager = null, $batchSize = 1000)
+    public function __construct(Generator $generator, ?ObjectManager $manager = null, $batchSize = 1000)
     {
         $this->generator = $generator;
         $this->manager = $manager;

--- a/src/Faker/ORM/Spot/Populator.php
+++ b/src/Faker/ORM/Spot/Populator.php
@@ -17,7 +17,7 @@ class Populator
     /**
      * Populator constructor.
      */
-    public function __construct(\Faker\Generator $generator, Locator $locator = null)
+    public function __construct(\Faker\Generator $generator, ?Locator $locator = null)
     {
         $this->generator = $generator;
         $this->locator = $locator;

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -334,7 +334,7 @@ class DateTime extends Base
      *
      * @example 'Europe/Paris'
      */
-    public static function timezone(string $countryCode = null)
+    public static function timezone(?string $countryCode = null)
     {
         if ($countryCode) {
             $timezones = \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, $countryCode);

--- a/src/Faker/Provider/de_AT/Person.php
+++ b/src/Faker/Provider/de_AT/Person.php
@@ -127,7 +127,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string
      */
-    public static function ssn(\DateTime $birthdate = null)
+    public static function ssn(?\DateTime $birthdate = null)
     {
         $birthdate = $birthdate ?? DateTime::dateTimeThisCentury();
 

--- a/src/Faker/Provider/en_GB/Company.php
+++ b/src/Faker/Provider/en_GB/Company.php
@@ -18,7 +18,7 @@ class Company extends \Faker\Provider\Company
      *
      * @see https://en.wikipedia.org/wiki/VAT_identification_number#VAT_numbers_by_country
      */
-    public static function vat(string $type = null): string
+    public static function vat(?string $type = null): string
     {
         switch ($type) {
             case static::VAT_TYPE_BRANCH:

--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -140,7 +140,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string
      */
-    public function idNumber(\DateTime $birthdate = null, $citizen = true, $gender = null)
+    public function idNumber(?\DateTime $birthdate = null, $citizen = true, $gender = null)
     {
         if (!$birthdate) {
             $birthdate = $this->generator->dateTimeThisCentury();

--- a/src/Faker/Provider/fi_FI/Person.php
+++ b/src/Faker/Provider/fi_FI/Person.php
@@ -95,7 +95,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string on format DDMMYYCZZZQ, where DDMMYY is the date of birth, C the century sign, ZZZ the individual number and Q the control character (checksum)
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null)
+    public function personalIdentityNumber(?\DateTime $birthdate = null, $gender = null)
     {
         $checksumCharacters = '0123456789ABCDEFHJKLMNPRSTUVWXY';
 

--- a/src/Faker/Provider/kk_KZ/Company.php
+++ b/src/Faker/Provider/kk_KZ/Company.php
@@ -56,7 +56,7 @@ class Company extends \Faker\Provider\Company
      *
      * @return string 12 digits, like 150140000019
      */
-    public static function businessIdentificationNumber(\DateTime $registrationDate = null)
+    public static function businessIdentificationNumber(?\DateTime $registrationDate = null)
     {
         if (!$registrationDate) {
             $registrationDate = \Faker\Provider\DateTime::dateTimeThisYear();

--- a/src/Faker/Provider/kk_KZ/Person.php
+++ b/src/Faker/Provider/kk_KZ/Person.php
@@ -211,7 +211,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string 12 digits, like 780322300455
      */
-    public static function individualIdentificationNumber(\DateTime $birthDate = null, $gender = self::GENDER_MALE)
+    public static function individualIdentificationNumber(?\DateTime $birthDate = null, $gender = self::GENDER_MALE)
     {
         if (!$birthDate) {
             $birthDate = DateTime::dateTimeBetween();

--- a/src/Faker/Provider/lt_LT/Person.php
+++ b/src/Faker/Provider/lt_LT/Person.php
@@ -330,7 +330,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string on format XXXXXXXXXXX
      */
-    public function personalIdentityNumber($gender = 'male', \DateTime $birthdate = null, $randomNumber = '')
+    public function personalIdentityNumber($gender = 'male', ?\DateTime $birthdate = null, $randomNumber = '')
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();

--- a/src/Faker/Provider/lv_LV/Person.php
+++ b/src/Faker/Provider/lv_LV/Person.php
@@ -136,7 +136,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string on format XXXXXX-XXXXX
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null)
+    public function personalIdentityNumber(?\DateTime $birthdate = null)
     {
         if (!$birthdate) {
             $birthdate = DateTime::dateTimeThisCentury();

--- a/src/Faker/Provider/nb_NO/Person.php
+++ b/src/Faker/Provider/nb_NO/Person.php
@@ -292,7 +292,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string on format DDMMYY#####
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null)
+    public function personalIdentityNumber(?\DateTime $birthdate = null, $gender = null)
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -125,7 +125,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string on format XXXXXX-XXXX
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null)
+    public function personalIdentityNumber(?\DateTime $birthdate = null, $gender = null)
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

- Adds PHP 8.4 to Test Matrix
- Add explicit nullable declarations to remove PHP 8.4 deprecations.
- Add `nullable_type_declaration_for_default_null_value` to Coding Standards

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
