### PR TITLE
Add Dockerfile for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 ARG PHP_VERSION=8.3 \
-	COMPOSER_VERSION=latest
+	COMPOSER_VERSION=latest \
+	EXTENSION_INSTALLER_VERSION=latest
 
 # At the moment, it's NOT possible to interpolate inside the COPY --from
+FROM mlocati/php-extension-installer:${EXTENSION_INSTALLER_VERSION} AS extension-installer
 FROM composer:${COMPOSER_VERSION} AS composer
 FROM php:${PHP_VERSION}
 COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=extension-installer --chmod=0755 /usr/bin/install-php-extensions /usr/local/bin/
 
 # https://getcomposer.org/doc/articles/troubleshooting.md#root-package-version-detection
 ENV COMPOSER_ROOT_VERSION=2.0.x-dev
 
-ARG USERNAME=faker \
+ARG USERNAME=FakerPHP \
  	USER_UID=1000 \
 	USER_GID=$USER_UID
 
@@ -17,10 +20,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
 
 RUN apt-get update && apt-get install -y \
-		gzip \
 		unzip
-
-ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN install-php-extensions intl 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+ARG PHP_VERSION=8.3 \
+	COMPOSER_VERSION=latest
+
+# At the moment, it's NOT possible to interpolate inside the COPY --from
+FROM composer:${COMPOSER_VERSION} AS composer
+FROM php:${PHP_VERSION}
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# https://getcomposer.org/doc/articles/troubleshooting.md#root-package-version-detection
+ENV COMPOSER_ROOT_VERSION=2.0.x-dev
+
+ARG USERNAME=faker \
+ 	USER_UID=1000 \
+	USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+RUN apt-get update && apt-get install -y \
+		gzip \
+		unzip
+
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions intl 
+
+USER $USERNAME


### PR DESCRIPTION
### What is the reason for this PR?

- Dockerfile to build an image with the FakerPHP dev dependencies. 

- It doesn't impact end users, it just improves the DX (Developer Experience) for anyone that wants to contribute to the repo without having to worry about installing any dependency (e.g. php, composer, make) on the host machine.


You just need to:
1. Build the image: `docker build -t php8.3-composer .`
2. Add an alias: `alias php8.3="docker run -it --rm -v .:/app -w /app php8.3-composer"`
3. Use it: `php8.3 make cs`

**Note**:
- The script that is added with `ADD` is meant to facilitate the installation of extensions. You can verify that the script is even mentioned in the [README of the offical PHP image](https://hub.docker.com/_/php):

> If you are having difficulty figuring out which Debian or Alpine packages need to be installed before docker-php-ext-install, then have a look at [the install-php-extensions project⁠](https://github.com/mlocati/docker-php-extension-installer). This script builds upon the docker-php-ext-* scripts and simplifies the installation of PHP extensions by automatically adding and removing Debian (apt) and Alpine (apk) packages.

- The image defaults to PHP version `8.3` since there seems to be a dependency that requires a max of 8.3.X. Composer defaults to `latest`. You can override these defaults using `docker build --build-args`, allowing you to have multiple versions to work with (by setting multiple alias).

Let me know what you think, I will add some info to the README if you find this useful.