### PR TITLE
Fix: prevent curl_close() deprecation on PHP 8.5

### DIFF
--- a/src/Provider/Image.php
+++ b/src/Provider/Image.php
@@ -145,7 +145,10 @@ class Image extends Base
             curl_setopt($ch, CURLOPT_FILE, $fp);
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
             fclose($fp);
-            curl_close($ch);
+
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            }
 
             if (!$success) {
                 unlink($filepath);

--- a/test/Provider/ImageTest.php
+++ b/test/Provider/ImageTest.php
@@ -185,7 +185,10 @@ final class ImageTest extends TestCase
         curl_setopt($curlPing, CURLOPT_FOLLOWLOCATION, true);
         $data = curl_exec($curlPing);
         $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
-        curl_close($curlPing);
+
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($curlPing);
+        }
 
         if ($httpCode < 200 || $httpCode > 300) {
             self::markTestSkipped(sprintf('"%s" is offline, skipping test', $url));


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [ ] A new feature
- [x] Fixed an issue (resolve #1040)

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

This PR addresses the curl_close() deprecation introduced in PHP 8.5. Since PHP 8.0, cURL handles are automatically managed objects, making explicit calls to curl_close() a no-op. Starting with PHP 8.5, calling this function triggers an E_DEPRECATED notice.

Changes included:

- Wrapped curl_close() calls in src/Faker/Provider/Image.php with a PHP_VERSION_ID < 80000 check.
- Updated the corresponding test in test/Faker/Provider/ImageTest.php to prevent deprecation warnings during test execution.
- Verified that the fix maintains compatibility with PHP 7.4 through PHP 8.5.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
