### PR TITLE
Improved italian phone numbers

### DIFF
--- a/src/Provider/it_IT/PhoneNumber.php
+++ b/src/Provider/it_IT/PhoneNumber.php
@@ -5,17 +5,12 @@ namespace Faker\Provider\it_IT;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $formats = [
-        '+## ### ## ## ####',
-        '+## ## #######',
-        '+## ## ########',
-        '+## ### #######',
-        '+## ### ########',
-        '+## #### #######',
-        '+## #### ########',
         // According to http://it.wikipedia.org/wiki/Prefisso_telefonico#Elenco_degli_indicativi_in_Italia.2C_a_San_Marino_e_nel_Vaticano
+        '0## ### ###',
         '0## ### ####',
         '+39 0## ### ###',
-        '3## ### ###',
-        '+39 3## ### ###',
+        '+39 0## ### ####',
+        '3## ### ####',
+        '+39 3## ### ####',
     ];
 }


### PR DESCRIPTION
### What is the reason for this PR?

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [ ] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Italian phone numbers start with 3 (for mobile) or 0 (for landline). They typically have 10 digits but landlines may also have 9 digits, excluding the +39 international prefix.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
