### PR TITLE
fix(Payment): calculate national BBAN checksums for IBAN generation

### DIFF
--- a/src/Faker/Calculator/Iban.php
+++ b/src/Faker/Calculator/Iban.php
@@ -109,4 +109,37 @@ class Iban
             strtoupper($string),
         );
     }
+
+    /**
+     * Calculate check digit using weighted MOD 11 algorithm
+     *
+     * Used by Norway, Netherlands, Slovakia, Iceland, and other countries.
+     * Formula: sum = Σ(digit[i] * weight[i]), check = 11 - (sum % 11)
+     *
+     * @param string $number  Numeric string to calculate check for
+     * @param int[]  $weights Array of weights (must match length of $number)
+     *
+     * @return int|null Check digit (0-9), or null if would be 10 (invalid, must regenerate)
+     */
+    public static function mod11(string $number, array $weights): ?int
+    {
+        $sum = 0;
+        $len = strlen($number);
+
+        for ($i = 0; $i < $len; ++$i) {
+            $sum += (int) $number[$i] * $weights[$i];
+        }
+
+        $check = 11 - ($sum % 11);
+
+        if ($check === 11) {
+            return 0;
+        }
+
+        if ($check === 10) {
+            return null; // Invalid - must regenerate
+        }
+
+        return $check;
+    }
 }

--- a/src/Faker/Calculator/Iban.php
+++ b/src/Faker/Calculator/Iban.php
@@ -66,4 +66,47 @@ class Iban
     {
         return self::checksum($iban) === substr($iban, 2, 2);
     }
+
+    /**
+     * Calculate check digits using ISO 7064 MOD 97-10 algorithm
+     *
+     * This is used by many countries for their BBAN check digits.
+     * Formula: (98 - mod97(number || '00')) % 97
+     *
+     * The % 97 at the end maps 97→00 and 98→01, which are equivalent
+     * under mod 97 verification since (N + 98) ≡ (N + 01) ≡ 1 (mod 97).
+     *
+     * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number#Algorithms
+     *
+     * @param string $number Numeric string (bank code + account number)
+     *
+     * @return string 2 digit check digits (00-96)
+     */
+    public static function mod97_10(string $number): string
+    {
+        $check = (98 - self::mod97($number . '00')) % 97;
+
+        return str_pad((string) $check, 2, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Convert alphanumeric string to numeric by replacing letters
+     *
+     * Used for calculating check digits on alphanumeric BBAN parts.
+     * A=10, B=11, ..., Z=35 (same as IBAN letter substitution).
+     *
+     * @param string $string Alphanumeric string
+     *
+     * @return string Numeric string
+     */
+    public static function alphanumericToNumeric(string $string): string
+    {
+        return preg_replace_callback(
+            '/[A-Z]/',
+            static function (array $matches): string {
+                return (string) self::alphaToNumber($matches[0]);
+            },
+            strtoupper($string),
+        );
+    }
 }

--- a/src/Faker/Provider/es_ES/Payment.php
+++ b/src/Faker/Provider/es_ES/Payment.php
@@ -2,9 +2,100 @@
 
 namespace Faker\Provider\es_ES;
 
+use Faker\Calculator\Iban;
+
 class Payment extends \Faker\Provider\Payment
 {
     private static $vatMap = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'N', 'P', 'Q', 'R', 'S', 'U', 'V', 'W'];
+
+    /**
+     * Weights for Spanish MOD 11 calculation (right to left)
+     *
+     * @var int[]
+     */
+    private static $mod11Weights = [1, 2, 4, 8, 5, 10, 9, 7, 3, 6];
+
+    /**
+     * International Bank Account Number (IBAN) for Spain
+     *
+     * Spanish IBAN structure: ES + 2 check digits + 20 digit BBAN
+     * BBAN structure: 4 digit bank code + 4 digit branch code + 2 control digits + 10 digit account
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     * @see https://es.wikipedia.org/wiki/C%C3%B3digo_cuenta_cliente
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always ES)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 20)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (4 digits)
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $bankCode = substr($prefix, 0, 4);
+            $prefix = substr($prefix, 4);
+        } else {
+            $bankCode = static::numerify('####');
+        }
+
+        // Branch code (4 digits)
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $branchCode = substr($prefix, 0, 4);
+            $prefix = substr($prefix, 4);
+        } else {
+            $branchCode = static::numerify('####');
+        }
+
+        // Account number (10 digits)
+        if ($prefix !== '') {
+            $accountNumber = str_pad(substr($prefix, 0, 10), 10, '0', STR_PAD_LEFT);
+        } else {
+            $accountNumber = static::numerify('##########');
+        }
+
+        // Calculate control digits
+        $dc1 = static::calculateControlDigit('00' . $bankCode . $branchCode);
+        $dc2 = static::calculateControlDigit($accountNumber);
+
+        // Assemble BBAN
+        $bban = $bankCode . $branchCode . $dc1 . $dc2 . $accountNumber;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('ES00' . $bban);
+
+        return 'ES' . $checksum . $bban;
+    }
+
+    /**
+     * Calculate Spanish control digit using MOD 11 algorithm
+     *
+     * @param string $digits 10 digit string
+     *
+     * @return string Single control digit (0-9)
+     */
+    protected static function calculateControlDigit(string $digits): string
+    {
+        $sum = 0;
+        $digits = str_pad($digits, 10, '0', STR_PAD_LEFT);
+
+        for ($i = 0; $i < 10; $i++) {
+            $sum += (int) $digits[$i] * self::$mod11Weights[$i];
+        }
+
+        $remainder = $sum % 11;
+        $digit = 11 - $remainder;
+
+        // Special cases
+        if ($digit === 11) {
+            $digit = 0;
+        } elseif ($digit === 10) {
+            $digit = 1;
+        }
+
+        return (string) $digit;
+    }
 
     /**
      * International Bank Account Number (IBAN)

--- a/src/Faker/Provider/fr_BE/Payment.php
+++ b/src/Faker/Provider/fr_BE/Payment.php
@@ -2,41 +2,12 @@
 
 namespace Faker\Provider\fr_BE;
 
-class Payment extends \Faker\Provider\Payment
+/**
+ * French-speaking Belgium payment provider
+ *
+ * Extends nl_BE\Payment since Belgian IBANs and VAT numbers are national,
+ * not language-specific.
+ */
+class Payment extends \Faker\Provider\nl_BE\Payment
 {
-    /**
-     * International Bank Account Number (IBAN)
-     *
-     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
-     *
-     * @param string $prefix      for generating bank account number of a specific bank
-     * @param string $countryCode ISO 3166-1 alpha-2 country code
-     * @param int    $length      total length without country code and 2 check digits
-     *
-     * @return string
-     */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'BE', $length = null)
-    {
-        return static::iban($countryCode, $prefix, $length);
-    }
-
-    /**
-     * Value Added Tax (VAT)
-     *
-     * @example 'BE0123456789', ('spaced') 'BE 0123456789'
-     *
-     * @see http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
-     * @see http://www.iecomputersystems.com/ordering/eu_vat_numbers.htm
-     * @see http://en.wikipedia.org/wiki/VAT_identification_number
-     *
-     * @param bool $spacedNationalPrefix
-     *
-     * @return string VAT Number
-     */
-    public static function vat($spacedNationalPrefix = true)
-    {
-        $prefix = $spacedNationalPrefix ? 'BE ' : 'BE';
-
-        return sprintf('%s0%d', $prefix, self::randomNumber(9, true));
-    }
 }

