### PR TITLE
Fixes #925: Invalid E.164 format for pt_PT PhoneNumber Provider

### DIFF
--- a/src/Provider/pt_PT/PhoneNumber.php
+++ b/src/Provider/pt_PT/PhoneNumber.php
@@ -5,35 +5,73 @@ namespace Faker\Provider\pt_PT;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     /**
+     * Returns the pt_PT phone country code.
+     */
+    const COUNTRY_CODE = '+351';
+
+    /**
+     * pt_PT Mobile Service Codes
+     */
+    protected static $mobileServiceCode = [
+        91,
+        92,
+        93,
+        96,
+    ];
+
+    /**
+     * pt_PT Geographic Area Codes
+     */
+    protected static $areaCode = [
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+    ];
+
+    /**
+     * pt_PT Geographic Area and Mobile Service Codes
+     */
+    protected static $areaOrMobileServiceCode = [
+        91,
+        92,
+        93,
+        96,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+    ];
+
+    /**
      * @see http://en.wikipedia.org/wiki/Telephone_numbers_in_Portugal
      */
     protected static $formats = [
-        '+351 91#######',
-        '+351 92#######',
-        '+351 93#######',
-        '+351 96#######',
-        '+351 21#######',
-        '+351 22#######',
-        '+351 23#######',
-        '+351 24#######',
-        '+351 25#######',
-        '+351 26#######',
-        '+351 27#######',
-        '+351 28#######',
-        '+351 29#######',
-        '91#######',
-        '92#######',
-        '93#######',
-        '96#######',
-        '21#######',
-        '22#######',
-        '23#######',
-        '24#######',
-        '25#######',
-        '26#######',
-        '27#######',
-        '28#######',
-        '29#######',
+        '{{countryCode}} {{areaOrMobileServiceCode}}#######',
+        '{{mobileServiceCode}}#######',
+        '{{areaCode}}#######',
+    ];
+
+    protected static $e164Formats = [
+        '{{countryCode}}{{areaOrMobileServiceCode}}#######',
+    ];
+
+    protected static $e164MobileFormat = [
+        '{{countryCode}}{{mobileServiceCode}}#######',
+    ];
+
+    protected static $e164LandlineFormat = [
+        '{{countryCode}}{{areaCode}}#######',
     ];
 
     protected static $mobileNumberPrefixes = [
@@ -46,5 +84,54 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     public static function mobileNumber()
     {
         return static::numerify(static::randomElement(static::$mobileNumberPrefixes));
+    }
+
+    public static function areaOrMobileServiceCode()
+    {
+        return self::randomElement(static::$areaOrMobileServiceCode);
+    }
+
+    public static function areaCode()
+    {
+        return self::randomElement(static::$areaCode);
+    }
+
+    public static function mobileServiceCode()
+    {
+        return self::randomElement(static::$mobileServiceCode);
+    }
+
+    /**
+     * Returns the pt_PT phone country code.
+     *
+     * @return string
+     */
+    public static function countryCode()
+    {
+        return self::COUNTRY_CODE;
+    }
+
+    /**
+     * Returns a pt_PT mobile number in E.164 format.
+     * 
+     * Example: +35193XXXXXXX
+     *
+     * @return string
+     */
+    public function e164MobileNumber()
+    {
+        return static::numerify($this->generator->parse(static::randomElement(static::$e164MobileFormat)));
+    }
+
+    /**
+     * Returns a pt_PT landline number in E.164 format.
+     * 
+     * Example: +35121XXXXXXX
+     *
+     * @return string
+     */
+    public function e164LandlineNumber()
+    {
+        return static::numerify($this->generator->parse(static::randomElement(static::$e164LandlineFormat)));
     }
 }

--- a/src/Provider/pt_PT/PhoneNumber.php
+++ b/src/Provider/pt_PT/PhoneNumber.php
@@ -7,12 +7,12 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     /**
      * Returns the pt_PT phone country code.
      */
-    const COUNTRY_CODE = '+351';
+    public const COUNTRY_CODE = '+351';
 
     /**
      * pt_PT Mobile Service Codes
      */
