### PR TITLE
Fix/ja jp postcode leading zero

### DIFF
--- a/src/Provider/ja_JP/Address.php
+++ b/src/Provider/ja_JP/Address.php
@@ -68,23 +68,23 @@ class Address extends \Faker\Provider\Address
     ];
 
     /**
-     * @example 111
+     * @example '111'
      */
     public static function postcode1()
     {
-        return self::numberBetween(100, 999);
+        return static::numerify('###');
     }
 
     /**
-     * @example 2222
+     * @example '2222'
      */
     public static function postcode2()
     {
-        return self::numberBetween(1000, 9999);
+        return static::numerify('####');
     }
 
     /**
-     * @example 1112222
+     * @example '1112222'
      */
     public static function postcode()
     {

--- a/test/Provider/ja_JP/AddressTest.php
+++ b/test/Provider/ja_JP/AddressTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Test\Provider\ja_JP;
+
+use Faker\Provider\ja_JP\Address;
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class AddressTest extends TestCase
+{
+    public function testPostcodeMatchesFormat(): void
+    {
+        $postcode = Address::postcode();
+        self::assertMatchesRegularExpression('/^[0-9]{7}$/', str_replace('-', '', $postcode));
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

In Japan, some regions (notably Hokkaido) have postal codes starting with zero (e.g., `001-XXXX`). The previous implementation used `numberBetween()`, which resulted in integers. When these were concatenated, leading zeros were lost (e.g., `001` became `1`). This PR ensures leading zeros are preserved by using `numerify()`.

- [ ] A new feature
- [x] Fixed an issue (resolve leading zero issue in ja_JP postcode)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

- Changed `postcode1()` and `postcode2()` in `Faker\Provider\ja_JP\Address` to use `numerify('###')` and `numerify('####')` instead of `numberBetween()`.
- Updated PHPDoc `@example` tags to reflect string return values.
- Added `test/Faker/Provider/ja_JP/AddressTest.php` to ensure the postcode format is correctly generated.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer