### PR TITLE
Add en-CA Person provider with sin() method

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -552,6 +552,11 @@ use Faker\Container\ContainerInterface;
  * @property string $uuid
  *
  * @method string uuid()
+ *
+ * @property string $sin()
+ *
+ * @method string sin()
+ *
  */
 class Generator
 {

--- a/src/Provider/en_CA/Person.php
+++ b/src/Provider/en_CA/Person.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Faker\Provider\en_CA;
+
+class Person extends \Faker\Provider\Person {
+
+    /**
+     * @example '744-884-672'
+     *
+     * @return string
+     *
+     * Generated values are intentionally not Luhn-valid and should be used for testing purposes only.
+     */
+    public function sin()
+    {
+
+    $first = static::randomElement([1,2,3,4,5,6,7,9]);
+    return $first . static::numerify('##-###-###');
+
+    }
+}

--- a/test/Provider/en_CA/PersonTest.php
+++ b/test/Provider/en_CA/PersonTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Provider\en_CA;
+
+use Faker\Test\TestCase;
+
+/**
+ * @group legacy
+ */
+final class PersonTest extends TestCase
+{
+    /**
+     * Test the validity of SIN
+     */
+    public function testSin(): void
+    {
+        $sin = $this->faker->sin();
+        self::assertNotEmpty($sin);
+        self::assertIsString($sin);
+        self::assertMatchesRegularExpression('/^[1-79]\d{2}-\d{3}-\d{3}$/', $sin);
+    }
+
+    protected function getProviders(): iterable
+    {
+        yield new Person($this->faker);
+    }
+}


### PR DESCRIPTION
### What is the reason for this PR?

<!-- Explain your goals for this PR -->

- [X] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [X] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [X] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

<!-- Give a quick explanation about your code changes here -->
Added a new Person formatter for en_CA that contains a sin() method to generate a Canadian Social Insurance Number (SIN). 

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