-    protected static $mobileServiceCode = [
+    public const MOBILE_SERVICE_CODE = [
         91,
         92,
         93,
@@ -22,7 +22,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     /**
      * pt_PT Geographic Area Codes
      */
-    protected static $areaCode = [
+    public const AREA_CODE = [
         21,
         22,
         23,
@@ -37,20 +37,9 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     /**
      * pt_PT Geographic Area and Mobile Service Codes
      */
-    protected static $areaOrMobileServiceCode = [
-        91,
-        92,
-        93,
-        96,
-        21,
-        22,
-        23,
-        24,
-        25,
-        26,
-        27,
-        28,
-        29,
+    public const AREA_OR_MOBILE_SERVICE_CODE = [
+        ...self::MOBILE_SERVICE_CODE,
+        ...self::AREA_CODE,
     ];
 
     /**
@@ -88,17 +77,17 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
     public static function areaOrMobileServiceCode()
     {
-        return self::randomElement(static::$areaOrMobileServiceCode);
+        return self::randomElement(static::AREA_OR_MOBILE_SERVICE_CODE);
     }
 
     public static function areaCode()
     {
-        return self::randomElement(static::$areaCode);
+        return self::randomElement(static::AREA_CODE);
     }
 
     public static function mobileServiceCode()
     {
-        return self::randomElement(static::$mobileServiceCode);
+        return self::randomElement(static::MOBILE_SERVICE_CODE);
     }
 
     /**

--- a/src/Provider/pt_PT/PhoneNumber.php
+++ b/src/Provider/pt_PT/PhoneNumber.php
@@ -5,12 +5,12 @@ namespace Faker\Provider\pt_PT;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     /**
-     * Returns the pt_PT phone country code.
+     * Phone country code.
      */
     public const COUNTRY_CODE = '+351';
 
     /**
-     * pt_PT Mobile Service Codes
+     * Mobile Service Codes
      */
     public const MOBILE_SERVICE_CODE = [
         91,
@@ -20,7 +20,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     ];
 
     /**
-     * pt_PT Geographic Area Codes
+     * Geographic Area Codes
      */
     public const AREA_CODE = [
         21,
@@ -35,24 +35,24 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     ];
 
     /**
-     * pt_PT Geographic Area and Mobile Service Codes
+     * Geographic Area and Mobile Service Codes
      */
-    public const AREA_OR_MOBILE_SERVICE_CODE = [
-        ...self::MOBILE_SERVICE_CODE,
+    public const AREA_AND_MOBILE_SERVICE_CODE = [
         ...self::AREA_CODE,
+        ...self::MOBILE_SERVICE_CODE,
     ];
 
     /**
      * @see http://en.wikipedia.org/wiki/Telephone_numbers_in_Portugal
      */
     protected static $formats = [
-        '{{countryCode}} {{areaOrMobileServiceCode}}#######',
+        '{{countryCode}} {{areaAndMobileServiceCode}}#######',
         '{{mobileServiceCode}}#######',
         '{{areaCode}}#######',
     ];
 
     protected static $e164Formats = [
-        '{{countryCode}}{{areaOrMobileServiceCode}}#######',
+        '{{countryCode}}{{areaAndMobileServiceCode}}#######',
     ];
 
     protected static $e164MobileFormat = [
@@ -75,23 +75,23 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return static::numerify(static::randomElement(static::$mobileNumberPrefixes));
     }
 
-    public static function areaOrMobileServiceCode()
+    public static function areaAndMobileServiceCode()
     {
-        return self::randomElement(static::AREA_OR_MOBILE_SERVICE_CODE);
+        return static::randomElement(self::AREA_AND_MOBILE_SERVICE_CODE);
     }
 
     public static function areaCode()
     {
-        return self::randomElement(static::AREA_CODE);
+        return static::randomElement(self::AREA_CODE);
     }
 
     public static function mobileServiceCode()
     {
-        return self::randomElement(static::MOBILE_SERVICE_CODE);
+        return static::randomElement(self::MOBILE_SERVICE_CODE);
     }
 
     /**
-     * Returns the pt_PT phone country code.
+     * Returns the phone country code.
      *
      * @return string
      */
@@ -101,8 +101,8 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     }
 
     /**
-     * Returns a pt_PT mobile number in E.164 format.
-     * 
+     * Returns a mobile number in E.164 format.
+     *
      * Example: +35193XXXXXXX
      *
      * @return string
@@ -113,8 +113,8 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     }
 
     /**
-     * Returns a pt_PT landline number in E.164 format.
-     * 
+     * Returns a landline number in E.164 format.
+     *
      * Example: +35121XXXXXXX
      *
      * @return string

--- a/test/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Provider/pt_PT/PhoneNumberTest.php
@@ -14,12 +14,27 @@ final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumberReturnsPhoneNumberWithOrWithoutPrefix(): void
     {
-        self::assertMatchesRegularExpression('/^(9[1,2,3,6][0-9]{7})|(2[0-9]{8})|(\+351 [2][0-9]{8})|(\+351 9[1,2,3,6][0-9]{7})/', $this->faker->phoneNumber());
+        self::assertMatchesRegularExpression('/^(?:\+351 )?(?:9[1,2,3,6][0-9]{7}|2[1-9][0-9]{7})$/', $this->faker->phoneNumber());
     }
 
-    public function testMobileNumberReturnsMobileNumberWithOrWithoutPrefix(): void
+    public function testMobileNumberReturnsMobileNumberWithoutPrefix(): void
     {
         self::assertMatchesRegularExpression('/^(9[1,2,3,6][0-9]{7})/', $this->faker->mobileNumber());
+    }
+
+    public function testE164PhoneNumberReturnsE164MobileOrLandlineNumber(): void
+    {
+        self::assertMatchesRegularExpression('/^\+351(?:9[1,2,3,6][0-9]{7}|2[1-9][0-9]{7})$/', $this->faker->e164PhoneNumber());
+    }
+
+    public function testE164MobileNumberReturnsE164MobileNumber(): void
+    {
+        self::assertMatchesRegularExpression('/^\+3519[1,2,3,6][0-9]{7}$/', $this->faker->e164MobileNumber());
+    }
+
+    public function testE164LandlineNumberReturnsE164LandlineNumber(): void
+    {
+        self::assertMatchesRegularExpression('/^\+3512[1-9][0-9]{7}$/', $this->faker->e164LandlineNumber());
     }
 
     protected function getProviders(): iterable


### PR DESCRIPTION
### Summary

- Fix bug where `e164PhoneNumber` doesn't return `pt_PT` phone numbers when using the specific `pt_PT` provider. Override `$e164Formats` in order to provide locale specific phone numbers (mobile and landline) in E.164 format. 

- Add constants / static properties for common formatting codes (country, area and mobile service).

- Add methods `e164MobileNumber` and `e164LandlineNumber` to provide mobile-only and landline-only phone numbers, respectively.

- Add tests.

### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [X] Fixed an issue (resolve #925)
- [X] Add `e164MobileNumber` and `e164LandlineNumber` to allow the users to retrieve only phone or landline numbers.

</br>

**Note**: I wanted to use the same "formatting rules" for `$mobileNumberPrefixes` but I think there is some issue with the `{{ }}` substitution since the `mobileNumber` method is static and there's not static `parse` method.

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)


### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
