### PR TITLE
Replacement via.placeholder.com to placehold.co

### DIFF
--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -49,4 +49,4 @@ parameters:
     - '#\[BC\] REMOVED: Method Faker\\Core\\DateTime\#setTimezone\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid3\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid\(\) was removed#'
-    - "#\[BC\] CHANGED: Value of constant Faker\\Provider\\Image::BASE_URL changed from 'https://via.placeholder.com' to 'https://placehold.co'#"
+    - '#\[BC\] CHANGED: Value of constant Faker\\Provider\\Image::BASE_URL changed from \'https://via.placeholder.com\' to \'https://placehold.co\'#'

--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -49,4 +49,4 @@ parameters:
     - '#\[BC\] REMOVED: Method Faker\\Core\\DateTime\#setTimezone\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid3\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid\(\) was removed#'
-    - '#\[BC\] CHANGED: Value of constant Faker\\Provider\\Image::BASE_URL changed from \'https://via.placeholder.com\' to \'https://placehold.co\'#'
+    - '#\[BC\] CHANGED: Value of constant Faker\\Provider\\Image::BASE_URL changed from ''https://via.placeholder.com'' to ''https://placehold.co''#'

--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -49,3 +49,4 @@ parameters:
     - '#\[BC\] REMOVED: Method Faker\\Core\\DateTime\#setTimezone\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid3\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid\(\) was removed#'
+    - "#\[BC\] CHANGED: Value of constant Faker\\Provider\\Image::BASE_URL changed from 'https://via.placeholder.com' to 'https://placehold.co'#"

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -60,11 +60,13 @@ class Color extends Base
 
         return '#' . $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
     }
+
     /**
      * Returns a suitable text color for the given background color.
      * If the background is dark, returns white (`FFFFFF`); if light, returns black (`000000`).
      *
      * @param string $backgroundHex Background color in hex format (e.g. '#CCCCCC')
+     *
      * @return string Text color hex code ('000000' or 'FFFFFF')
      */
     public static function safeTextColorForBackground($backgroundHex)
@@ -74,6 +76,7 @@ class Color extends Base
         $g = hexdec(substr($backgroundHex, 2, 2));
         $b = hexdec(substr($backgroundHex, 4, 2));
         $luminance = (0.299 * $r + 0.587 * $g + 0.114 * $b);
+
         return $luminance > 186 ? '000000' : 'FFFFFF';
     }
 

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -60,6 +60,22 @@ class Color extends Base
 
         return '#' . $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
     }
+    /**
+     * Returns a suitable text color for the given background color.
+     * If the background is dark, returns white (`FFFFFF`); if light, returns black (`000000`).
+     *
+     * @param string $backgroundHex Background color in hex format (e.g. '#CCCCCC')
+     * @return string Text color hex code ('000000' or 'FFFFFF')
+     */
+    public static function safeTextColorForBackground($backgroundHex)
+    {
+        $backgroundHex = str_replace('#', '', $backgroundHex);
+        $r = hexdec(substr($backgroundHex, 0, 2));
+        $g = hexdec(substr($backgroundHex, 2, 2));
+        $b = hexdec(substr($backgroundHex, 4, 2));
+        $luminance = (0.299 * $r + 0.587 * $g + 0.114 * $b);
+        return $luminance > 186 ? '000000' : 'FFFFFF';
+    }
 
     /**
      * @example 'array(0,255,122)'

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -10,7 +10,7 @@ class Image extends Base
     /**
      * @var string
      */
-    public const BASE_URL = 'https://via.placeholder.com';
+    public const BASE_URL = 'https://placehold.co';
 
     public const FORMAT_JPG = 'jpg';
     public const FORMAT_JPEG = 'jpeg';
@@ -31,7 +31,7 @@ class Image extends Base
      *
      * Set randomize to false to remove the random GET parameter at the end of the url.
      *
-     * @example 'http://via.placeholder.com/640x480.png/CCCCCC?text=well+hi+there'
+     * @example 'https://placehold.co/640x480/CCCCCC/0000000/png?text=well+hi+there'
      *
      * @param int         $width
      * @param int         $height
