### PR TITLE
Fix locale discovery so provider tests run again

### DIFF
--- a/test/Provider/ProviderOverrideTest.php
+++ b/test/Provider/ProviderOverrideTest.php
@@ -28,6 +28,11 @@ final class ProviderOverrideTest extends TestCase
      */
     public const TEST_EMAIL_REGEX = '/^(.+)@(.+)$/ui';
 
+    public function testLocalesAreDiscovered(): void
+    {
+        self::assertNotEmpty(self::localeDataProvider(), 'No locales were discovered');
+    }
+
     /**
      * @dataProvider localeDataProvider
      *

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -37,7 +37,7 @@ abstract class TestCase extends BaseTestCase
 
     protected static function getAllLocales(): array
     {
-        return array_map('basename', glob(__DIR__ . '/../../src/Faker/Provider/*_*', GLOB_ONLYDIR));
+        return array_map('basename', glob(__DIR__ . '/../src/Provider/*_*', GLOB_ONLYDIR));
     }
 
     protected function loadLocalProvider(string $locale, string $provider): void


### PR DESCRIPTION
### What is the reason for this PR?

- [ ] A new feature
- [x] Fixed an issue

`Faker\Test\TestCase::getAllLocales()` globs `__DIR__ . '/../../src/Faker/Provider/*_*'`. On `2.0`
that path resolves outside the repository, so the glob returns an empty array,
`localeDataProvider()` yields no data sets, and every test using it is silently skipped — PHPUnit
only reports `skipped by data provider`.

Both halves of the path went stale in the same commit — 67825a19 "Fix: Flatten directory structure"
(#773, 2023-09-20): tests moved from `test/Faker/` to `test/`, and providers moved from
`src/Faker/Provider` to `src/Provider`. The glob was never updated, so these tests have not run
since then.

This affects 8 test methods in `ProviderOverrideTest`, 4 in `InternetTest` and 1 in `PaymentTest`,
across all 75 locales. On `1.24` the same code lives in `test/Faker/TestCase.php`, where the path
still resolves, so that branch is unaffected.

To reproduce on `2.0` before this change:

```
vendor/bin/phpunit --filter ProviderOverrideTest
# 8 tests, every one of them "skipped by data provider"
```

### Author's checklist

- [x] Follow the [Contribution Guide](https://github.com/FakerPHP/Faker/blob/main/.github/CONTRIBUTING.md)
- [ ] New features and changes are [documented](https://github.com/FakerPHP/fakerphp.github.io)

### Summary of changes

- point the glob at `src/Provider` relative to `test/`
- add a regression test asserting that locales are discovered; it fails with
  `No locales were discovered` if the path breaks again

Before:

```
Tests: 1416, Assertions: 10495, Skipped: 16.
```

After:

```
Tests: 2453, Assertions: 12457, Skipped: 34.
```

No test starts failing once they run — the suite stays green, only the count grows.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer
