### PR TITLE
Update Lithuanian phone number prefix in lt_LT provider

### DIFF
--- a/src/Provider/lt_LT/PhoneNumber.php
+++ b/src/Provider/lt_LT/PhoneNumber.php
@@ -5,13 +5,13 @@ namespace Faker\Provider\lt_LT;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $formats = [
-        '86#######',
-        '8 6## #####',
+        '06#######',
+        '0 6## #####',
         '+370 6## ## ###',
         '+3706#######',
-        '(8 5) ### ####',
+        '(0 5) ### ####',
         '+370 5 ### ####',
         '+370 46 ## ## ##',
-        '(8 46) ## ## ##',
+        '(0 46) ## ## ##',
     ];
 }


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- Updated Lithuanian local phone number prefix from `8` to `0`. 

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

Numbers starting with `8` are no longer valid starting from 2025 December 1st and cannot be used for calls. This change allows to generate numbers that are valid and would pass new validation rules.

https://www.telia.lt/privatiems/kitos-paslaugos/namu-telefono-planai/kodai
https://www.rrt.lt/butina-zinoti-svarbiausi-etapai-kaip-8-numeriu-priekyje-virs-0/


### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
