### PR TITLE
chore: change default placeholder image URL 

### DIFF
--- a/src/Provider/Image.php
+++ b/src/Provider/Image.php
@@ -10,7 +10,11 @@ class Image extends Base
     /**
      * @var string
      */
-    public const BASE_URL = 'https://via.placeholder.com';
+    // Old URL for placeholder images
+    // public const BASE_URL = 'https://via.placeholder.com';
+
+    // New URL for placeholder images
+    public const BASE_URL = 'https://placeholder.himagawa.fr';
 
     public const FORMAT_JPG = 'jpg';
     public const FORMAT_JPEG = 'jpeg';
@@ -31,7 +35,7 @@ class Image extends Base
      *
      * Set randomize to false to remove the random GET parameter at the end of the url.
      *
-     * @example 'http://via.placeholder.com/640x480.png/CCCCCC?text=well+hi+there'
+     * @example 'http://placeholder.himagawa.fr/640x480.png/CCCCCC?text=well+hi+there'
      *
      * @param int         $width
      * @param int         $height


### PR DESCRIPTION
### What is the reason for this PR?

Update the default placeholder image URL to https://placeholder.himagawa.fr/
The previous URL (https://via.placeholder.com) has been kept as a comment for reference.
This change does not add new features or break existing functionality.

- [ ] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Changed the BASE_URL constant in src/Faker/Provider/Image.php from
'https://via.placeholder.com' to 'https://placeholder.himagawa.fr/'.
The old URL is kept in a comment for reference.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
