### PR TITLE
Century in swedish personal identity number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Removed functionality for populating ORM entities and models (#764)
 - Added a PHP version support policy (#752)
 - Stopped using `static` in callables in `Provider\pt_BR\PhoneNumber` (#785)
-- Possibility to include century in swedish personal identity numbers
+- Possibility to include century in swedish personal identity numbers (#964)
 
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed functionality for populating ORM entities and models (#764)
 - Added a PHP version support policy (#752)
 - Stopped using `static` in callables in `Provider\pt_BR\PhoneNumber` (#785)
+- Possibility to include century in swedish personal identity numbers
 
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 

--- a/src/Provider/sv_SE/Person.php
+++ b/src/Provider/sv_SE/Person.php
@@ -125,7 +125,7 @@ class Person extends \Faker\Provider\Person
      *
      * @return string on format XXXXXX-XXXX or XXXXXXXX-XXXX depending on $withCentury value
      */
-    public function personalIdentityNumber(\DateTimeInterface $birthdate = null, $gender = null, $withCentury = false)
+    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null, $withCentury = false)
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();

--- a/src/Provider/sv_SE/Person.php
+++ b/src/Provider/sv_SE/Person.php
@@ -123,14 +123,14 @@ class Person extends \Faker\Provider\Person
      *
      * @param string $gender Person::GENDER_MALE || Person::GENDER_FEMALE
      *
-     * @return string on format XXXXXX-XXXX
+     * @return string on format XXXXXX-XXXX or XXXXXXXX-XXXX depending on $withCentury value
      */
-    public function personalIdentityNumber(\DateTime $birthdate = null, $gender = null)
+    public function personalIdentityNumber(\DateTimeInterface $birthdate = null, $gender = null, $withCentury = false)
     {
         if (!$birthdate) {
             $birthdate = \Faker\Provider\DateTime::dateTimeThisCentury();
         }
-        $datePart = $birthdate->format('ymd');
+        $datePart = $birthdate->format($withCentury ? 'Ymd' : 'ymd');
         $randomDigits = $this->getBirthNumber($gender);
 
         $checksum = Luhn::computeCheckDigit($datePart . $randomDigits);

--- a/test/Provider/sv_SE/PersonTest.php
+++ b/test/Provider/sv_SE/PersonTest.php
@@ -16,22 +16,27 @@ final class PersonTest extends TestCase
     public function provideSeedAndExpectedReturn()
     {
         return [
-            [1, '720727', '720727-5798'],
-            [2, '710414', '710414-5664'],
-            [3, '591012', '591012-4519'],
-            [4, '180307', '180307-0356'],
-            [5, '820904', '820904-7748'],
+            [1, '19720727', false, '720727-5798'],
+            [2, '19710414', false, '710414-5664'],
+            [3, '19591012', false, '591012-4519'],
+            [4, '20180307', false, '180307-0356'],
+            [5, '19820904', false, '820904-7748'],
+            [6, '19720727', true, '19720727-1010'],
+            [7, '19710414', true, '19710414-9269'],
+            [8, '19591012', true, '19591012-1290'],
+            [9, '20180307', true, '20180307-9858'],
+            [10, '19820904', true, '19820904-2334'],
         ];
     }
 
     /**
      * @dataProvider provideSeedAndExpectedReturn
      */
-    public function testPersonalIdentityNumberUsesBirthDateIfProvided($seed, $birthdate, $expected): void
+    public function testPersonalIdentityNumberUsesBirthDateIfProvided($seed, $birthdate, $withCentury, $expected): void
     {
         $faker = $this->faker;
         $faker->seed($seed);
-        $pin = $faker->personalIdentityNumber(\DateTime::createFromFormat('ymd', $birthdate));
+        $pin = $faker->personalIdentityNumber(\DateTime::createFromFormat('Ymd', $birthdate), null, $withCentury);
         self::assertEquals($expected, $pin);
     }
 


### PR DESCRIPTION
### What is the reason for this PR?

Sometimes you need the full identity number (with century). For example when working with Swedish Bank ID.

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io) - https://github.com/FakerPHP/fakerphp.github.io/pull/108

### Review checklist

- [x] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
