### PR TITLE
refactor: remove obsolete free email domains for `es_ES`

### DIFF
--- a/src/Provider/es_ES/Internet.php
+++ b/src/Provider/es_ES/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\es_ES;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es', 'live.com', 'hispavista.com', 'latinmail.com', 'terra.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es'];
     protected static $tld = ['com', 'com', 'com', 'com', 'net', 'org', 'org', 'es', 'es', 'es', 'com.es'];
 }


### PR DESCRIPTION
### Summary of changes

Just removed old and obsolete free email domains for the `es_ES` locale.
Domains removed do not offer free email services anymore.

Maybe we could remove them also from the `es_VE` locale? 🤔

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
