### PR TITLE
remove gmail.com.au from free email domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/FakerPHP/Faker/compare/v1.24.0...1.24.1)
 
+- Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#886)
+
 ## [2024-11-09, v1.24.0](https://github.com/FakerPHP/Faker/compare/v1.23.1..v1.24.0)
 
 - Fix internal deprecations in Doctrine's populator by @gnutix in (#889)

--- a/src/Faker/Provider/en_AU/Internet.php
+++ b/src/Faker/Provider/en_AU/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\en_AU;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'gmail.com.au', 'yahoo.com.au', 'hotmail.com.au'];
+    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'yahoo.com.au', 'hotmail.com.au'];
     protected static $tld = ['com', 'com.au', 'org', 'org.au', 'net', 'net.au', 'biz', 'info', 'edu', 'edu.au'];
 }


### PR DESCRIPTION
### What is the reason for this PR?

`freeEmail()` function for AU provider included the domain `gmail.com.au`, which does not exist. It causes failing tests when validating emails with `email:rfc,dns`

- [ ] A new feature
- [x] Fixed an issue (resolve #886 )

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Removed the errant domain from the en_AU/Internet provider file

### Review checklist

- [ ] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
