### PR TITLE
Replace legacy __wakeup with __unserialize

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -966,8 +966,8 @@ class Generator
         $this->seed();
     }
 
-    public function __wakeup()
+    public function __unserialize(array $data)
     {
-        $this->formatters = [];
+        throw new \Exception('Generator cannot be unserialized');
     }
 }


### PR DESCRIPTION
The `__wakeup` method was initially added in #136, but `__wakeup` is deprecated in PHP 8.5.