### PR TITLE
Better deprecation message

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -55,7 +55,8 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            '%s is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            __CLASS__,
         );
 
         // Validate image format
@@ -119,7 +120,8 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            '%s is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            __CLASS__,
         );
 
         $dir = null === $dir ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
@@ -173,7 +175,8 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            '%s is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            __CLASS__,
         );
 
         return array_keys(static::getFormatConstants());
@@ -184,7 +187,8 @@ class Image extends Base
         trigger_deprecation(
             'fakerphp/faker',
             '1.20',
-            'Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            '%s is deprecated and will no longer be available in Faker 2. Please use a custom provider instead',
+            __CLASS__,
         );
 
         return [


### PR DESCRIPTION
### What is the reason for this PR?

Without searching for the deprecation message, I was not able to know what exactly is deprecated:

```bash
Since fakerphp/faker 1.20: Provider is deprecated and will no longer be available in Faker 2. Please use a custom provider instead
```

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

See above

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
