### PR TITLE
fix(isbn13): update ISBN-13 generation logic and examples

### DIFF
--- a/src/Faker/Core/Barcode.php
+++ b/src/Faker/Core/Barcode.php
@@ -52,4 +52,11 @@ final class Barcode implements Extension\BarcodeExtension
 
         return sprintf('%s%s', $code, Calculator\Ean::checksum($code));
     }
+
+    public function ismn(): string
+    {
+        $code = '9790' . Extension\Helper::numerify(str_repeat('#', 8));
+
+        return sprintf('%s%s', $code, Calculator\Ean::checksum($code));
+    }
 }

--- a/src/Faker/Core/Barcode.php
+++ b/src/Faker/Core/Barcode.php
@@ -45,7 +45,10 @@ final class Barcode implements Extension\BarcodeExtension
 
     public function isbn13(): string
     {
-        $code = '97' . $this->numberExtension->numberBetween(8, 9) . Extension\Helper::numerify(str_repeat('#', 9));
+        $prefix = '97' . $this->numberExtension->numberBetween(8, 9);
+        $group = $this->numberExtension->numberBetween($prefix === '978' ? 0 : 1, 9) . $this->numberExtension->numberBetween(0, 9);
+
+        $code = $prefix . $group . Extension\Helper::numerify(str_repeat('#', 7));
 
         return sprintf('%s%s', $code, Calculator\Ean::checksum($code));
     }

--- a/src/Faker/Extension/BarcodeExtension.php
+++ b/src/Faker/Extension/BarcodeExtension.php
@@ -35,7 +35,7 @@ interface BarcodeExtension extends Extension
      *
      * @see http://en.wikipedia.org/wiki/International_Standard_Book_Number
      *
-     * @example '9790404436093'
+     * @example '9791404436090'
      */
     public function isbn13(): string;
 }

--- a/src/Faker/Extension/BarcodeExtension.php
+++ b/src/Faker/Extension/BarcodeExtension.php
@@ -38,4 +38,13 @@ interface BarcodeExtension extends Extension
      * @example '9791404436090'
      */
     public function isbn13(): string;
+
+    /**
+     * Get a random ISMN code
+     *
+     * @see https://en.wikipedia.org/wiki/International_Standard_Music_Number
+     *
+     * @example '9790404436093'
+     */
+    public function ismn(): string;
 }

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -868,6 +868,18 @@ class Generator
     }
 
     /**
+     * Get a random ISMN code
+     *
+     * @see https://en.wikipedia.org/wiki/International_Standard_Music_Number
+     *
+     * @example '9790404436093'
+     */
+    public function ismn(): string
+    {
+        return $this->ext(Extension\BarcodeExtension::class)->ismn();
+    }
+
+    /**
      * Returns a random number between $int1 and $int2 (any order)
      *
      * @example 79907610

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -860,7 +860,7 @@ class Generator
      *
      * @see http://en.wikipedia.org/wiki/International_Standard_Book_Number
      *
-     * @example '9790404436093'
+     * @example '9791404436090'
      */
     public function isbn13(): string
     {

--- a/test/Faker/Core/BarcodeTest.php
+++ b/test/Faker/Core/BarcodeTest.php
@@ -37,4 +37,11 @@ final class BarcodeTest extends TestCase
         self::assertMatchesRegularExpression('/^97(8\d{9}|9[1-9]\d{8})\d$/i', $code);
         self::assertTrue(Ean::isValid($code));
     }
+
+    public function testIsmn(): void
+    {
+        $code = $this->faker->ismn();
+        self::assertMatchesRegularExpression('/^9790\d{9}$/i', $code);
+        self::assertTrue(Ean::isValid($code));
+    }
 }

--- a/test/Faker/Core/BarcodeTest.php
+++ b/test/Faker/Core/BarcodeTest.php
@@ -34,7 +34,7 @@ final class BarcodeTest extends TestCase
     public function testIsbn13(): void
     {
         $code = $this->faker->isbn13();
-        self::assertMatchesRegularExpression('/^\d{13}$/i', $code);
+        self::assertMatchesRegularExpression('/^97(8\d{9}|9[1-9]\d{8})\d$/i', $code);
         self::assertTrue(Ean::isValid($code));
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [X] A new feature
- [X] Fixed an issue (resolve #1051)

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

https://github.com/FakerPHP/fakerphp.github.io/pull/119

### Summary of changes

 #### Bug fix
 `isbn13()` could generate codes starting with `9790`, which is the reserved
 prefix for ISMN (International Standard Music Number), not ISBN-13.
 
 The generation logic now correctly restricts the `979` prefix range to
 `9791`–`9799`.
 
 #### New feature
 A dedicated `ismn()` method has been added to generate valid ISMN codes
 (prefix `9790` + 8 digits + EAN-13 checksum).

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
