### PR TITLE
Fix standard en_GB VAT numbers being generated with an incorrect digit length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#886)
 - Refreshed ISO currencies (#919)
 - Improved italian phone number formats
+- Fixed en_GB standard VAT numbers having an incorrect length if the check digit has a leading zero
 
 ## [2024-11-09, v1.24.0](https://github.com/FakerPHP/Faker/compare/v1.23.1..v1.24.0)
 

--- a/src/Faker/Provider/en_GB/Company.php
+++ b/src/Faker/Provider/en_GB/Company.php
@@ -49,7 +49,7 @@ class Company extends \Faker\Provider\Company
         $secondBlock = static::randomNumber(4, true);
 
         return sprintf(
-            '%s%d %d %d',
+            '%s%s %s %s',
             static::VAT_PREFIX,
             $firstBlock,
             $secondBlock,
@@ -64,7 +64,7 @@ class Company extends \Faker\Provider\Company
     private static function generateHealthAuthorityVatNumber(): string
     {
         return sprintf(
-            '%sHA%d',
+            '%sHA%s',
             static::VAT_PREFIX,
             static::numberBetween(500, 999),
         );
@@ -77,7 +77,7 @@ class Company extends \Faker\Provider\Company
     private static function generateBranchTraderVatNumber(): string
     {
         return sprintf(
-            '%s %d',
+            '%s %s',
             static::generateStandardVatNumber(),
             static::randomNumber(3, true),
         );

--- a/test/Faker/Provider/en_GB/CompanyTest.php
+++ b/test/Faker/Provider/en_GB/CompanyTest.php
@@ -66,6 +66,15 @@ final class CompanyTest extends TestCase
         self::assertTrue($matches[1] < 1000);
     }
 
+    public function testLeadingZeroInModulus97BlockRemainsAfterFormatting(): void
+    {
+        // Force Faker to generate VAT number GB216 5727 07
+        $this->faker->seed(297957);
+        $number = $this->faker->vat();
+        $this->assertDefaultVatFormat($number);
+        self::assertStringEndsWith('07', substr($number, -2));
+    }
+
     protected function getProviders(): iterable
     {
         yield new Company($this->faker);


### PR DESCRIPTION
### What is the reason for this PR?

Standard UK VAT numbers should be 9 digits.

If the Modulus 97 block of a UK VAT number has a leading 0, this zero gets thrown out when sprintf casts this block from a string (%s) to an int (%d) during formatting.

For example, a check block of "07" would end up like:

`GB216 5727 7`

but it should be:

`GB216 5727 07`

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io) _(N/A)_

### Summary of changes

Change `sprintf` from using `%d` to `%s` so that zero-padded strings are not truncated when casting to integers, to preserve leading zeroes and retain a digit length of 9 for standard VAT numbers.

### Review checklist

- [ ] All checks have passed
- [x] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
