### PR TITLE
Add missing return type for some Generator methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#886)
 - Refreshed ISO currencies (#919)
--
+- Add missing return types in Generator (#922)
+
 ## [2024-11-09, v1.24.0](https://github.com/FakerPHP/Faker/compare/v1.23.1..v1.24.0)
 
 - Fix internal deprecations in Doctrine's populator by @gnutix in (#889)

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -764,7 +764,7 @@ class Generator
      *
      * @example 'video/avi'
      */
-    public function mimeType()
+    public function mimeType(): string
     {
         return $this->ext(Extension\FileExtension::class)->mimeType();
     }
@@ -774,7 +774,7 @@ class Generator
      *
      * @example avi
      */
-    public function fileExtension()
+    public function fileExtension(): string
     {
         return $this->ext(Extension\FileExtension::class)->extension();
     }
@@ -782,7 +782,7 @@ class Generator
     /**
      * Get a full path to a new real file on the system.
      */
-    public function filePath()
+    public function filePath(): string
     {
         return $this->ext(Extension\FileExtension::class)->filePath();
     }


### PR DESCRIPTION
### What is the reason for this PR?

Some methods does not have any return type.
PHPStan consider they return `mixed` and I have some "errors" in personal projects which use those methods.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Add missing return type for some Generator methods

### Review checklist

- [ ] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
