### PR TITLE
Replace deprecated via.placeholder.com with placehold.co 

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -10,7 +10,7 @@ class Image extends Base
     /**
      * @var string
      */
-    public const BASE_URL = 'https://via.placeholder.com';
+    public const BASE_URL = 'https://placehold.co';
 
     public const FORMAT_JPG = 'jpg';
     public const FORMAT_JPEG = 'jpeg';
@@ -31,7 +31,7 @@ class Image extends Base
      *
      * Set randomize to false to remove the random GET parameter at the end of the url.
      *
-     * @example 'http://via.placeholder.com/640x480.png/CCCCCC?text=well+hi+there'
+     * @example 'http://placehold.co/640x480.png/CCCCCC?text=well+hi+there'
      *
      * @param int         $width
      * @param int         $height

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -13,7 +13,7 @@ final class ImageTest extends TestCase
     public function testImageUrlUses640x680AsTheDefaultSize(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/640x480.png/#',
+            '#^https://placehold.co/640x480.png/#',
             Image::imageUrl(),
         );
     }
@@ -21,7 +21,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomWidthAndHeight(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/#',
+            '#^https://placehold.co/800x400.png/#',
             Image::imageUrl(800, 400),
         );
     }
@@ -29,7 +29,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomCategory(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+.*#',
+            '#^https://placehold.co/800x400.png/[\w]{6}\?text=nature\+.*#',
             Image::imageUrl(800, 400, 'nature'),
         );
     }
@@ -37,7 +37,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomText(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400.png/[\w]{6}\?text=nature\+Faker#',
             Image::imageUrl(800, 400, 'nature', false, 'Faker'),
         );
     }
@@ -54,7 +54,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400.png/[\w]{6}\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -71,7 +71,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/CCCCCC\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400.png/CCCCCC\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -113,7 +113,7 @@ final class ImageTest extends TestCase
             );
 
             self::assertMatchesRegularExpression(
-                "#^https://via.placeholder.com/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
+                "#^https://placehold.co/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
                 $imageUrl,
             );
         }


### PR DESCRIPTION
### What is the reason for this PR?

Updated the default image placeholder URL in the Image provider from https://via.placeholder.com (which is no longer available) to https://placehold.co. This change ensures that Faker's imageUrl() method returns valid, working placeholder image URLs. It fixes broken image links and maintains compatibility for users relying on Faker-generated images.
