### PR TITLE
Add stateAbbr() method for en_AU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#886)
 - Refreshed ISO currencies (#919)
--
+- Add support for stateAddr() to `Provider\en_AU\Address` (#927)
+    
 ## [2024-11-09, v1.24.0](https://github.com/FakerPHP/Faker/compare/v1.23.1..v1.24.0)
 
 - Fix internal deprecations in Doctrine's populator by @gnutix in (#889)

--- a/src/Faker/Provider/en_AU/Address.php
+++ b/src/Faker/Provider/en_AU/Address.php
@@ -109,4 +109,16 @@ class Address extends \Faker\Provider\en_US\Address
     {
         return static::randomElement(static::$state);
     }
+
+    /**
+     * Returns a sane state abbreviation
+     *
+     * @example NSW
+     *
+     * @return string
+     */
+    public static function stateAbbr()
+    {
+        return static::randomElement(static::$stateAbbr);
+    }
 }

--- a/test/Faker/Provider/en_AU/AddressTest.php
+++ b/test/Faker/Provider/en_AU/AddressTest.php
@@ -33,6 +33,14 @@ final class AddressTest extends TestCase
         self::assertMatchesRegularExpression('/[A-Z][a-z]+/', $state);
     }
 
+    public function testStateAbbr(): void
+     {
+        $stateAbbr = $this->faker->stateAbbr();
+        self::assertNotEmpty($stateAbbr);
+        self::assertIsString($stateAbbr);
+        self::assertMatchesRegularExpression('/^[A-Z]{2,3}$/', $stateAbbr);
+     }
+
     protected function getProviders(): iterable
     {
         yield new Address($this->faker);


### PR DESCRIPTION
### What is the reason for this PR?

Add state abbreviation for Australian addresses

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

- Add stateAbbr implementation for en_AU
- Add new test for en_AU stateAbbr()

### Review checklist

- [ ] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
