### PR TITLE
Add in_BD locale provider for Bangladesh (English)

### DIFF
--- a/src/Provider/in_BD/Address.php
+++ b/src/Provider/in_BD/Address.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Faker\Provider\in_BD;
+
+class Address extends \Faker\Provider\Address
+{
+    protected static $districts = [
+        'Dhaka', 'Chattogram', 'Rajshahi', 'Khulna', 'Barishal',
+        'Sylhet', 'Rangpur', 'Mymensingh', 'Cumilla', 'Narayanganj'
+    ];
+
+    protected static $streets = [
+        'Station Road', 'College Road', 'Banani Road', 'Gulshan Avenue', 'New Market Road',
+        'Airport Road', 'Baily Road', 'Kakrail Road', 'Kazi Nazrul Islam Avenue', 'Mirpur Road'
+    ];
+
+    public function district()
+    {
+        return static::randomElement(static::$districts);
+    }
+
+    public function streetName()
+    {
+        return static::randomElement(static::$streets);
+    }
+
+    public function streetAddress()
+    {
+        return $this->numberBetween(1, 200) . ' ' . $this->streetName();
+    }
+
+    public function address()
+    {
+        return $this->streetAddress() . ', ' . $this->district() . ' ' . $this->postcode();
+    }
+
+    public function postcode()
+    {
+        return (string) $this->numberBetween(1000, 9999);
+    }
+}

--- a/src/Provider/in_BD/Company.php
+++ b/src/Provider/in_BD/Company.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Faker\Provider\in_BD;
+
+class Company extends \Faker\Provider\Company
+{
+    protected static $companyPrefixes = [
+        'Tech', 'Soft', 'Info', 'Data', 'Green', 'Sky', 'Smart', 'Global', 'Next', 'Prime'
+    ];
+
+    protected static $companySuffixes = [
+        'Ltd', 'Limited', 'Corporation', 'Group', 'Inc'
+    ];
+
+    public function company()
+    {
+        return static::randomElement(static::$companyPrefixes) . ' ' . static::randomElement(static::$companySuffixes);
+    }
+}

--- a/src/Provider/in_BD/Person.php
+++ b/src/Provider/in_BD/Person.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Faker\Provider\in_BD;
+
+class Person extends \Faker\Provider\Person
+{
+    protected static $maleFirstName = [
+        'Abdul', 'Hasan', 'Rafiqul', 'Shahidul', 'Mahmud', 'Faruk', 'Jamal', 'Nazrul', 'Masud', 'Anis'
+    ];
+
+    protected static $femaleFirstName = [
+        'Ayesha', 'Fatema', 'Shamima', 'Nusrat', 'Rokeya', 'Sadia', 'Mitu', 'Tahmina', 'Shirin', 'Lubna'
+    ];
+
+    protected static $lastName = [
+        'Haque', 'Chowdhury', 'Ahmed', 'Siddique', 'Rahman', 'Khan', 'Miah', 'Uddin', 'Sarker', 'Ali'
+    ];
+}

--- a/src/Provider/in_BD/PhoneNumber.php
+++ b/src/Provider/in_BD/PhoneNumber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Faker\Provider\in_BD;
+
+class PhoneNumber extends \Faker\Provider\PhoneNumber
+{
+    protected static $mobilePrefixes = [
+        '013', '014', '015', '016', '017', '018', '019'
+    ];
+
+    protected static $stdCodes = [
+        '02',    // Dhaka
+        '031',   // Chattogram
+        '0721',  // Rajshahi
+        '041',   // Khulna
+        '0431',  // Barishal
+        '0821',  // Sylhet
+        '0521',  // Rangpur
+    ];
+
+    public function mobileNumber()
+    {
+        return static::randomElement(static::$mobilePrefixes) . $this->numberBetween(10000000, 99999999);
+    }
+
+    public function landlineNumber()
+    {
+        return static::randomElement(static::$stdCodes) . '-' . $this->numberBetween(100000, 999999);
+    }
+
+    public function phoneNumber()
+    {
+        return $this->randomElement([
+            $this->mobileNumber(),
+            $this->landlineNumber()
+        ]);
+    }
+}


### PR DESCRIPTION
Adds a new en_BD locale for generating Bangladesh-specific fake data in English.
Includes Person, Address, Company, and PhoneNumber providers with local names, districts, realistic street addresses, valid mobile/landline formats, and localized company names.