--- a/src/Faker/Provider/fr_FR/Payment.php
+++ b/src/Faker/Provider/fr_FR/Payment.php
@@ -2,8 +2,21 @@
 
 namespace Faker\Provider\fr_FR;
 
+use Faker\Calculator\Iban;
+
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Mapping of letters to numbers for RIB key calculation
+     *
+     * @var array<string, string>
+     */
+    private static $ribLetterMap = [
+        'A' => '1', 'B' => '2', 'C' => '3', 'D' => '4', 'E' => '5', 'F' => '6', 'G' => '7', 'H' => '8', 'I' => '9',
+        'J' => '1', 'K' => '2', 'L' => '3', 'M' => '4', 'N' => '5', 'O' => '6', 'P' => '7', 'Q' => '8', 'R' => '9',
+        'S' => '2', 'T' => '3', 'U' => '4', 'V' => '5', 'W' => '6', 'X' => '7', 'Y' => '8', 'Z' => '9',
+    ];
+
     /**
      * Value Added Tax (VAT)
      *
@@ -29,6 +42,86 @@ class Payment extends \Faker\Provider\Payment
         }
 
         return sprintf($pattern, 'FR', $key, $siren);
+    }
+
+    /**
+     * International Bank Account Number (IBAN) for France
+     *
+     * French IBAN structure: FR + 2 check digits + 23 character BBAN
+     * BBAN structure: 5 digit bank code + 5 digit branch code (guichet) + 11 alphanumeric account + 2 digit clé RIB
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     * @see https://fr.wikipedia.org/wiki/Cl%C3%A9_RIB
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always FR)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 23)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $bankCode = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $bankCode = static::numerify('#####');
+        }
+
+        // Branch code / guichet (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $branchCode = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $branchCode = static::numerify('#####');
+        }
+
+        // Account number (11 alphanumeric characters)
+        if ($prefix !== '') {
+            $accountNumber = str_pad(strtoupper(substr($prefix, 0, 11)), 11, '0', STR_PAD_LEFT);
+        } else {
+            $accountNumber = strtoupper(static::bothify('###########'));
+        }
+
+        // Calculate clé RIB (last 2 digits of BBAN)
+        $cleRib = static::calculateCleRib($bankCode, $branchCode, $accountNumber);
+
+        // Assemble BBAN
+        $bban = $bankCode . $branchCode . $accountNumber . $cleRib;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('FR00' . $bban);
+
+        return 'FR' . $checksum . $bban;
+    }
+
+    /**
+     * Calculate clé RIB (French BBAN check digits)
+     *
+     * @param string $bankCode      5 digit bank code
+     * @param string $branchCode    5 digit branch code
+     * @param string $accountNumber 11 character account number
+     *
+     * @return string 2 digit clé RIB
+     */
+    protected static function calculateCleRib(string $bankCode, string $branchCode, string $accountNumber): string
+    {
+        // Convert letters in account number to numbers
+        $numericAccount = strtr(strtoupper($accountNumber), self::$ribLetterMap);
+
+        // Concatenate all parts as a number
+        $fullNumber = $bankCode . $branchCode . $numericAccount;
+
+        // Calculate: 97 - (number mod 97)
+        $cle = 97 - Iban::mod97($fullNumber . '00');
+
+        // Special case: if remainder is 0, clé RIB is 97
+        if ($cle === 0) {
+            $cle = 97;
+        }
+
+        return str_pad((string) $cle, 2, '0', STR_PAD_LEFT);
     }
 
     /**

--- a/src/Faker/Provider/fr_MC/Payment.php
+++ b/src/Faker/Provider/fr_MC/Payment.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Faker\Provider\fr_MC;
+
+use Faker\Calculator\Iban;
+
+/**
+ * Monaco Payment Provider
+ *
+ * Monaco IBANs use the French BBAN format (clé RIB) with MC country code.
+ *
+ * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ */
+class Payment extends \Faker\Provider\fr_FR\Payment
+{
+    /**
+     * International Bank Account Number (IBAN) for Monaco
+     *
+     * Monaco IBAN structure: MC + 2 check digits + 23 character BBAN
+     * BBAN structure: 5 digit bank code + 5 digit branch code (guichet) + 11 alphanumeric account + 2 digit clé RIB
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always MC)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 23)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $bankCode = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $bankCode = static::numerify('#####');
+        }
+
+        // Branch code / guichet (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $branchCode = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $branchCode = static::numerify('#####');
+        }
+
+        // Account number (11 alphanumeric characters)
+        if ($prefix !== '') {
+            $accountNumber = str_pad(strtoupper(substr($prefix, 0, 11)), 11, '0', STR_PAD_LEFT);
+        } else {
+            $accountNumber = strtoupper(static::bothify('###########'));
+        }
+
+        // Calculate clé RIB (inherited from fr_FR)
+        $cleRib = static::calculateCleRib($bankCode, $branchCode, $accountNumber);
+
+        // Assemble BBAN
+        $bban = $bankCode . $branchCode . $accountNumber . $cleRib;
+
+        // Calculate IBAN check digits for Monaco
+        $checksum = Iban::checksum('MC00' . $bban);
+
+        return 'MC' . $checksum . $bban;
+    }
+
+    /**
+     * International Bank Account Number (IBAN)
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @param int    $length      total length without country code and 2 check digits
+     *
+     * @return string
+     */
+    public static function bankAccountNumber($prefix = '', $countryCode = 'MC', $length = null)
+    {
+        return static::iban($countryCode, $prefix, $length);
+    }
+}

