### PR TITLE
fix: Generate valid BIC/SWIFT numbers (#902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#886)
 - Refreshed ISO currencies (#919)
--
+- Generate valid BIC/SWIFT numnbers (#902)
+
 ## [2024-11-09, v1.24.0](https://github.com/FakerPHP/Faker/compare/v1.23.1..v1.24.0)
 
 - Fix internal deprecations in Doctrine's populator by @gnutix in (#889)

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -443,7 +443,7 @@ use Faker\Container\ContainerInterface;
  *
  * @property string $swiftBicNumber
  *
- * @method string swiftBicNumber()
+ * @method string swiftBicNumber($countryCode = null)
  *
  * @property string $name
  *

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -297,16 +297,22 @@ class Payment extends Base
     }
 
     /**
-     * Return the String of a SWIFT/BIC number
+     * Return the String of a SWIFT/BIC number.
      *
      * @example 'RZTIAT22263'
      *
      * @see    http://en.wikipedia.org/wiki/ISO_9362
      *
+     * @param string|null $countryCode ISO 3166-1 alpha-2 country code
+     *
      * @return string Swift/Bic number
      */
-    public static function swiftBicNumber()
+    public static function swiftBicNumber($countryCode = null)
     {
-        return self::regexify('^([A-Z]){4}([A-Z]){2}([0-9A-Z]){2}([0-9A-Z]{3})?$');
+        if (null !== $countryCode && 1 !== preg_match('/^[A-Z]{2}$/', $countryCode)) {
+            throw new \InvalidArgumentException('Invalid country code format.');
+        }
+
+        return self::regexify('^([A-Z]){4}' . ($countryCode ?? Miscellaneous::countryCode()) . '([0-9A-Z]){2}([0-9A-Z]{3})?$');
     }
 }

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -197,4 +197,20 @@ final class PaymentTest extends TestCase
 
         yield new PaymentProvider($this->faker);
     }
+
+    public function testSwiftBicNumber(): void
+    {
+        self::assertMatchesRegularExpression(
+            '/^([A-Z]){4}([A-Z]){2}([0-9A-Z]){2}([0-9A-Z]{3})?$/',
+            $this->faker->swiftBicNumber(),
+        );
+    }
+
+    public function testLocalizedSwiftBicNumber(): void
+    {
+        self::assertMatchesRegularExpression(
+            '/^([A-Z]){4}DE([0-9A-Z]){2}([0-9A-Z]{3})?$/',
+            $this->faker->swiftBicNumber('DE'),
+        );
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [X] Fixed an issue (#902)

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

`swiftBicNumber()` now returns SWIFT/BIC numbers that pass validation.
Added a dev requirement for symfony/validator that might be used for other generators as well.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
