### PR TITLE
Fix internal deprecations in Faker\Guesser\Name

### DIFF
--- a/src/Faker/Guesser/Name.php
+++ b/src/Faker/Guesser/Name.php
@@ -26,37 +26,37 @@ class Name
 
         if (preg_match('/^is[_A-Z]/', $name)) {
             return static function () use ($generator) {
-                return $generator->boolean;
+                return $generator->boolean();
             };
         }
 
         if (preg_match('/(_a|A)t$/', $name)) {
             return static function () use ($generator) {
-                return $generator->dateTime;
+                return $generator->dateTime();
             };
         }
 
         switch (str_replace('_', '', $name)) {
             case 'firstname':
                 return static function () use ($generator) {
-                    return $generator->firstName;
+                    return $generator->firstName();
                 };
 
             case 'lastname':
                 return static function () use ($generator) {
-                    return $generator->lastName;
+                    return $generator->lastName();
                 };
 
             case 'username':
             case 'login':
                 return static function () use ($generator) {
-                    return $generator->userName;
+                    return $generator->userName();
                 };
 
             case 'email':
             case 'emailaddress':
                 return static function () use ($generator) {
-                    return $generator->email;
+                    return $generator->email();
                 };
 
             case 'phonenumber':
@@ -64,68 +64,68 @@ class Name
             case 'telephone':
             case 'telnumber':
                 return static function () use ($generator) {
-                    return $generator->phoneNumber;
+                    return $generator->phoneNumber();
                 };
 
             case 'address':
                 return static function () use ($generator) {
-                    return $generator->address;
+                    return $generator->address();
                 };
 
             case 'city':
             case 'town':
                 return static function () use ($generator) {
-                    return $generator->city;
+                    return $generator->city();
                 };
 
             case 'streetaddress':
                 return static function () use ($generator) {
-                    return $generator->streetAddress;
+                    return $generator->streetAddress();
                 };
 
             case 'postcode':
             case 'zipcode':
                 return static function () use ($generator) {
-                    return $generator->postcode;
+                    return $generator->postcode();
                 };
 
             case 'state':
                 return static function () use ($generator) {
-                    return $generator->state;
+                    return $generator->state();
                 };
 
             case 'county':
                 if ($this->generator->locale == 'en_US') {
                     return static function () use ($generator) {
-                        return sprintf('%s County', $generator->city);
+                        return sprintf('%s County', $generator->city());
                     };
                 }
 
                 return static function () use ($generator) {
-                    return $generator->state;
+                    return $generator->state();
                 };
 
             case 'country':
                 switch ($size) {
                     case 2:
                         return static function () use ($generator) {
-                            return $generator->countryCode;
+                            return $generator->countryCode();
                         };
 
                     case 3:
                         return static function () use ($generator) {
-                            return $generator->countryISOAlpha3;
+                            return $generator->countryISOAlpha3();
                         };
 
                     case 5:
                     case 6:
                         return static function () use ($generator) {
-                            return $generator->locale;
+                            return $generator->locale();
                         };
 
                     default:
                         return static function () use ($generator) {
-                            return $generator->country;
+                            return $generator->country();
                         };
                 }
 
@@ -133,37 +133,37 @@ class Name
 
             case 'locale':
                 return static function () use ($generator) {
-                    return $generator->locale;
+                    return $generator->locale();
                 };
 
             case 'currency':
             case 'currencycode':
                 return static function () use ($generator) {
-                    return $generator->currencyCode;
+                    return $generator->currencyCode();
                 };
 
             case 'url':
             case 'website':
                 return static function () use ($generator) {
-                    return $generator->url;
+                    return $generator->url();
                 };
 
             case 'company':
             case 'companyname':
             case 'employer':
                 return static function () use ($generator) {
-                    return $generator->company;
+                    return $generator->company();
                 };
 
             case 'title':
                 if ($size !== null && $size <= 10) {
                     return static function () use ($generator) {
-                        return $generator->title;
+                        return $generator->title();
                     };
                 }
 
                 return static function () use ($generator) {
-                    return $generator->sentence;
+                    return $generator->sentence();
                 };
 
             case 'body':
@@ -171,7 +171,7 @@ class Name
             case 'article':
             case 'description':
                 return static function () use ($generator) {
-                    return $generator->text;
+                    return $generator->text();
                 };
         }
 


### PR DESCRIPTION
### What is the reason for this PR?

Fixes internal deprecations like :

> Since fakerphp/faker 1.14: Accessing property "text" is deprecated, use "text()" instead.

Relates to #889