### PR TITLE
Fix datetime deprecation in Doctrine ColumnTypeGuesser

### DIFF
--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -80,7 +80,7 @@ class ColumnTypeGuesser
             case 'date_immutable':
             case 'time_immutable':
                 return static function () use ($generator) {
-                    return \DateTimeImmutable::createFromMutable($generator->datetime);
+                    return \DateTimeImmutable::createFromMutable($generator->datetime());
                 };
 
             default:


### PR DESCRIPTION
### What is the reason for this PR?

Fixes deprecation warning `Accessing property "datetime" is deprecated, use "datetime()" instead.`.

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [x] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

- Changed one line in ColumnTypeGuesser class where datetime property was used instead of method call.  

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
