### PR TITLE
fix(DateTime): support DateTimeImmutable in DateTime generators

### DIFF
--- a/src/Faker/Core/DateTime.php
+++ b/src/Faker/Core/DateTime.php
@@ -26,7 +26,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
     /**
      * Get the POSIX-timestamp of a DateTime, int or string.
      *
-     * @param \DateTime|float|int|string $until
+     * @param \DateTimeInterface|float|int|string $until
      *
      * @return false|int
      */
@@ -36,7 +36,7 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
             return (int) $until;
         }
 
-        if ($until instanceof \DateTime) {
+        if ($until instanceof \DateTimeInterface) {
             return $until->getTimestamp();
         }
 
@@ -110,7 +110,14 @@ final class DateTime implements DateTimeExtension, GeneratorAwareExtension
     public function dateTimeInInterval($from = '-30 years', string $interval = '+5 days', ?string $timezone = null): \DateTime
     {
         $intervalObject = \DateInterval::createFromDateString($interval);
-        $datetime = $from instanceof \DateTime ? $from : new \DateTime($from);
+
+        if ($from instanceof \DateTimeInterface) {
+            // Create mutable DateTime from DateTimeInterface (including DateTimeImmutable)
+            $datetime = new \DateTime($from->format('Y-m-d H:i:s.u'));
+            $datetime->setTimezone($from->getTimezone());
+        } else {
+            $datetime = new \DateTime($from);
+        }
 
         $other = (clone $datetime)->add($intervalObject);
 

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -9,7 +9,7 @@ class DateTime extends Base
     protected static $defaultTimezone = null;
 
     /**
-     * @param \DateTime|float|int|string $max
+     * @param \DateTimeInterface|float|int|string $max
      *
      * @return false|int
      */
@@ -19,7 +19,7 @@ class DateTime extends Base
             return (int) $max;
         }
 
-        if ($max instanceof \DateTime) {
+        if ($max instanceof \DateTimeInterface) {
             return $max->getTimestamp();
         }
 
@@ -29,7 +29,7 @@ class DateTime extends Base
     /**
      * Get a timestamp between January 1, 1970, and now
      *
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return int
      *
@@ -43,7 +43,7 @@ class DateTime extends Base
     /**
      * Get a datetime object for a date between January 1, 1970 and now
      *
-     * @param \DateTime|int|string $max      maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max      maximum timestamp used as random end limit, default to "now"
      * @param string               $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
      * @return \DateTime
@@ -64,7 +64,7 @@ class DateTime extends Base
     /**
      * Get a datetime object for a date between January 1, 001 and now
      *
-     * @param \DateTime|int|string $max      maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max      maximum timestamp used as random end limit, default to "now"
      * @param string|null          $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
      * @return \DateTime
@@ -87,7 +87,7 @@ class DateTime extends Base
     /**
      * get a date string formatted with ISO8601
      *
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -102,7 +102,7 @@ class DateTime extends Base
      * Get a date string between January 1, 1970 and now
      *
      * @param string               $format
-     * @param \DateTime|int|string $max    maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max    maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -117,7 +117,7 @@ class DateTime extends Base
      * Get a time string (24h format by default)
      *
      * @param string               $format
-     * @param \DateTime|int|string $max    maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max    maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -132,8 +132,8 @@ class DateTime extends Base
      * Get a DateTime object based on a random date between two given dates.
      * Accepts date strings that can be recognized by strtotime().
      *
-     * @param \DateTime|string $startDate Defaults to 30 years ago
-     * @param \DateTime|string $endDate   Defaults to "now"
+     * @param \DateTimeInterface|string $startDate Defaults to 30 years ago
+     * @param \DateTimeInterface|string $endDate   Defaults to "now"
      * @param string|null      $timezone  time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
      * @return \DateTime
@@ -145,7 +145,7 @@ class DateTime extends Base
      */
     public static function dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = null)
     {
-        $startTimestamp = $startDate instanceof \DateTime ? $startDate->getTimestamp() : strtotime($startDate);
+        $startTimestamp = $startDate instanceof \DateTimeInterface ? $startDate->getTimestamp() : strtotime($startDate);
         $endTimestamp = static::getMaxTimestamp($endDate);
 
         if ($startTimestamp > $endTimestamp) {
@@ -165,7 +165,7 @@ class DateTime extends Base
      * an interval
      * Accepts date string that can be recognized by strtotime().
      *
-     * @param \DateTime|string $date     Defaults to 30 years ago
+     * @param \DateTimeInterface|string $date     Defaults to 30 years ago
      * @param string           $interval Defaults to 5 days after
      * @param string|null      $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
@@ -179,7 +179,15 @@ class DateTime extends Base
     public static function dateTimeInInterval($date = '-30 years', $interval = '+5 days', $timezone = null)
     {
         $intervalObject = \DateInterval::createFromDateString($interval);
-        $datetime = $date instanceof \DateTime ? $date : new \DateTime($date);
+
+        if ($date instanceof \DateTimeInterface) {
+            // Create mutable DateTime from DateTimeInterface (including DateTimeImmutable)
+            $datetime = new \DateTime($date->format('Y-m-d H:i:s.u'));
+            $datetime->setTimezone($date->getTimezone());
+        } else {
+            $datetime = new \DateTime($date);
+        }
+
         $otherDatetime = clone $datetime;
         $otherDatetime->add($intervalObject);
 
@@ -196,7 +204,7 @@ class DateTime extends Base
     /**
      * Get a date time object somewhere within a century.
      *
-     * @param \DateTime|int|string $max      maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max      maximum timestamp used as random end limit, default to "now"
      * @param string|null          $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
      * @return \DateTime
@@ -209,7 +217,7 @@ class DateTime extends Base
     /**
      * Get a date time object somewhere within a decade.
      *
-     * @param \DateTime|int|string $max      maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max      maximum timestamp used as random end limit, default to "now"
      * @param string|null          $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
      * @return \DateTime
@@ -222,7 +230,7 @@ class DateTime extends Base
     /**
      * Get a date time object somewhere inside the current year.
      *
-     * @param \DateTime|int|string $max      maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max      maximum timestamp used as random end limit, default to "now"
      * @param string|null          $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
      * @return \DateTime
@@ -235,7 +243,7 @@ class DateTime extends Base
     /**
      * Get a date time object somewhere within a month.
      *
-     * @param \DateTime|int|string $max      maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max      maximum timestamp used as random end limit, default to "now"
      * @param string|null          $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      *
      * @return \DateTime
@@ -248,7 +256,7 @@ class DateTime extends Base
     /**
      * Get a string containing either "am" or "pm".
      *
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -260,7 +268,7 @@ class DateTime extends Base
     }
 
     /**
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -272,7 +280,7 @@ class DateTime extends Base
     }
 
     /**
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -284,7 +292,7 @@ class DateTime extends Base
     }
 
     /**
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -296,7 +304,7 @@ class DateTime extends Base
     }
 
     /**
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *
@@ -308,7 +316,7 @@ class DateTime extends Base
     }
 
     /**
-     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param \DateTimeInterface|int|string $max maximum timestamp used as random end limit, default to "now"
      *
      * @return string
      *

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -292,4 +292,48 @@ final class DateTimeTest extends TestCase
         self::assertIsString($countryTimezone);
         self::assertContains($countryTimezone, \DateTimeZone::listIdentifiers(\DateTimeZone::PER_COUNTRY, 'US'));
     }
+
+    public function testDateTimeBetweenAcceptsDateTimeImmutable(): void
+    {
+        $start = new \DateTimeImmutable('-1 week');
+        $end = new \DateTimeImmutable('now');
+
+        $date = DateTimeProvider::dateTimeBetween($start, $end);
+
+        self::assertInstanceOf(\DateTime::class, $date);
+        self::assertGreaterThanOrEqual($start, $date);
+        self::assertLessThanOrEqual($end, $date);
+    }
+
+    public function testDateTimeInIntervalAcceptsDateTimeImmutable(): void
+    {
+        $start = new \DateTimeImmutable('-1 week');
+
+        $date = DateTimeProvider::dateTimeInInterval($start, '+3 days');
+
+        self::assertInstanceOf(\DateTime::class, $date);
+        self::assertGreaterThanOrEqual($start, $date);
+        self::assertLessThanOrEqual($start->modify('+3 days'), $date);
+    }
+
+    public function testUnixTimeAcceptsDateTimeImmutable(): void
+    {
+        $max = new \DateTimeImmutable('2020-01-01 00:00:00');
+
+        $timestamp = DateTimeProvider::unixTime($max);
+
+        self::assertIsInt($timestamp);
+        self::assertGreaterThanOrEqual(0, $timestamp);
+        self::assertLessThanOrEqual($max->getTimestamp(), $timestamp);
+    }
+
+    public function testDateTimeAcceptsDateTimeImmutable(): void
+    {
+        $max = new \DateTimeImmutable('2020-01-01 00:00:00');
+
+        $date = DateTimeProvider::dateTime($max);
+
+        self::assertInstanceOf(\DateTime::class, $date);
+        self::assertLessThanOrEqual($max, $date);
+    }
 }


### PR DESCRIPTION
DateTime generators now accept `DateTimeImmutable`, not just `DateTime`. The type check in `getTimestamp()` was looking for `DateTime` specifically — changed it to `DateTimeInterface`.

Fixes #947