--- a/src/Faker/Provider/is_IS/Payment.php
+++ b/src/Faker/Provider/is_IS/Payment.php
@@ -2,8 +2,105 @@
 
 namespace Faker\Provider\is_IS;
 
+use Faker\Calculator\Iban;
+
+/**
+ * Iceland Payment Provider
+ *
+ * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ */
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Weights for Icelandic kennitala check digit calculation
+     *
+     * @var int[]
+     */
+    private static $kennitalaWeights = [3, 2, 7, 6, 5, 4, 3, 2];
+
+    /**
+     * International Bank Account Number (IBAN) for Iceland
+     *
+     * Icelandic IBAN structure: IS + 2 check digits + 22 digit BBAN
+     * BBAN structure: 4 digit bank code + 2 digit branch + 6 digit account + 10 digit kennitala
+     *
+     * The kennitala has a check digit at position 9.
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always IS)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 22)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (4 digits)
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $bankCode = substr($prefix, 0, 4);
+            $prefix = substr($prefix, 4);
+        } else {
+            $bankCode = static::numerify('####');
+        }
+
+        // Branch code (2 digits)
+        $branchCode = static::numerify('##');
+
+        // Account number (6 digits)
+        $accountNumber = static::numerify('######');
+
+        // Generate kennitala (10 digits) with valid check digit
+        $kennitala = static::generateValidKennitala();
+
+        // Assemble BBAN
+        $bban = $bankCode . $branchCode . $accountNumber . $kennitala;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('IS00' . $bban);
+
+        return 'IS' . $checksum . $bban;
+    }
+
+    /**
+     * Generate a 10-digit kennitala with valid check digit at position 9
+     *
+     * Kennitala structure: DDMMYY-RRRC + century digit
+     * - DD = day (01-31)
+     * - MM = month (01-12)
+     * - YY = year
+     * - RR = random (2 digits at positions 7-8)
+     * - C = check digit at position 9
+     * - Century digit at position 10 (9=1900s, 0=2000s)
+     *
+     * @return string 10-digit kennitala
+     */
+    protected static function generateValidKennitala(): string
+    {
+        // Generate DDMMYY (6 digits) - use realistic date
+        $day = str_pad(mt_rand(1, 28), 2, '0', STR_PAD_LEFT);
+        $month = str_pad(mt_rand(1, 12), 2, '0', STR_PAD_LEFT);
+        $year = str_pad(mt_rand(50, 99), 2, '0', STR_PAD_LEFT);
+
+        // Random digits (2 digits at positions 7-8)
+        $random = static::numerify('##');
+
+        // First 8 digits
+        $base = $day . $month . $year . $random;
+
+        // Calculate check digit (position 9) using MOD 11
+        $checkDigit = Iban::mod11($base, self::$kennitalaWeights);
+
+        if ($checkDigit === null) {
+            return static::generateValidKennitala();
+        }
+
+        // Century digit (9 for 1900s)
+        $century = '9';
+
+        return $base . $checkDigit . $century;
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/src/Faker/Provider/it_IT/Payment.php
+++ b/src/Faker/Provider/it_IT/Payment.php
@@ -2,8 +2,114 @@
 
 namespace Faker\Provider\it_IT;
 
+use Faker\Calculator\Iban;
+
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Odd position values for CIN calculation
+     *
+     * @see https://it.wikipedia.org/wiki/Coordinate_bancarie_italiane
+     *
+     * @var array<string, int>
+     */
+    private static $cinOddValues = [
+        '0' => 1, '1' => 0, '2' => 5, '3' => 7, '4' => 9, '5' => 13, '6' => 15,
+        '7' => 17, '8' => 19, '9' => 21,
+        'A' => 1, 'B' => 0, 'C' => 5, 'D' => 7, 'E' => 9, 'F' => 13, 'G' => 15,
+        'H' => 17, 'I' => 19, 'J' => 21, 'K' => 2, 'L' => 4, 'M' => 18, 'N' => 20,
+        'O' => 11, 'P' => 3, 'Q' => 6, 'R' => 8, 'S' => 12, 'T' => 14, 'U' => 16,
+        'V' => 10, 'W' => 22, 'X' => 25, 'Y' => 24, 'Z' => 23,
+    ];
+
+    /**
+     * International Bank Account Number (IBAN) for Italy
+     *
+     * Italian IBAN structure: IT + 2 check digits + 23 character BBAN
+     * BBAN structure: 1 CIN letter + 5 digit ABI + 5 digit CAB + 12 char account
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     * @see https://it.wikipedia.org/wiki/Coordinate_bancarie_italiane
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always IT)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 23)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // ABI - bank code (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $abi = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $abi = static::numerify('#####');
+        }
+
+        // CAB - branch code (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $cab = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $cab = static::numerify('#####');
+        }
+
+        // Account number (12 alphanumeric characters)
+        if ($prefix !== '') {
+            $account = strtoupper(str_pad(substr($prefix, 0, 12), 12, '0', STR_PAD_LEFT));
+        } else {
+            $account = strtoupper(static::bothify('############'));
+        }
+
+        // Calculate CIN
+        $cin = static::calculateCin($abi . $cab . $account);
+
+        // Assemble BBAN
+        $bban = $cin . $abi . $cab . $account;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('IT00' . $bban);
+
+        return 'IT' . $checksum . $bban;
+    }
+
+    /**
+     * Calculate Italian CIN (Controllo Interno)
+     *
+     * @see https://it.wikipedia.org/wiki/Coordinate_bancarie_italiane
+     *
+     * @param string $code 22 character string (ABI + CAB + Account)
+     *
+     * @return string Single CIN letter (A-Z)
+     */
+    protected static function calculateCin(string $code): string
+    {
+        $code = strtoupper($code);
+        $sum = 0;
+
+        for ($i = 0; $i < 22; ++$i) {
+            $char = $code[$i];
+            // Position is 1-indexed for odd/even determination
+            $position = $i + 1;
+
+            if ($position % 2 === 1) {
+                // Odd position - use special values
+                $sum += self::$cinOddValues[$char];
+            } else {
+                // Even position - letters A=0, B=1..., digits as their value
+                if (ctype_digit($char)) {
+                    $sum += (int) $char;
+                } else {
+                    $sum += ord($char) - ord('A');
+                }
+            }
+        }
+
+        // CIN is the result mod 26 converted to a letter
+        return chr(ord('A') + ($sum % 26));
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/src/Faker/Provider/it_SM/Payment.php
+++ b/src/Faker/Provider/it_SM/Payment.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Faker\Provider\it_SM;
+
+use Faker\Calculator\Iban;
+
+/**
+ * San Marino Payment Provider
+ *
+ * San Marino IBANs use the Italian BBAN format (CIN) with SM country code.
+ *
+ * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ */
+class Payment extends \Faker\Provider\it_IT\Payment
+{
+    /**
+     * International Bank Account Number (IBAN) for San Marino
+     *
+     * San Marino IBAN structure: SM + 2 check digits + 23 character BBAN
+     * BBAN structure: 1 CIN letter + 5 digit ABI + 5 digit CAB + 12 char account
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always SM)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 23)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // ABI - bank code (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $abi = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $abi = static::numerify('#####');
+        }
+
+        // CAB - branch code (5 digits)
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $cab = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $cab = static::numerify('#####');
+        }
+
+        // Account number (12 alphanumeric characters)
+        if ($prefix !== '') {
+            $account = strtoupper(str_pad(substr($prefix, 0, 12), 12, '0', STR_PAD_LEFT));
+        } else {
+            $account = strtoupper(static::bothify('############'));
+        }
+
+        // Calculate CIN (inherited from it_IT)
+        $cin = static::calculateCin($abi . $cab . $account);
+
+        // Assemble BBAN
+        $bban = $cin . $abi . $cab . $account;
+
+        // Calculate IBAN check digits for San Marino
+        $checksum = Iban::checksum('SM00' . $bban);
+
+        return 'SM' . $checksum . $bban;
+    }
+
+    /**
+     * International Bank Account Number (IBAN)
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @param int    $length      total length without country code and 2 check digits
+     *
+     * @return string
+     */
+    public static function bankAccountNumber($prefix = '', $countryCode = 'SM', $length = null)
+    {
+        return static::iban($countryCode, $prefix, $length);
+    }
+}

--- a/src/Faker/Provider/mk_MK/Payment.php
+++ b/src/Faker/Provider/mk_MK/Payment.php
@@ -1,29 +1,30 @@
 <?php
 
-namespace Faker\Provider\me_ME;
+namespace Faker\Provider\mk_MK;
 
 use Faker\Calculator\Iban;
 
 /**
- * Montenegro Payment Provider
+ * North Macedonia Payment Provider
  *
  * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
  */
 class Payment extends \Faker\Provider\Payment
 {
     /**
-     * International Bank Account Number (IBAN) for Montenegro
+     * International Bank Account Number (IBAN) for North Macedonia
      *
-     * Montenegrin IBAN structure: ME + 2 check digits + 18 digit BBAN
-     * BBAN structure: 3 digit bank code + 13 digit account number + 2 digit national check digits
+     * North Macedonia IBAN structure: MK + 2 check digits + 15 digit BBAN
+     * BBAN structure: 3 digit bank code + 10 alphanumeric account characters + 2 digit national check digits
      *
      * National check digits use ISO 7064 MOD 97-10.
+     * Letters in account number are converted to numbers (A=10, B=11, ... Z=35) for calculation.
      *
      * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
      *
-     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always ME)
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always MK)
      * @param string $prefix      for generating bank account number of a specific bank
-     * @param int    $length      total length without country code and 2 check digits (ignored, always 18)
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 15)
      *
      * @return string
      */
@@ -37,20 +38,25 @@ class Payment extends \Faker\Provider\Payment
             $bankCode = static::numerify('###');
         }
 
-        // Account number (13 digits)
+        // Account number (10 alphanumeric characters)
         if ($prefix !== '') {
-            $accountNumber = str_pad(substr($prefix, 0, 13), 13, '0', STR_PAD_LEFT);
+            $accountNumber = strtoupper(str_pad(substr($prefix, 0, 10), 10, '0', STR_PAD_LEFT));
         } else {
-            $accountNumber = static::numerify('#############');
+            $accountNumber = strtoupper(static::bothify('##########'));
         }
 
-        // Assemble BBAN with check digits
-        $bban = $bankCode . $accountNumber . Iban::mod97_10($bankCode . $accountNumber);
+        // Calculate national check digits using MOD 97-10
+        // Convert letters to numbers for calculation
+        $numericAccount = Iban::alphanumericToNumeric($accountNumber);
+        $checkDigits = Iban::mod97_10($bankCode . $numericAccount);
+
+        // Assemble BBAN
+        $bban = $bankCode . $accountNumber . $checkDigits;
 
         // Calculate IBAN check digits
-        $checksum = Iban::checksum('ME00' . $bban);
+        $checksum = Iban::checksum('MK00' . $bban);
 
-        return 'ME' . $checksum . $bban;
+        return 'MK' . $checksum . $bban;
     }
 
     /**
@@ -64,7 +70,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @return string
      */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'ME', $length = null)
