### PR TITLE
Make sure provider methods are callable in `Generator::getFormatter()`

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -721,8 +721,10 @@ class Generator
         }
 
         foreach ($this->providers as $provider) {
-            if (method_exists($provider, $format)) {
-                $this->formatters[$format] = [$provider, $format];
+            $callable = [$provider, $format];
+
+            if (is_callable($callable)) {
+                $this->formatters[$format] = $callable;
 
                 return $this->formatters[$format];
             }

--- a/test/Fixture/Provider/BarProvider.php
+++ b/test/Fixture/Provider/BarProvider.php
@@ -10,4 +10,14 @@ final class BarProvider
     {
         return 'barfoo';
     }
+
+    private function maybeShadowedFormatter()
+    {
+        return 'shadowed';
+    }
+
+    private function maybeShadowedFormatter2()
+    {
+        return 'shadowed';
+    }
 }

--- a/test/Fixture/Provider/FooProvider.php
+++ b/test/Fixture/Provider/FooProvider.php
@@ -15,4 +15,27 @@ final class FooProvider
     {
         return 'baz' . $value;
     }
+
+    // The PHP CS Fixer `protected_to_private` fixer rule rewrites this to `private function`
+    /*
+    protected function protectedFormatter()
+    {
+        return 'protected';
+    }
+    */
+
+    private function privateFormatter()
+    {
+        return 'private';
+    }
+
+    public function maybeShadowedFormatter()
+    {
+        return 'not shadowed';
+    }
+
+    public function maybeShadowedFormatter2()
+    {
+        return 'also not shadowed';
+    }
 }

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -327,4 +327,45 @@ final class GeneratorTest extends TestCase
 
         $uniqueGenerator->word();
     }
+
+    // Disabled because the PHP CS Fixer’s `protected_to_private` rule rewrites
+    // `protected function protectedFormatter()` to `private function protectedFormatter()`,
+    // and currently there’s no way to disable CS Fixer rules for a single line
+    /*
+    public function testProtectedProviderMethodsAreNotCalled(): void
+    {
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Unknown format "protectedFormatter"'));
+
+        $this->faker->protectedFormatter();
+    }
+
+    public function testProtectedProviderMethodsDoNotShadowPublicMethods(): void
+    {
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\BarProvider());
+
+        self::assertSame('not shadowed', $this->faker->maybeShadowedFormatter());
+    }
+    */
+
+    public function testPrivateProviderMethodsAreNotCalled(): void
+    {
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Unknown format "privateFormatter"'));
+
+        $this->faker->privateFormatter();
+    }
+
+    public function testPrivateProviderMethodsDoNotShadowPublicMethods(): void
+    {
+        $this->faker->addProvider(new Fixture\Provider\FooProvider());
+        $this->faker->addProvider(new Fixture\Provider\BarProvider());
+
+        self::assertSame('also not shadowed', $this->faker->maybeShadowedFormatter2());
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?
Currently non-public methods of providers can override public methods of providers below them in the chain.

If accepted, this change can also be backported to 1.x.

- [ ] A new feature
- [x] Fixed an issue 

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

Note: Before and after the change, the same 7 test cases failed.

### Summary of changes

```php
class ProviderA extends \Faker\Provider\Base {
    public function testFN() {
        echo 'Hello, world!';
    }
}

class ProviderB extends \Faker\Provider\Base {
    private function testFN() {
        echo 'Get off my lawn!';
    }
}

$generator = \Faker\Factory::create();
$generator->addProvider(new ProviderA($generator));
$generator->addProvider(new ProviderB($generator));
$generator->testFN();
```

This example will throw a fatal error:
`call_user_func_array(): Argument #1 ($callback) must be a valid callback, cannot access private method ProviderB::testFN()`

If we take a look at the Generator class, we find
https://github.com/FakerPHP/Faker/blob/36ab4515337167ca65d68b59c6503b1a7db71668/src/Generator.php#L723-L729

`method_exists()` also returns `true` for protected and private methods.
See https://3v4l.org/eXkna

Instead we can use `is_callable()`, which respects the visibility, see https://3v4l.org/rHeUg

With this change we get `Hello, world!` as a result. :)

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
