### PR TITLE
Replacement via.placeholder.com to placehold.co

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed functionality for populating ORM entities and models (#764)
 - Added a PHP version support policy (#752)
 - Stopped using `static` in callables in `Provider\pt_BR\PhoneNumber` (#785)
+- Fixed deprecated Image base URL in `Provider\Image` (#787)
 
 ## [2023-06-12, v1.23.0](https://github.com/FakerPHP/Faker/compare/v1.22.0..v1.23.0)
 

--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -83,3 +83,4 @@ parameters:
     - '#\[BC\] CHANGED: The parameter $numberExtension of Faker\\Core\\Barcode\#__construct\(\) changed from Faker\\Extension\\NumberExtension|null to a non-contravariant Faker\\Extension\\NumberExtension#'
     - '#\[BC\] CHANGED: The number of required arguments for Faker\\Core\\Version\#__construct\(\) increased from 0 to 1#'
     - '#\[BC\] CHANGED: The parameter $numberExtension of Faker\\Core\\Version\#__construct\(\) changed from Faker\\Extension\\NumberExtension|null to a non-contravariant Faker\\Extension\\NumberExtension#'
+    - "#\[BC\] CHANGED: Value of constant Faker\\Provider\\Image::BASE_URL changed from 'https://via.placeholder.com' to 'https://placehold.co'#"

--- a/src/Provider/Color.php
+++ b/src/Provider/Color.php
@@ -62,6 +62,22 @@ class Color extends Base
     }
 
     /**
+     * Returns a suitable text color for the given background color.
+     * If the background is dark, returns white (`FFFFFF`); if light, returns black (`000000`).
+     *
+     * @param string $backgroundHex Background color in hex format (e.g. '#CCCCCC')
+     * @return string Text color hex code ('000000' or 'FFFFFF')
+     */
+    public static function safeTextColorForBackground($backgroundHex)
+    {
+        $backgroundHex = str_replace('#', '', $backgroundHex);
+        $r = hexdec(substr($backgroundHex, 0, 2));
+        $g = hexdec(substr($backgroundHex, 2, 2));
+        $b = hexdec(substr($backgroundHex, 4, 2));
+        $luminance = (0.299 * $r + 0.587 * $g + 0.114 * $b);
+        return $luminance > 186 ? '000000' : 'FFFFFF';
+    }
+    /**
      * @example 'array(0,255,122)'
      *
      * @return array

--- a/src/Provider/Image.php
+++ b/src/Provider/Image.php
@@ -86,7 +86,7 @@ class Image extends Base
         }
 
         $backgroundColor = $gray === true ? 'CCCCCC' : str_replace('#', '', Color::safeHexColor());
-        $textColor = "000000";
+        $textColor = $gray === true ? '000000' : Color::safeTextColorForBackground($backgroundColor);
 
         return sprintf(
             '%s/%s/%s/%s/%s%s',

--- a/src/Provider/Image.php
+++ b/src/Provider/Image.php
@@ -10,7 +10,7 @@ class Image extends Base
     /**
      * @var string
      */
-    public const BASE_URL = 'https://via.placeholder.com';
+    public const BASE_URL = 'https://placehold.co';
 
     public const FORMAT_JPG = 'jpg';
     public const FORMAT_JPEG = 'jpeg';
@@ -31,7 +31,7 @@ class Image extends Base
      *
      * Set randomize to false to remove the random GET parameter at the end of the url.
      *
-     * @example 'http://via.placeholder.com/640x480.png/CCCCCC?text=well+hi+there'
+     * @example 'http://placehold.co/640x480/CCCCCC/000000/png?text=well+hi+there'
      *
      * @param int         $width
      * @param int         $height
@@ -69,7 +69,7 @@ class Image extends Base
             ));
         }
 
-        $size = sprintf('%dx%d.%s', $width, $height, $format);
+        $size = sprintf('%dx%d', $width, $height);
 
         $imageParts = [];
 
@@ -86,12 +86,15 @@ class Image extends Base
         }
 
         $backgroundColor = $gray === true ? 'CCCCCC' : str_replace('#', '', Color::safeHexColor());
+        $textColor = "000000";
 
         return sprintf(
-            '%s/%s/%s%s',
+            '%s/%s/%s/%s/%s%s',
             self::BASE_URL,
             $size,
             $backgroundColor,
+            $textColor,
+            $format,
             count($imageParts) > 0 ? '?text=' . urlencode(implode(' ', $imageParts)) : '',
         );
     }
@@ -140,7 +143,7 @@ class Image extends Base
         // save file
         if (function_exists('curl_exec')) {
             // use cURL
-            $fp = fopen($filepath, 'w');
+            $fp = fopen($filepath, 'wb');
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;

--- a/test/Provider/ImageTest.php
+++ b/test/Provider/ImageTest.php
@@ -15,7 +15,7 @@ final class ImageTest extends TestCase
     public function testImageUrlUses640x680AsTheDefaultSize(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/640x480.png/#',
+            '#^https://placehold.co/640x480#',
             Image::imageUrl(),
         );
     }
@@ -23,7 +23,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomWidthAndHeight(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/#',
+            '#^https://placehold.co/800x400#',
             Image::imageUrl(800, 400),
         );
     }
@@ -31,7 +31,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomCategory(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+.*#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}/png\?text=nature\+.*#',
             Image::imageUrl(800, 400, 'nature'),
         );
     }
@@ -39,7 +39,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomText(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}/png\?text=nature\+Faker#',
             Image::imageUrl(800, 400, 'nature', false, 'Faker'),
         );
     }
@@ -56,7 +56,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}/png\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -73,7 +73,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/CCCCCC\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/CCCCCC/000000/png\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -81,9 +81,9 @@ final class ImageTest extends TestCase
     public function testImageUrlAddsARandomGetParameterByDefault(): void
     {
         $url = Image::imageUrl(800, 400);
-        $splitUrl = preg_split('/\?text=/', $url);
+        $splitUrl = explode("?text=", $url);
 
-        self::assertEquals(count($splitUrl), 2);
+        self::assertCount(2, $splitUrl);
         self::assertMatchesRegularExpression('#\w*#', $splitUrl[1]);
     }
 
@@ -115,7 +115,7 @@ final class ImageTest extends TestCase
             );
 
             self::assertMatchesRegularExpression(
-                "#^https://via.placeholder.com/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
+                "#^https://placehold.co/800x400/CCCCCC/000000/{$format}\?text=nature\+Faker#",
                 $imageUrl,
             );
         }


### PR DESCRIPTION
### What is the reason for this PR?

Updated the default image placeholder URL in the Image provider from https://via.placeholder.com/ (which is no longer available) to https://placehold.co/. This change ensures that Faker's imageUrl() method returns valid, working placeholder image URLs. It fixes broken image links and maintains compatibility for users relying on Faker-generated images.

- [X] Fixed an issue (resolve #986 #797 #645 #614  )

### Review checklist

- [x] All checks have passed
- [X] Changes are added to the `CHANGELOG.md`