+    public static function bankAccountNumber($prefix = '', $countryCode = 'MK', $length = null)
     {
         return static::iban($countryCode, $prefix, $length);
     }

--- a/src/Faker/Provider/nb_NO/Payment.php
+++ b/src/Faker/Provider/nb_NO/Payment.php
@@ -2,8 +2,72 @@
 
 namespace Faker\Provider\nb_NO;
 
+use Faker\Calculator\Iban;
+
+/**
+ * Norway Payment Provider
+ *
+ * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ */
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Weights for Norwegian MOD 11 check digit calculation
+     *
+     * @var int[]
+     */
+    private static $mod11Weights = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2];
+
+    /**
+     * International Bank Account Number (IBAN) for Norway
+     *
+     * Norwegian IBAN structure: NO + 2 check digits + 11 digit BBAN
+     * BBAN structure: 4 digit bank code + 6 digit account number + 1 check digit
+     *
+     * The check digit uses weighted MOD 11.
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always NO)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 11)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (4 digits)
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $bankCode = substr($prefix, 0, 4);
+            $prefix = substr($prefix, 4);
+        } else {
+            $bankCode = static::numerify('####');
+        }
+
+        // Account number (6 digits) - will have check digit appended
+        if ($prefix !== '' && strlen($prefix) >= 6) {
+            $accountNumber = substr($prefix, 0, 6);
+        } else {
+            $accountNumber = static::numerify('######');
+        }
+
+        // Calculate check digit using MOD 11
+        $checkDigit = Iban::mod11($bankCode . $accountNumber, self::$mod11Weights);
+
+        // If check digit is invalid (10), regenerate
+        if ($checkDigit === null) {
+            return static::iban($countryCode, '', $length);
+        }
+
+        // Assemble BBAN
+        $bban = $bankCode . $accountNumber . $checkDigit;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('NO00' . $bban);
+
+        return 'NO' . $checksum . $bban;
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/src/Faker/Provider/nl_BE/Payment.php
+++ b/src/Faker/Provider/nl_BE/Payment.php
@@ -2,8 +2,76 @@
 
 namespace Faker\Provider\nl_BE;
 
+use Faker\Calculator\Iban;
+
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * International Bank Account Number (IBAN) for Belgium
+     *
+     * Belgian IBAN structure: BE + 2 check digits + 12 digit BBAN
+     * BBAN structure: 3 digit bank code + 7 digit account number + 2 check digits
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     * @see https://www.nbb.be/en/payment-systems/payment-standards/bank-account-numbers
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always BE)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 12)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (3 digits)
+        if ($prefix !== '' && strlen($prefix) >= 3) {
+            $bankCode = substr($prefix, 0, 3);
+            $prefix = substr($prefix, 3);
+        } else {
+            $bankCode = static::numerify('###');
+        }
+
+        // Account number (7 digits)
+        if ($prefix !== '') {
+            $accountNumber = str_pad(substr($prefix, 0, 7), 7, '0', STR_PAD_LEFT);
+        } else {
+            $accountNumber = static::numerify('#######');
+        }
+
+        // Calculate check digits (MOD 97 of bank code + account number)
+        $checkDigits = static::calculateBelgianCheckDigits($bankCode . $accountNumber);
+
+        // Assemble BBAN
+        $bban = $bankCode . $accountNumber . $checkDigits;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('BE00' . $bban);
+
+        return 'BE' . $checksum . $bban;
+    }
+
+    /**
+     * Calculate Belgian BBAN check digits
+     *
+     * Belgian check digits = (bank code + account number) MOD 97
+     * If the result is 0, use 97 instead.
+     *
+     * @param string $number 10 digit string (bank code + account number)
+     *
+     * @return string 2 digit check digits
+     */
+    protected static function calculateBelgianCheckDigits(string $number): string
+    {
+        $check = (int) bcmod($number, '97');
+
+        // If result is 0, use 97
+        if ($check === 0) {
+            $check = 97;
+        }
+
+        return str_pad((string) $check, 2, '0', STR_PAD_LEFT);
+    }
+
     /**
      * International Bank Account Number (IBAN).
      *

--- a/src/Faker/Provider/nl_BE/Payment.php
+++ b/src/Faker/Provider/nl_BE/Payment.php
@@ -54,7 +54,6 @@ class Payment extends \Faker\Provider\Payment
      * Calculate Belgian BBAN check digits
      *
      * Belgian check digits = (bank code + account number) MOD 97
-     * If the result is 0, use 97 instead.
      *
      * @param string $number 10 digit string (bank code + account number)
      *
@@ -63,11 +62,6 @@ class Payment extends \Faker\Provider\Payment
     protected static function calculateBelgianCheckDigits(string $number): string
     {
         $check = (int) bcmod($number, '97');
-
-        // If result is 0, use 97
-        if ($check === 0) {
-            $check = 97;
-        }
 
         return str_pad((string) $check, 2, '0', STR_PAD_LEFT);
     }

--- a/src/Faker/Provider/nl_NL/Payment.php
+++ b/src/Faker/Provider/nl_NL/Payment.php
@@ -25,6 +25,13 @@ class Payment extends \Faker\Provider\Payment
     ];
 
     /**
+     * Weights for Dutch 11-test (elfproef)
+     *
+     * @var int[]
+     */
+    private static $mod11Weights = [10, 9, 8, 7, 6, 5, 4, 3, 2];
+
+    /**
      * International Bank Account Number (IBAN) for Netherlands
      *
      * Dutch IBAN structure: NL + 2 check digits + 14 character BBAN
@@ -77,32 +84,17 @@ class Payment extends \Faker\Provider\Payment
     protected static function generateValidAccountNumber(): string
     {
         // Generate first 9 digits randomly
-        $digits = [];
+        $base = static::numerify('#########');
 
-        for ($i = 0; $i < 9; ++$i) {
-            $digits[] = mt_rand(0, 9);
-        }
+        // Calculate check digit using MOD 11
+        $checkDigit = Iban::mod11($base, self::$mod11Weights);
 
-        // Calculate the check digit (position 10, weight 1)
-        // Sum = d1*10 + d2*9 + d3*8 + ... + d9*2 + d10*1
-        // We need (sum + d10) % 11 == 0
-        $sum = 0;
-
-        for ($i = 0; $i < 9; ++$i) {
-            $sum += $digits[$i] * (10 - $i);
-        }
-
-        // Find check digit: (sum + checkDigit) % 11 == 0
-        $checkDigit = (11 - ($sum % 11)) % 11;
-
-        // If check digit is 10, regenerate (can't represent with single digit)
-        if ($checkDigit === 10) {
+        // If check digit is 10 (invalid), regenerate
+        if ($checkDigit === null) {
             return static::generateValidAccountNumber();
         }
 
-        $digits[] = $checkDigit;
-
-        return implode('', $digits);
+        return $base . $checkDigit;
     }
 
     /**

--- a/src/Faker/Provider/nl_NL/Payment.php
+++ b/src/Faker/Provider/nl_NL/Payment.php
@@ -2,8 +2,109 @@
 
 namespace Faker\Provider\nl_NL;
 
+use Faker\Calculator\Iban;
+
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Dutch bank codes (BIC prefixes) that use the 11-test
+     *
+     * Note: ING (INGB) uses a different validation scheme and is excluded.
+     *
+     * @var string[]
+     */
+    protected static $bankCodes = [
+        'ABNA', // ABN AMRO
+        'RABO', // Rabobank
+        'SNSB', // SNS Bank
+        'TRIO', // Triodos
+        'KNAB', // Knab
+        'BUNQ', // Bunq
+        'ASNB', // ASN Bank
+        'RBRB', // RegioBank
+    ];
+
+    /**
+     * International Bank Account Number (IBAN) for Netherlands
+     *
+     * Dutch IBAN structure: NL + 2 check digits + 14 character BBAN
+     * BBAN structure: 4 letter bank code + 10 digit account number
+     *
+     * The account number must pass the 11-test (elfproef).
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     * @see https://nl.wikipedia.org/wiki/Elfproef
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always NL)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 14)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (4 letters)
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $bankCode = strtoupper(substr($prefix, 0, 4));
+            $prefix = substr($prefix, 4);
+        } else {
+            $bankCode = static::randomElement(static::$bankCodes);
+        }
+
+        // Generate account number that passes 11-test
+        if ($prefix !== '' && strlen($prefix) === 10) {
+            $accountNumber = $prefix;
+        } else {
+            $accountNumber = static::generateValidAccountNumber();
+        }
+
+        // Assemble BBAN
+        $bban = $bankCode . $accountNumber;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('NL00' . $bban);
+
+        return 'NL' . $checksum . $bban;
+    }
+
+    /**
+     * Generate a 10-digit account number that passes the 11-test
+     *
+     * @see https://nl.wikipedia.org/wiki/Elfproef
+     *
+     * @return string 10-digit account number
+     */
+    protected static function generateValidAccountNumber(): string
+    {
+        // Generate first 9 digits randomly
+        $digits = [];
+
+        for ($i = 0; $i < 9; ++$i) {
+            $digits[] = mt_rand(0, 9);
+        }
+
+        // Calculate the check digit (position 10, weight 1)
+        // Sum = d1*10 + d2*9 + d3*8 + ... + d9*2 + d10*1
+        // We need (sum + d10) % 11 == 0
+        $sum = 0;
+
+        for ($i = 0; $i < 9; ++$i) {
+            $sum += $digits[$i] * (10 - $i);
+        }
+
+        // Find check digit: (sum + checkDigit) % 11 == 0
+        $checkDigit = (11 - ($sum % 11)) % 11;
+
+        // If check digit is 10, regenerate (can't represent with single digit)
+        if ($checkDigit === 10) {
+            return static::generateValidAccountNumber();
+        }
+
+        $digits[] = $checkDigit;
+
+        return implode('', $digits);
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/src/Faker/Provider/pt_PT/Payment.php
+++ b/src/Faker/Provider/pt_PT/Payment.php
@@ -73,7 +73,13 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * Calculate NIB check digits using MOD 97
+     * Calculate NIB check digits using ISO 7064 MOD 97-10
+     *
+     * The formula (98 - r) % 97 produces check digits in range 00-96,
+     * mapping the edge cases: 98→01, 97→00. These are equivalent under
+     * mod 97 verification since (N + 98) ≡ (N + 01) ≡ 1 (mod 97).
+     *
+     * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number#Algorithms
      *
      * @param string $nibWithoutCheck 19 digit string (bank code + branch code + account number)
      *
@@ -81,8 +87,7 @@ class Payment extends \Faker\Provider\Payment
      */
     protected static function calculateNibCheckDigits(string $nibWithoutCheck): string
     {
-        // NIB check digit calculation: 98 - (nibWithoutCheck * 100) mod 97
-        $check = 98 - Iban::mod97($nibWithoutCheck . '00');
+        $check = (98 - Iban::mod97($nibWithoutCheck . '00')) % 97;
 
         return str_pad((string) $check, 2, '0', STR_PAD_LEFT);
     }

--- a/src/Faker/Provider/pt_PT/Payment.php
+++ b/src/Faker/Provider/pt_PT/Payment.php
@@ -2,8 +2,91 @@
 
 namespace Faker\Provider\pt_PT;
 
+use Faker\Calculator\Iban;
+
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Valid Portuguese bank codes (assigned by Banco de Portugal)
+     *
+     * @see https://www.bportugal.pt/
+     *
+     * @var string[]
+     */
+    protected static $bankCodes = [
+        '0001', '0007', '0008', '0010', '0014', '0018', '0019', '0022', '0023', '0025',
+        '0027', '0033', '0035', '0036', '0045', '0046', '0047', '0048', '0059', '0061',
+        '0063', '0064', '0065', '0073', '0076', '0079', '0086', '0097', '0098', '0099',
+        '0160', '0170', '0186', '0189', '0193', '0235', '0244', '0269', '0698', '0781',
+        '5180', '5200', '5340', '8050',
+    ];
+
+    /**
+     * International Bank Account Number (IBAN) for Portugal
+     *
+     * Portuguese IBAN structure: PT + 2 check digits + 21 digit BBAN
+     * BBAN structure: 4 digit bank code + 4 digit branch code + 11 digit account number + 2 digit NIB check digits
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always PT)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 21)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (4 digits) - use prefix if provided and valid, otherwise random
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $bankCode = substr($prefix, 0, 4);
+            $prefix = substr($prefix, 4);
+        } else {
+            $bankCode = static::randomElement(static::$bankCodes);
+        }
+
+        // Branch code (4 digits)
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $branchCode = substr($prefix, 0, 4);
+            $prefix = substr($prefix, 4);
+        } else {
+            $branchCode = static::numerify('####');
+        }
+
+        // Account number (11 digits)
+        if ($prefix !== '') {
+            $accountNumber = str_pad(substr($prefix, 0, 11), 11, '0', STR_PAD_LEFT);
+        } else {
+            $accountNumber = static::numerify('###########');
+        }
+
+        // Calculate NIB check digits (last 2 digits of BBAN)
+        $nibCheckDigits = static::calculateNibCheckDigits($bankCode . $branchCode . $accountNumber);
+
+        // Assemble BBAN
+        $bban = $bankCode . $branchCode . $accountNumber . $nibCheckDigits;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('PT00' . $bban);
+
+        return 'PT' . $checksum . $bban;
+    }
+
+    /**
+     * Calculate NIB check digits using MOD 97
+     *
+     * @param string $nibWithoutCheck 19 digit string (bank code + branch code + account number)
+     *
+     * @return string 2 digit check digits
+     */
+    protected static function calculateNibCheckDigits(string $nibWithoutCheck): string
+    {
+        // NIB check digit calculation: 98 - (nibWithoutCheck * 100) mod 97
+        $check = 98 - Iban::mod97($nibWithoutCheck . '00');
+
+        return str_pad((string) $check, 2, '0', STR_PAD_LEFT);
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/src/Faker/Provider/pt_PT/Payment.php
+++ b/src/Faker/Provider/pt_PT/Payment.php
@@ -60,36 +60,13 @@ class Payment extends \Faker\Provider\Payment
             $accountNumber = static::numerify('###########');
         }
 
-        // Calculate NIB check digits (last 2 digits of BBAN)
-        $nibCheckDigits = static::calculateNibCheckDigits($bankCode . $branchCode . $accountNumber);
-
-        // Assemble BBAN
-        $bban = $bankCode . $branchCode . $accountNumber . $nibCheckDigits;
+        // Assemble BBAN with NIB check digits (MOD 97-10)
+        $bban = $bankCode . $branchCode . $accountNumber . Iban::mod97_10($bankCode . $branchCode . $accountNumber);
 
         // Calculate IBAN check digits
         $checksum = Iban::checksum('PT00' . $bban);
 
         return 'PT' . $checksum . $bban;
-    }
-
-    /**
-     * Calculate NIB check digits using ISO 7064 MOD 97-10
-     *
-     * The formula (98 - r) % 97 produces check digits in range 00-96,
-     * mapping the edge cases: 98→01, 97→00. These are equivalent under
-     * mod 97 verification since (N + 98) ≡ (N + 01) ≡ 1 (mod 97).
-     *
-     * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number#Algorithms
-     *
-     * @param string $nibWithoutCheck 19 digit string (bank code + branch code + account number)
-     *
-     * @return string 2 digit check digits
-     */
-    protected static function calculateNibCheckDigits(string $nibWithoutCheck): string
-    {
-        $check = (98 - Iban::mod97($nibWithoutCheck . '00')) % 97;
-
-        return str_pad((string) $check, 2, '0', STR_PAD_LEFT);
     }
 
     /**

--- a/src/Faker/Provider/sk_SK/Payment.php
+++ b/src/Faker/Provider/sk_SK/Payment.php
@@ -2,8 +2,104 @@
 
 namespace Faker\Provider\sk_SK;
 
+use Faker\Calculator\Iban;
+
+/**
+ * Slovakia Payment Provider
+ *
+ * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ */
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Weights for Slovak MOD 11 check digit calculation (account number)
+     *
+     * @var int[]
+     */
+    private static $accountWeights = [6, 3, 7, 9, 10, 5, 8, 4, 2];
+
+    /**
+     * Weights for Slovak MOD 11 check digit calculation (prefix)
+     *
+     * @var int[]
+     */
+    private static $prefixWeights = [10, 5, 8, 4, 2];
+
+    /**
+     * International Bank Account Number (IBAN) for Slovakia
+     *
+     * Slovak IBAN structure: SK + 2 check digits + 20 digit BBAN
+     * BBAN structure: 4 digit bank code + 6 digit prefix + 10 digit account number
+     *
+     * Both prefix and account have embedded MOD 11 check digits.
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always SK)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 20)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (4 digits)
+        if ($prefix !== '' && strlen($prefix) >= 4) {
+            $bankCode = substr($prefix, 0, 4);
+            $prefix = substr($prefix, 4);
+        } else {
+            $bankCode = static::numerify('####');
+        }
+
+        // Generate prefix (6 digits) with valid check digit
+        $accountPrefix = static::generateValidPrefix();
+
+        // Generate account number (10 digits) with valid check digit
+        $accountNumber = static::generateValidAccount();
+
+        // Assemble BBAN
+        $bban = $bankCode . $accountPrefix . $accountNumber;
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('SK00' . $bban);
+
+        return 'SK' . $checksum . $bban;
+    }
+
+    /**
+     * Generate a 6-digit prefix with valid MOD 11 check digit
+     *
+     * @return string 6-digit prefix
+     */
+    protected static function generateValidPrefix(): string
+    {
+        $base = static::numerify('#####');
+        $checkDigit = Iban::mod11($base, self::$prefixWeights);
+
+        if ($checkDigit === null) {
+            return static::generateValidPrefix();
+        }
+
+        return $base . $checkDigit;
+    }
+
+    /**
+     * Generate a 10-digit account number with valid MOD 11 check digit
+     *
+     * @return string 10-digit account number
+     */
+    protected static function generateValidAccount(): string
+    {
+        $base = static::numerify('#########');
+        $checkDigit = Iban::mod11($base, self::$accountWeights);
+
+        if ($checkDigit === null) {
+            return static::generateValidAccount();
+        }
+
+        return $base . $checkDigit;
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/src/Faker/Provider/sl_SI/Payment.php
+++ b/src/Faker/Provider/sl_SI/Payment.php
@@ -2,8 +2,73 @@
 
 namespace Faker\Provider\sl_SI;
 
+use Faker\Calculator\Iban;
+
+/**
+ * Slovenia Payment Provider
+ *
+ * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ */
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Slovenian bank codes that use MOD 97-10 check digits
+     *
+     * Note: Bank 01 (Banka Slovenije / Bank of Slovenia) uses a different scheme.
+     *
+     * @var string[]
+     */
+    protected static $bankCodes = [
+        '02', '03', '04', '05', '06', '08', '09', '10', '11', '12',
+        '13', '14', '15', '17', '18', '19', '20', '22', '23', '24',
+        '25', '26', '27', '28', '29', '30', '31', '32', '33', '34',
+        '35', '36', '37', '38', '39', '40',
+    ];
+
+    /**
+     * International Bank Account Number (IBAN) for Slovenia
+     *
+     * Slovenian IBAN structure: SI + 2 check digits + 15 digit BBAN
+     * BBAN structure: 5 digit bank/branch code + 8 digit account number + 2 digit national check digits
+     *
+     * National check digits use ISO 7064 MOD 97-10.
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always SI)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 15)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (2 digits) + branch code (3 digits) = 5 digits total
+        if ($prefix !== '' && strlen($prefix) >= 5) {
+            $bankBranch = substr($prefix, 0, 5);
+            $prefix = substr($prefix, 5);
+        } else {
+            $bankCode = static::randomElement(static::$bankCodes);
+            $branchCode = static::numerify('###');
+            $bankBranch = $bankCode . $branchCode;
+        }
+
+        // Account number (8 digits)
+        if ($prefix !== '') {
+            $accountNumber = str_pad(substr($prefix, 0, 8), 8, '0', STR_PAD_LEFT);
+        } else {
+            $accountNumber = static::numerify('########');
+        }
+
+        // Assemble BBAN with check digits
+        $bban = $bankBranch . $accountNumber . Iban::mod97_10($bankBranch . $accountNumber);
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('SI00' . $bban);
+
+        return 'SI' . $checksum . $bban;
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/src/Faker/Provider/sr_RS/Payment.php
+++ b/src/Faker/Provider/sr_RS/Payment.php
@@ -2,8 +2,72 @@
 
 namespace Faker\Provider\sr_RS;
 
+use Faker\Calculator\Iban;
+
+/**
+ * Serbia Payment Provider
+ *
+ * @see https://en.wikipedia.org/wiki/International_Bank_Account_Number
+ */
 class Payment extends \Faker\Provider\Payment
 {
+    /**
+     * Serbian bank codes that use MOD 97-10 check digits
+     *
+     * Note: Bank 908 (Narodna banka Srbije / National Bank of Serbia) uses a different scheme.
+     *
+     * @var string[]
+     */
+    protected static $bankCodes = [
+        '105', '115', '125', '145', '150', '155', '160', '165', '170', '175',
+        '180', '190', '200', '205', '220', '240', '250', '260', '265', '270',
+        '275', '280', '285', '290', '295', '310', '325', '330', '340', '360',
+        '370', '375', '380', '385', '390', '395', '405', '415', '440', '445',
+        '485', '500', '505', '540', '555', '575',
+    ];
+
+    /**
+     * International Bank Account Number (IBAN) for Serbia
+     *
+     * Serbian IBAN structure: RS + 2 check digits + 18 digit BBAN
+     * BBAN structure: 3 digit bank code + 13 digit account number + 2 digit national check digits
+     *
+     * National check digits use ISO 7064 MOD 97-10.
+     *
+     * @see http://en.wikipedia.org/wiki/International_Bank_Account_Number
+     *
+     * @param string $countryCode ISO 3166-1 alpha-2 country code (ignored, always RS)
+     * @param string $prefix      for generating bank account number of a specific bank
+     * @param int    $length      total length without country code and 2 check digits (ignored, always 18)
+     *
+     * @return string
+     */
+    public static function iban($countryCode = null, $prefix = '', $length = null)
+    {
+        // Bank code (3 digits)
+        if ($prefix !== '' && strlen($prefix) >= 3) {
+            $bankCode = substr($prefix, 0, 3);
+            $prefix = substr($prefix, 3);
+        } else {
+            $bankCode = static::randomElement(static::$bankCodes);
+        }
+
+        // Account number (13 digits)
+        if ($prefix !== '') {
+            $accountNumber = str_pad(substr($prefix, 0, 13), 13, '0', STR_PAD_LEFT);
+        } else {
+            $accountNumber = static::numerify('#############');
+        }
+
+        // Assemble BBAN with check digits
+        $bban = $bankCode . $accountNumber . Iban::mod97_10($bankCode . $accountNumber);
+
+        // Calculate IBAN check digits
+        $checksum = Iban::checksum('RS00' . $bban);
+
+        return 'RS' . $checksum . $bban;
+    }
+
     /**
      * International Bank Account Number (IBAN)
      *

--- a/test/Faker/Provider/pt_PT/PaymentTest.php
+++ b/test/Faker/Provider/pt_PT/PaymentTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Faker\Test\Provider\pt_PT;
+
+use Faker\Calculator\Iban;
+use Faker\Provider\pt_PT\Payment;
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class PaymentTest extends TestCase
+{
+    /**
+     * @var string[] Valid Portuguese bank codes
+     */
+    private static $validBankCodes = [
+        '0001', '0007', '0008', '0010', '0014', '0018', '0019', '0022', '0023', '0025',
+        '0027', '0033', '0035', '0036', '0045', '0046', '0047', '0048', '0059', '0061',
+        '0063', '0064', '0065', '0073', '0076', '0079', '0086', '0097', '0098', '0099',
+        '0160', '0170', '0186', '0189', '0193', '0235', '0244', '0269', '0698', '0781',
+        '5180', '5200', '5340', '8050',
+    ];
+
+    public function testIbanIsValid(): void
+    {
+        $iban = $this->faker->iban('PT');
+
+        self::assertTrue(Iban::isValid($iban), "IBAN $iban should be valid");
+    }
+
+    public function testIbanHasCorrectLength(): void
+    {
+        $iban = $this->faker->iban('PT');
+
+        self::assertSame(25, strlen($iban), "PT IBAN should be 25 characters long");
+    }
+
+    public function testIbanStartsWithPT(): void
+    {
+        $iban = $this->faker->iban('PT');
+
+        self::assertStringStartsWith('PT', $iban);
+    }
+
+    public function testIbanUsesValidBankCode(): void
+    {
+        $iban = $this->faker->iban('PT');
+        $bankCode = substr($iban, 4, 4);
+
+        self::assertContains($bankCode, self::$validBankCodes, "Bank code $bankCode should be a valid Portuguese bank code");
+    }
+
+    public function testIbanNibCheckDigitsAreCorrect(): void
+    {
+        $iban = $this->faker->iban('PT');
+
+        // Extract BBAN components
+        $bankCode = substr($iban, 4, 4);
+        $branchCode = substr($iban, 8, 4);
+        $accountNumber = substr($iban, 12, 11);
+        $nibCheckDigits = substr($iban, 23, 2);
+
+        // Recalculate NIB check digits
+        $nibWithoutCheck = $bankCode . $branchCode . $accountNumber;
+        $expectedCheckDigits = 98 - Iban::mod97($nibWithoutCheck . '00');
+        $expectedCheckDigits = str_pad((string) $expectedCheckDigits, 2, '0', STR_PAD_LEFT);
+
+        self::assertSame($expectedCheckDigits, $nibCheckDigits, "NIB check digits should be correctly calculated");
+    }
+
+    public function testMultipleIbansAreAllValid(): void
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $iban = $this->faker->iban('PT');
+            self::assertTrue(Iban::isValid($iban), "IBAN $iban should be valid");
+        }
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Payment($this->faker);
+    }
+}


### PR DESCRIPTION
Generated IBANs now pass national validation, not just IBAN-level MOD 97. Previously the BBAN check digits were random, so ~97% of IBANs failed validation in banking systems that check national formats.

Fixed 15 countries:

| Algorithm | Countries |
|-----------|-----------|
| MOD 97-10 | PT, ME, MK, RS, SI |
| Clé RIB | FR, MC |
| Control digits | ES |
| MOD 97 | BE |
| CIN | IT, SM |
| 11-test | NL |
| MOD 11 | NO, SK, IS |

Added `Iban::mod97_10()` and `Iban::mod11()` as reusable algorithms. Created three new locales: `mk_MK`, `fr_MC`, `it_SM`.

Fixes #1007