### PR TITLE
Fix: Replace via.placeholder.com with placehold.co #1013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removed domain `gmail.com.au` from `Provider\en_AU\Internet` (#886)
 - Refreshed ISO currencies (#919)
 - Improved italian phone number formats
+- Replaced `via.placeholder.com` with `placehold.co` in Image provider (#1013)
 
 ## [2024-11-09, v1.24.0](https://github.com/FakerPHP/Faker/compare/v1.23.1..v1.24.0)
 

--- a/roave-bc-check.yaml
+++ b/roave-bc-check.yaml
@@ -49,3 +49,4 @@ parameters:
     - '#\[BC\] REMOVED: Method Faker\\Core\\DateTime\#setTimezone\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid3\(\) was removed#'
     - '#\[BC\] REMOVED: Method Faker\\Generator\#uuid\(\) was removed#'
+    - '#\[BC\] CHANGED: Value of constant Faker\\Provider\\Image::BASE_URL changed from .*#'

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -10,7 +10,7 @@ class Image extends Base
     /**
      * @var string
      */
-    public const BASE_URL = 'https://via.placeholder.com';
+    public const BASE_URL = 'https://placehold.co';
 
     public const FORMAT_JPG = 'jpg';
     public const FORMAT_JPEG = 'jpeg';
@@ -31,7 +31,7 @@ class Image extends Base
      *
      * Set randomize to false to remove the random GET parameter at the end of the url.
      *
-     * @example 'http://via.placeholder.com/640x480.png/CCCCCC?text=well+hi+there'
+     * @example 'https://placehold.co/640x480.png/CCCCCC?text=well+hi+there'
      *
      * @param int         $width
      * @param int         $height
@@ -70,7 +70,7 @@ class Image extends Base
             ));
         }
 
-        $size = sprintf('%dx%d.%s', $width, $height, $format);
+        $size = sprintf('%dx%d', $width, $height);
 
         $imageParts = [];
 
@@ -87,12 +87,15 @@ class Image extends Base
         }
 
         $backgroundColor = $gray === true ? 'CCCCCC' : str_replace('#', '', Color::safeHexColor());
+        $textColor = str_replace('#', '', Color::safeHexColor());
 
         return sprintf(
-            '%s/%s/%s%s',
+            '%s/%s/%s/%s.%s%s',
             self::BASE_URL,
             $size,
             $backgroundColor,
+            $textColor,
+            $format,
             count($imageParts) > 0 ? '?text=' . urlencode(implode(' ', $imageParts)) : '',
         );
     }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -13,7 +13,7 @@ final class ImageTest extends TestCase
     public function testImageUrlUses640x680AsTheDefaultSize(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/640x480.png/#',
+            '#^https://placehold.co/640x480/#',
             Image::imageUrl(),
         );
     }
@@ -21,7 +21,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomWidthAndHeight(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/#',
+            '#^https://placehold.co/800x400/#',
             Image::imageUrl(800, 400),
         );
     }
@@ -29,7 +29,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomCategory(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+.*#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}\.png\?text=nature\+.*#',
             Image::imageUrl(800, 400, 'nature'),
         );
     }
@@ -37,7 +37,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomText(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}\.png\?text=nature\+Faker#',
             Image::imageUrl(800, 400, 'nature', false, 'Faker'),
         );
     }
@@ -54,7 +54,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[\w]{6}/[\w]{6}\.png\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -71,7 +71,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/CCCCCC\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/CCCCCC/[\w]{6}\.png\?text=nature\+Faker#',
             $imageUrl,
         );
     }
@@ -113,7 +113,7 @@ final class ImageTest extends TestCase
             );
 
             self::assertMatchesRegularExpression(
-                "#^https://via.placeholder.com/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
+                "#^https://placehold.co/800x400/CCCCCC/[\w]{6}\.{$format}\?text=nature\+Faker#",
                 $imageUrl,
             );
         }


### PR DESCRIPTION
### What is the reason for this PR?

The default image provider `via.placeholder.com` is no longer working, causing the `Image` provider and its associated unit tests to fail consistently (Issue #1013). This PR replaces the broken service with `placehold.co` to restore functionality and fix the test suite.

- [ ] A new feature
- [x] Fixed an issue (resolve #1013)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

* Updated `Faker\Provider\Image::BASE_URL` to use `https://placehold.co`.
* Refactored the `imageUrl` generation logic to match the URL structure required by `placehold.co` (specifically the placement of background colors, text colors, and file extensions).
* Updated `Faker\Test\Provider\ImageTest` to assert against the new URL patterns and domain.
* Ensured `curl` and `fopen` download logic works with the new provider.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer