### PR TITLE
refactor: update free email domains

### DIFF
--- a/src/Provider/Internet.php
+++ b/src/Provider/Internet.php
@@ -4,7 +4,7 @@ namespace Faker\Provider;
 
 class Internet extends Base
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com'];
     protected static $tld = ['com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org'];
 
     protected static $userNameFormats = [

--- a/src/Provider/bg_BG/Internet.php
+++ b/src/Provider/bg_BG/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\bg_BG;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'mail.bg', 'abv.bg', 'dir.bg'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'mail.bg', 'abv.bg', 'dir.bg'];
     protected static $tld = ['bg', 'bg', 'bg', 'bg', 'bg', 'bg', 'com', 'biz', 'info', 'net', 'org'];
 }

--- a/src/Provider/cs_CZ/Internet.php
+++ b/src/Provider/cs_CZ/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\cs_CZ;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'seznam.cz', 'atlas.cz', 'centrum.cz', 'email.cz', 'post.cz'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'seznam.cz', 'atlas.cz', 'centrum.cz', 'email.cz', 'post.cz'];
     protected static $tld = ['cz', 'cz', 'cz', 'cz', 'cz', 'cz', 'com', 'info', 'net', 'org'];
 }

--- a/src/Provider/da_DK/Internet.php
+++ b/src/Provider/da_DK/Internet.php
@@ -15,7 +15,7 @@ class Internet extends \Faker\Provider\Internet
      * @var array Some email domains in Denmark.
      */
     protected static $freeEmailDomain = [
-        'gmail.com', 'yahoo.com', 'yahoo.dk', 'hotmail.com', 'hotmail.dk', 'mail.dk', 'live.dk',
+        'gmail.com', 'outlook.com', 'yahoo.com', 'yahoo.dk', 'hotmail.com', 'hotmail.dk', 'mail.dk', 'live.dk',
     ];
 
     /**

--- a/src/Provider/de_AT/Internet.php
+++ b/src/Provider/de_AT/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\de_AT;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['aon.at', 'chello.at', 'gmail.com', 'gmx.at', 'univie.ac.at'];
+    protected static $freeEmailDomain = ['aon.at', 'chello.at', 'gmail.com', 'outlook.com', 'gmx.at', 'univie.ac.at'];
     protected static $tld = ['at', 'co.at', 'com', 'net', 'org'];
 }

--- a/src/Provider/el_CY/Internet.php
+++ b/src/Provider/el_CY/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\el_CY;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'cablenet.com.cy', 'cytanet.com.cy', 'primehome.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'cablenet.com.cy', 'cytanet.com.cy', 'primehome.com'];
     protected static $tld = ['com.cy', 'com.cy', 'com.cy', 'com.cy', 'com.cy', 'com.cy', 'biz', 'info', 'net', 'org'];
 }

--- a/src/Provider/en_AU/Internet.php
+++ b/src/Provider/en_AU/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\en_AU;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'gmail.com.au', 'yahoo.com.au', 'hotmail.com.au'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'gmail.com.au', 'yahoo.com.au', 'hotmail.com.au'];
     protected static $tld = ['com', 'com.au', 'org', 'org.au', 'net', 'net.au', 'biz', 'info', 'edu', 'edu.au'];
 }

--- a/src/Provider/en_GB/Internet.php
+++ b/src/Provider/en_GB/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\en_GB;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'gmail.co.uk', 'yahoo.co.uk', 'hotmail.co.uk'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'gmail.co.uk', 'yahoo.co.uk', 'hotmail.co.uk'];
     protected static $tld = ['com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org', 'co.uk'];
 }

--- a/src/Provider/en_HK/Internet.php
+++ b/src/Provider/en_HK/Internet.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\en_HK;
 class Internet extends \Faker\Provider\Internet
 {
     protected static $freeEmailDomain = [
-        'gmail.com', 'yahoo.com', 'hotmail.com', 'yahoo.com.hk', 'hotmail.com.hk',
+        'gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'yahoo.com.hk', 'hotmail.com.hk',
     ];
     protected static $tld = [
         'com', 'com', 'com', 'com.hk', 'com.hk', 'com', 'biz', 'info', 'net', 'org',

--- a/src/Provider/en_IN/Internet.php
+++ b/src/Provider/en_IN/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\en_IN;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'yahoo.co.in', 'rediffmail.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'yahoo.co.in', 'rediffmail.com'];
     protected static $tld = ['com', 'com', 'com', 'com', 'com', 'com', 'in', 'in', 'in', 'ac.in', 'net', 'org', 'co.in'];
 }

--- a/src/Provider/en_UG/Internet.php
+++ b/src/Provider/en_UG/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\en_UG;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'gmail.co.ug', 'yahoo.co.ug', 'hotmail.co.ug'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'gmail.co.ug', 'yahoo.co.ug', 'hotmail.co.ug'];
     protected static $tld = ['com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org', 'co.ug', 'ug'];
 }

--- a/src/Provider/en_ZA/Internet.php
+++ b/src/Provider/en_ZA/Internet.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\en_ZA;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'webmail.co.za', 'vodamail.co.za'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'webmail.co.za', 'vodamail.co.za'];
 
     /**
      * An array of South African TLDs.

--- a/src/Provider/es_ES/Internet.php
+++ b/src/Provider/es_ES/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\es_ES;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es'];
     protected static $tld = ['com', 'com', 'com', 'com', 'net', 'org', 'org', 'es', 'es', 'es', 'com.es'];
 }

--- a/src/Provider/es_ES/Internet.php
+++ b/src/Provider/es_ES/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\es_ES;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es', 'live.com', 'hispavista.com', 'latinmail.com', 'terra.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es'];
     protected static $tld = ['com', 'com', 'com', 'com', 'net', 'org', 'org', 'es', 'es', 'es', 'com.es'];
 }

--- a/src/Provider/es_VE/Internet.php
+++ b/src/Provider/es_VE/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\es_VE;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es'];
     protected static $tld = ['com', 'com.ve', 'net', 'net.ve', 'org', 'org.ve', 'info.ve', 'co.ve', 'web.ve'];
 }

--- a/src/Provider/es_VE/Internet.php
+++ b/src/Provider/es_VE/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\es_VE;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es', 'live.com', 'hispavista.com', 'latinmail.com', 'terra.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es'];
     protected static $tld = ['com', 'com.ve', 'net', 'net.ve', 'org', 'org.ve', 'info.ve', 'co.ve', 'web.ve'];
 }

--- a/src/Provider/fi_FI/Internet.php
+++ b/src/Provider/fi_FI/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\fi_FI;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'jippii.fi', 'luukku.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'jippii.fi', 'luukku.com'];
     protected static $tld = ['com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org', 'fi'];
 }

--- a/src/Provider/fr_BE/Internet.php
+++ b/src/Provider/fr_BE/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\fr_BE;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'yahoo.com', 'advalvas.be'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.com', 'yahoo.com', 'advalvas.be'];
     protected static $tld = ['com', 'net', 'org', 'be'];
 }

--- a/src/Provider/fr_CH/Internet.php
+++ b/src/Provider/fr_CH/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\fr_CH;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'yahoo.com', 'googlemail.com', 'gmx.ch', 'bluewin.ch', 'swissonline.ch'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.com', 'yahoo.com', 'googlemail.com', 'gmx.ch', 'bluewin.ch', 'swissonline.ch'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'li', 'ch', 'ch'];
 }

--- a/src/Provider/fr_FR/Internet.php
+++ b/src/Provider/fr_FR/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\fr_FR;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.fr', 'yahoo.fr', 'laposte.net', 'free.fr', 'sfr.fr', 'orange.fr', 'club-internet.fr', 'dbmail.com', 'live.com', 'noos.fr', 'tele2.fr', 'wanadoo.fr'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.fr', 'yahoo.fr', 'laposte.net', 'free.fr', 'sfr.fr', 'orange.fr', 'club-internet.fr', 'dbmail.com', 'live.com', 'noos.fr', 'tele2.fr', 'wanadoo.fr'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'fr', 'fr', 'fr'];
 }

--- a/src/Provider/hy_AM/Internet.php
+++ b/src/Provider/hy_AM/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\hy_AM;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'yandex.ru', 'mail.ru', 'mail.am'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'yandex.ru', 'mail.ru', 'mail.am'];
     protected static $tld = ['com', 'com', 'am', 'am', 'am', 'net', 'org', 'ru', 'am', 'am', 'am'];
 }

--- a/src/Provider/id_ID/Internet.php
+++ b/src/Provider/id_ID/Internet.php
@@ -8,7 +8,7 @@ class Internet extends \Faker\Provider\Internet
      * @var array some email domains
      */
     protected static $freeEmailDomain = [
-        'gmail.com', 'yahoo.com', 'gmail.co.id', 'yahoo.co.id',
+        'gmail.com', 'outlook.com', 'yahoo.com', 'gmail.co.id', 'yahoo.co.id',
     ];
 
     /**

--- a/src/Provider/is_IS/Internet.php
+++ b/src/Provider/is_IS/Internet.php
@@ -8,7 +8,7 @@ class Internet extends \Faker\Provider\Internet
      * @var array Some email domains in Denmark.
      */
     protected static $freeEmailDomain = [
-        'gmail.com', 'yahoo.com', 'hotmail.com', 'visir.is', 'simnet.is', 'internet.is',
+        'gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'visir.is', 'simnet.is', 'internet.is',
     ];
 
     /**

--- a/src/Provider/it_CH/Internet.php
+++ b/src/Provider/it_CH/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\it_CH;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'yahoo.com', 'googlemail.com', 'gmx.ch', 'bluewin.ch', 'swissonline.ch'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.com', 'yahoo.com', 'googlemail.com', 'gmx.ch', 'bluewin.ch', 'swissonline.ch'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'li', 'ch', 'ch'];
 }

--- a/src/Provider/it_IT/Internet.php
+++ b/src/Provider/it_IT/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\it_IT;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'email.it', 'libero.it', 'yahoo.it'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'email.it', 'libero.it', 'yahoo.it'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'it', 'it', 'it'];
 }

--- a/src/Provider/ja_JP/Internet.php
+++ b/src/Provider/ja_JP/Internet.php
@@ -16,7 +16,7 @@ class Internet extends \Faker\Provider\Internet
     ];
 
     protected static $freeEmailDomain = [
-        'gmail.com', 'yahoo.co.jp', 'hotmail.co.jp', 'mail.goo.ne.jp',
+        'gmail.com', 'outlook.com', 'yahoo.co.jp', 'hotmail.co.jp', 'mail.goo.ne.jp',
     ];
 
     protected static $tld = [

--- a/src/Provider/ka_GE/Internet.php
+++ b/src/Provider/ka_GE/Internet.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\ka_GE;
 class Internet extends \Faker\Provider\Internet
 {
     protected static $freeEmailDomain = [
-        'posta.ge', 'boom.ge', 'hotmail.com', 'gmail.com', 'yahoo.com', 'mail.ru', 'avoe.ge',
+        'posta.ge', 'boom.ge', 'hotmail.com', 'gmail.com', 'outlook.com', 'yahoo.com', 'mail.ru', 'avoe.ge',
     ];
 
     protected static $tld = [

--- a/src/Provider/lt_LT/Internet.php
+++ b/src/Provider/lt_LT/Internet.php
@@ -13,6 +13,6 @@ class Internet extends \Faker\Provider\Internet
         '?{{lastNameMale}}',
     ];
 
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com'];
     protected static $tld = ['com', 'com', 'net', 'org', 'lt', 'lt', 'lt', 'lt', 'lt'];
 }

--- a/src/Provider/lv_LV/Internet.php
+++ b/src/Provider/lv_LV/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\lv_LV;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['mail.lv', 'apollo.lv', 'inbox.lv', 'gmail.com', 'yahoo.com', 'hotmail.com'];
+    protected static $freeEmailDomain = ['mail.lv', 'apollo.lv', 'inbox.lv', 'gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com'];
     protected static $tld = ['com', 'com', 'net', 'org', 'lv', 'lv', 'lv', 'lv'];
 }

--- a/src/Provider/ne_NP/Internet.php
+++ b/src/Provider/ne_NP/Internet.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\ne_NP;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org'];
 
     protected static $emailFormats = [

--- a/src/Provider/nl_BE/Internet.php
+++ b/src/Provider/nl_BE/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\nl_BE;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'yahoo.com', 'advalvas.be'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.com', 'yahoo.com', 'advalvas.be'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'be', 'be', 'be'];
 }

--- a/src/Provider/nl_NL/Internet.php
+++ b/src/Provider/nl_NL/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\nl_NL;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.nl', 'live.nl', 'yahoo.nl'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.nl', 'live.nl', 'yahoo.nl'];
     protected static $tld = ['com', 'com', 'com', 'net', 'org', 'nl', 'nl', 'nl'];
 }

--- a/src/Provider/pl_PL/Internet.php
+++ b/src/Provider/pl_PL/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\pl_PL;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'wp.pl', 'onet.pl', 'interia.pl', 'gazeta.pl'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'wp.pl', 'onet.pl', 'interia.pl', 'gazeta.pl'];
     protected static $tld = ['pl', 'pl', 'pl', 'pl', 'pl', 'pl', 'com', 'info', 'net', 'org', 'com.pl', 'com.pl', 'co.pl', 'net.pl', 'org.pl'];
 }

--- a/src/Provider/pt_BR/Internet.php
+++ b/src/Provider/pt_BR/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\pt_BR;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'uol.com.br', 'terra.com.br', 'ig.com.br', 'r7.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'uol.com.br', 'terra.com.br', 'ig.com.br', 'r7.com'];
     protected static $tld = ['com', 'com', 'com.br', 'com.br', 'net', 'net.br', 'br', 'org'];
 }

--- a/src/Provider/pt_PT/Internet.php
+++ b/src/Provider/pt_PT/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\pt_PT;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'hotmail.com', 'sapo.pt', 'clix.pt', 'mail.pt'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', 'sapo.pt', 'clix.pt', 'mail.pt'];
     protected static $tld = ['com', 'com', 'pt', 'pt', 'net', 'org', 'eu'];
 }

--- a/src/Provider/ru_RU/Internet.php
+++ b/src/Provider/ru_RU/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\ru_RU;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['yandex.ru', 'ya.ru', 'narod.ru', 'gmail.com', 'mail.ru', 'list.ru', 'bk.ru', 'inbox.ru', 'rambler.ru', 'hotmail.com'];
+    protected static $freeEmailDomain = ['yandex.ru', 'ya.ru', 'narod.ru', 'gmail.com', 'outlook.com', 'mail.ru', 'list.ru', 'bk.ru', 'inbox.ru', 'rambler.ru', 'hotmail.com'];
     protected static $tld = ['com', 'com', 'net', 'org', 'ru', 'ru', 'ru', 'ru'];
 }

--- a/src/Provider/sk_SK/Internet.php
+++ b/src/Provider/sk_SK/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\sk_SK;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'yahoo.com', 'zoznam.sk', 'atlas.sk', 'centrum.sk', 'azet.sk', 'post.sk'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'yahoo.com', 'zoznam.sk', 'atlas.sk', 'centrum.sk', 'azet.sk', 'post.sk'];
     protected static $tld = ['sk', 'sk', 'sk', 'sk', 'sk', 'sk', 'eu', 'com', 'info', 'net', 'org'];
 }

--- a/src/Provider/sl_SI/Internet.php
+++ b/src/Provider/sl_SI/Internet.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\sl_SI;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'gmail.com', 'gmail.com', 'hotmail.com', 'yahoo.com', 'siol.net', 't-2.net'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'gmail.com', 'outlook.com', 'gmail.com', 'outlook.com', 'hotmail.com', 'yahoo.com', 'siol.net', 't-2.net'];
 
     protected static $tld = ['si', 'si', 'si', 'si', 'eu', 'com', 'info', 'net', 'org'];
 }

--- a/src/Provider/tr_TR/Internet.php
+++ b/src/Provider/tr_TR/Internet.php
@@ -4,6 +4,6 @@ namespace Faker\Provider\tr_TR;
 
 class Internet extends \Faker\Provider\Internet
 {
-    protected static $freeEmailDomain = ['gmail.com', 'hotmail.com', 'yahoo.com', 'yandex.com.tr', 'mynet.com', 'turk.net', 'superposta.com'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'hotmail.com', 'yahoo.com', 'yandex.com.tr', 'mynet.com', 'turk.net', 'superposta.com'];
     protected static $tld = ['com', 'com', 'com', 'com', 'com.tr', 'com.tr', 'info', 'net', 'org', 'org.tr', 'edu', 'edu.tr', 'edu.tr'];
 }

--- a/src/Provider/uk_UA/Internet.php
+++ b/src/Provider/uk_UA/Internet.php
@@ -5,5 +5,5 @@ namespace Faker\Provider\uk_UA;
 class Internet extends \Faker\Provider\Internet
 {
     protected static $tld = ['ua', 'com.ua', 'org.ua', 'net.ua', 'com', 'net', 'org'];
-    protected static $freeEmailDomain = ['gmail.com', 'mail.ru', 'ukr.net', 'i.ua', 'rambler.ru'];
+    protected static $freeEmailDomain = ['gmail.com', 'outlook.com', 'mail.ru', 'ukr.net', 'i.ua', 'rambler.ru'];
 }

--- a/src/Provider/zh_CN/Internet.php
+++ b/src/Provider/zh_CN/Internet.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\zh_CN;
 class Internet extends \Faker\Provider\Internet
 {
     protected static $freeEmailDomain = [
-        'gmail.com', 'yahoo.com', 'hotmail.com', '126.com', '163.com', 'qq.com', 'sohu.com', 'sina.com',
+        'gmail.com', 'outlook.com', 'yahoo.com', 'hotmail.com', '126.com', '163.com', 'qq.com', 'sohu.com', 'sina.com',
     ];
     protected static $tld = [
         'com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org', 'cn',


### PR DESCRIPTION
### Summary of changes

- Remove obsolete free email domains from `es_*` locales (no longer exist or offer free email services)
- Add `outlook.com` as a free email domain (it's probably the second most used worldwide)


### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
