### PR TITLE
Add @return annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix internal deprecations in Doctrine's populator by @gnutix in (#889)
 - Fix mobile phone number pattern for France by @ker0x in (#859)
 - PHP 8.4 Support by @Jubeki in (#904)
+- Add missing return type in annotations (#923)
 
 - Added support for PHP 8.4 (#904)
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -763,6 +763,8 @@ class Generator
      * Get a random MIME type
      *
      * @example 'video/avi'
+     *
+     * @return string
      */
     public function mimeType()
     {
@@ -773,6 +775,8 @@ class Generator
      * Get a random file extension (without a dot)
      *
      * @example avi
+     *
+     * @return string
      */
     public function fileExtension()
     {
@@ -781,6 +785,8 @@ class Generator
 
     /**
      * Get a full path to a new real file on the system.
+     *
+     * @return string
      */
     public function filePath()
     {


### PR DESCRIPTION
### What is the reason for this PR?

Some methods does not have any return type.
PHPStan consider they return mixed and I have some "errors" in personal projects which use those methods.
This PR add `@return` annotations to fix this "problem".

See #922 

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

See #922 

### Review checklist

- [ ] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
