### PR TITLE
Fix T.C. ID generation bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#886)
 - Refreshed ISO currencies (#919)
 - Improved italian phone number formats
+- Fix T.C. ID generation: no leading zero, correct tenth digit (#966)
 
 ## [2024-11-09, v1.24.0](https://github.com/FakerPHP/Faker/compare/v1.23.1..v1.24.0)
 

--- a/src/Faker/Provider/tr_TR/Person.php
+++ b/src/Faker/Provider/tr_TR/Person.php
@@ -104,7 +104,8 @@ class Person extends \Faker\Provider\Person
      */
     public function tcNo()
     {
-        $randomDigits = static::numerify('#########');
+        $firstDigit = static::randomDigitNotNull();
+        $randomDigits = $firstDigit . static::numerify('########');
         $checksum = self::tcNoChecksum($randomDigits);
 
         return $randomDigits . $checksum;
@@ -139,7 +140,7 @@ class Person extends \Faker\Provider\Person
             }
         }
 
-        $tenthDigit = (7 * $evenSum - $oddSum) % 10;
+        $tenthDigit = ((7 * $evenSum - $oddSum) % 10 + 10) % 10;
         $eleventhDigit = ($evenSum + $oddSum + $tenthDigit) % 10;
 
         return $tenthDigit . $eleventhDigit;


### PR DESCRIPTION
### What is the reason for this PR?

This PR addresses two issues in the T.C. ID number generator:
1. Prevents T.C. numbers from starting with 0, which is invalid.
2. Fixes the calculation of the tenth digit to ensure it is always a positive single digit.

- [ ] A new feature
- [x] Fixed an issue (resolve #966)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

- Updated the generation logic to ensure the first digit is always between 1 and 9.
- Fixed the tenth digit calculation to handle negative modulo results properly by applying ((value % 10) + 10) % 10.

### Review checklist

- [x] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
