### PR TITLE
Add missing references for `ein`, `secondaryAddress` and `state` on the Generator Docblock.

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -37,6 +37,14 @@ use Faker\Container\ContainerInterface;
  *
  * @method string address()
  *
+ * @property string $secondaryAddress
+ *
+ * @method string secondaryAddress()
+ *
+ * @property string $state
+ *
+ * @method string state()
+ *
  * @property string $country
  *
  * @method string country()
@@ -176,6 +184,10 @@ use Faker\Container\ContainerInterface;
  * @property string $jobTitle
  *
  * @method string jobTitle()
+ *
+ * @property string $ein
+ *
+ * @method string ein()
  *
  * @property int $unixTime
  *


### PR DESCRIPTION


### What is the reason for this PR?

This PR adds missing references for the `ein`, `secondaryAddress` and `state` on the Generator.

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This change will help static analysers and intellisense tools.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