@@ -70,7 +70,7 @@ class Image extends Base
             ));
         }
 
-        $size = sprintf('%dx%d.%s', $width, $height, $format);
+        $size = sprintf('%dx%d', $width, $height);
 
         $imageParts = [];
 
@@ -87,12 +87,15 @@ class Image extends Base
         }
 
         $backgroundColor = $gray === true ? 'CCCCCC' : str_replace('#', '', Color::safeHexColor());
+        $textColor = $gray === true ? '000000' : Color::safeTextColorForBackground($backgroundColor);
 
         return sprintf(
-            '%s/%s/%s%s',
+            '%s/%s/%s/%s/%s%s',
             self::BASE_URL,
             $size,
             $backgroundColor,
+            $textColor,
+            $format,
             count($imageParts) > 0 ? '?text=' . urlencode(implode(' ', $imageParts)) : '',
         );
     }
@@ -142,7 +145,7 @@ class Image extends Base
         // save file
         if (function_exists('curl_exec')) {
             // use cURL
-            $fp = fopen($filepath, 'w');
+            $fp = fopen($filepath, 'wb');
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -13,7 +13,7 @@ final class ImageTest extends TestCase
     public function testImageUrlUses640x680AsTheDefaultSize(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/640x480.png/#',
+            '#^https://placehold.co/640x480#',
             Image::imageUrl(),
         );
     }
@@ -21,7 +21,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomWidthAndHeight(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/#',
+            '#^https://placehold.co/800x400#',
             Image::imageUrl(800, 400),
         );
     }
@@ -29,7 +29,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomCategory(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+.*#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}/png\?text=nature\+.*#',
             Image::imageUrl(800, 400, 'nature'),
         );
     }
@@ -37,7 +37,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomText(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}/png\?text=nature\+Faker#',
             Image::imageUrl(800, 400, 'nature', false, 'Faker'),
         );
     }
@@ -54,7 +54,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}/png\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -71,7 +71,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/CCCCCC\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/CCCCCC/000000/png\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -79,9 +79,9 @@ final class ImageTest extends TestCase
     public function testImageUrlAddsARandomGetParameterByDefault(): void
     {
         $url = Image::imageUrl(800, 400);
-        $splitUrl = preg_split('/\?text=/', $url);
+        $splitUrl = explode("?text=", $url);
 
-        self::assertEquals(count($splitUrl), 2);
+        self::assertCount(2, $splitUrl);
         self::assertMatchesRegularExpression('#\w*#', $splitUrl[1]);
     }
 
@@ -113,7 +113,7 @@ final class ImageTest extends TestCase
             );
 
             self::assertMatchesRegularExpression(
-                "#^https://via.placeholder.com/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
+                "#^https://placehold.co/800x400/CCCCCC/000000/{$format}\?text=nature\+Faker#",
                 $imageUrl,
             );
         }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -79,9 +79,9 @@ final class ImageTest extends TestCase
     public function testImageUrlAddsARandomGetParameterByDefault(): void
     {
         $url = Image::imageUrl(800, 400);
-        $splitUrl = explode("?text=", $url);
+        $splitUrl = preg_split('/\?text=/', $url);
 
-        self::assertCount(2, $splitUrl);
+        self::assertEquals(count($splitUrl), 2);
         self::assertMatchesRegularExpression('#\w*#', $splitUrl[1]);
     }
 


### PR DESCRIPTION
### What is the reason for this PR?

Updated the default image placeholder URL in the Image provider from https://via.placeholder.com/ (which is no longer available) to https://placehold.co/. This change ensures that Faker's imageUrl() method returns valid, working placeholder image URLs. It fixes broken image links and maintains compatibility for users relying on Faker-generated images.

- [X] Fixed an issue (resolve #986 #797 #645 #614  )

### Review checklist

- [x] All checks have passed
- [X] Changes are added to the `CHANGELOG.md`
