### PR TITLE
fix(image): update BASE_URL to use placehold.co

### DIFF
--- a/src/Provider/Image.php
+++ b/src/Provider/Image.php
@@ -10,7 +10,7 @@ class Image extends Base
     /**
      * @var string
      */
-    public const BASE_URL = 'https://via.placeholder.com';
+    public const BASE_URL = 'https://placehold.co';
 
     public const FORMAT_JPG = 'jpg';
     public const FORMAT_JPEG = 'jpeg';
@@ -69,31 +69,33 @@ class Image extends Base
             ));
         }
 
-        $size = sprintf('%dx%d.%s', $width, $height, $format);
+        $bgColor = $gray === true ? 'CCCCCC' : str_replace('#', '', Color::safeHexColor());
+        $textColor = 'FFF'; // default text color
+        $format = strtolower($format);
+        $size = sprintf('%dx%d', $width, $height);
 
-        $imageParts = [];
+        // Placehold.co format: /widthxheight/bg/text/format
+        $url = self::BASE_URL . '/' . $size . '/' . $bgColor . '/' . $textColor . '/' . $format;
+
+        $textParts = [];
 
         if ($category !== null) {
-            $imageParts[] = $category;
+            $textParts[] = $category;
         }
 
         if ($word !== null) {
-            $imageParts[] = $word;
+            $textParts[] = $word;
         }
 
         if ($randomize === true) {
-            $imageParts[] = Lorem::word();
+            $textParts[] = Lorem::word();
         }
 
-        $backgroundColor = $gray === true ? 'CCCCCC' : str_replace('#', '', Color::safeHexColor());
+        if (count($textParts) > 0) {
+            $url .= '?text=' . urlencode(implode(' ', $textParts));
+        }
 
-        return sprintf(
-            '%s/%s/%s%s',
-            self::BASE_URL,
-            $size,
-            $backgroundColor,
-            count($imageParts) > 0 ? '?text=' . urlencode(implode(' ', $imageParts)) : '',
-        );
+        return $url;
     }
 
     /**

--- a/test/Provider/ImageTest.php
+++ b/test/Provider/ImageTest.php
@@ -15,7 +15,7 @@ final class ImageTest extends TestCase
     public function testImageUrlUses640x680AsTheDefaultSize(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/640x480.png/#',
+            '#^https://placehold.co/640x480/[A-Fa-f0-9]{6}/FFF/png\\?text=\\w+#',
             Image::imageUrl(),
         );
     }
@@ -23,7 +23,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomWidthAndHeight(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/#',
+            '#^https://placehold.co/800x400/[A-Fa-f0-9]{6}/FFF/png\\?text=\\w+#',
             Image::imageUrl(800, 400),
         );
     }
@@ -31,7 +31,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomCategory(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+.*#',
+            '#^https://placehold.co/800x400/[A-Fa-f0-9]{6}/FFF/png\\?text=nature\\+\\w+#',
             Image::imageUrl(800, 400, 'nature'),
         );
     }
@@ -39,7 +39,7 @@ final class ImageTest extends TestCase
     public function testImageUrlAcceptsCustomText(): void
     {
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[A-Fa-f0-9]{6}/FFF/png\\?text=nature\\+Faker#',
             Image::imageUrl(800, 400, 'nature', false, 'Faker'),
         );
     }
@@ -56,7 +56,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/[\w]{6}\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/[A-Fa-f0-9]{6}/FFF/png\\?text=nature\\+Faker#',
             $imageUrl,
         );
     }
@@ -73,7 +73,7 @@ final class ImageTest extends TestCase
         );
 
         self::assertMatchesRegularExpression(
-            '#^https://via.placeholder.com/800x400.png/CCCCCC\?text=nature\+Faker#',
+            '#^https://placehold.co/800x400/CCCCCC/FFF/png\\?text=nature\\+Faker#',
             $imageUrl,
         );
     }
@@ -115,7 +115,7 @@ final class ImageTest extends TestCase
             );
 
             self::assertMatchesRegularExpression(
-                "#^https://via.placeholder.com/800x400.{$format}/CCCCCC\?text=nature\+Faker#",
+                "#^https://placehold.co/800x400/CCCCCC/FFF/{$format}\\?text=nature\\+Faker#",
                 $imageUrl,
             );
         }


### PR DESCRIPTION
### What is the reason for this PR?

Based on documentation for [image generator](https://fakerphp.org/formatters/image/), placeholder.com has shutdown. As an alternative, we can use [placehold.co](https://placehold.co/), so I made that PR, changing placeholder.com to placehold.co
